### PR TITLE
patch(*): add missing hidden in vta field and update type field

### DIFF
--- a/json-definitions/v3/tech-record/get/car/complete/index.json
+++ b/json-definitions/v3/tech-record/get/car/complete/index.json
@@ -98,6 +98,12 @@
     },
     "vehicleSubclass": {
       "$ref": "../../../enums/vehicleSubclass.ignore.json"
+    },
+    "techRecord_hiddenInVta": {
+      "type": "boolean"
+    },
+    "techRecord_updateType": {
+      "type": "string"
     }
   }
 }

--- a/json-definitions/v3/tech-record/get/car/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/car/skeleton/index.json
@@ -95,6 +95,12 @@
     },
     "vin": {
       "type": "string"
+    },
+    "techRecord_hiddenInVta": {
+      "type": "boolean"
+    },
+    "techRecord_updateType": {
+      "type": "string"
     }
   }
 }

--- a/json-definitions/v3/tech-record/get/hgv/complete/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/complete/index.json
@@ -1,884 +1,660 @@
 {
-    "title": "GET HGV Technical Record V3 Complete",
-    "type": "object",
-    "additionalProperties": false,
-    "required": [
-        "createdTimestamp",
-        "partialVin",
-        "systemNumber",
-        "techRecord_createdAt",
-        "techRecord_createdById",
-        "techRecord_createdByName",
-        "techRecord_reasonForCreation",
-        "techRecord_recordCompleteness",
-        "techRecord_statusCode",
-        "techRecord_vehicleType",
-        "primaryVrm",
-        "vin",
-        "techRecord_vehicleConfiguration",
-        "techRecord_vehicleClass_code",
-        "techRecord_vehicleClass_description",
-        "techRecord_numberOfWheelsDriven",
-        "techRecord_approvalType",
-        "techRecord_manufactureYear",
-        "techRecord_bodyType_code",
-        "techRecord_bodyType_description",
-        "techRecord_grossGbWeight",
-        "techRecord_grossDesignWeight",
-        "techRecord_brakes_dtpNumber",
-        "techRecord_euVehicleCategory",
-        "axles",
-        "techRecord_euroStandard",
-        "techRecord_regnDate",
-        "techRecord_speedLimiterMrk",
-        "techRecord_tachoExemptMrk",
-        "techRecord_fuelPropulsionSystem",
-        "techRecord_make",
-        "techRecord_model",
-        "techRecord_trainGbWeight",
-        "techRecord_maxTrainGbWeight",
-        "techRecord_tyreUseCode",
-        "techRecord_dimensions_length",
-        "techRecord_dimensions_width",
-        "techRecord_frontAxleTo5thWheelMin",
-        "techRecord_frontAxleTo5thWheelMax",
-        "techRecord_frontAxleToRearAxle",
-        "techRecord_notes",
-        "techRecord_roadFriendly",
-        "techRecord_drawbarCouplingFitted",
-        "techRecord_offRoad",
-        "techRecord_applicantDetails_name",
-        "techRecord_applicantDetails_address1",
-        "techRecord_applicantDetails_address2",
-        "techRecord_applicantDetails_postTown"
-    ],
-    "properties": {
-        "createdTimestamp": {
-            "type": "string"
-        },
-        "partialVin": {
-            "type": "string"
-        },
-        "systemNumber": {
-            "type": "string"
-        },
-        "techRecord_adrDetails_vehicleDetails_type": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_vehicleDetails_approvalDate": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_permittedDangerousGoods": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": "string"
-            }
-        },
-        "techRecord_adrDetails_compatibilityGroupJ": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_additionalExaminerNotes": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1024
-        },
-        "techRecord_adrDetails_applicantDetails_name": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 150
-        },
-        "techRecord_adrDetails_applicantDetails_street": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 150
-        },
-        "techRecord_adrDetails_applicantDetails_town": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 100
-        },
-        "techRecord_adrDetails_applicantDetails_city": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 100
-        },
-        "techRecord_adrDetails_applicantDetails_postcode": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 25
-        },
-        "techRecord_adrDetails_memosApply": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": [
-                    "string"
-                ]
-            }
-        },
-        "techRecord_adrDetails_documents": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": [
-                    "string"
-                ]
-            }
-        },
-        "techRecord_adrDetails_listStatementApplicable": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_batteryListNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 8
-        },
-        "techRecord_adrDetails_brakeDeclarationsSeen": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_brakeDeclarationIssuer": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_brakeEndurance": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_weight": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 8
-        },
-        "techRecord_adrDetails_declarationsSeen": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_additionalNotes_guidanceNotes": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": "string"
-            }
-        },
-        "techRecord_adrDetails_additionalNotes_number": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": "string"
-            }
-        },
-        "techRecord_adrDetails_adrTypeApprovalNo": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_adrCertificateNotes": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1500
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 70
-        },
-        "techRecord_adrDetails_tank_tankDetails_yearOfManufacture": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 9999
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 50
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankTypeAppNo": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 30
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankCode": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 30
-        },
-        "techRecord_adrDetails_tank_tankDetails_specialProvisions": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1024
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2Type": {
-            "anyOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "$ref": "../../../enums/tc2Types.ignore.json"
-                }
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateApprovalNo": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 70
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateExpiryDate": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc3Details_tc3Type": {
-            "anyOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "$ref": "../../../enums/tc3Types.ignore.json"
-                }
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 75
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicExpiryDate": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_substancesPermitted": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_statement": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1500
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": [
-                    "string"
-                ]
-            }
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_productList": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1500
-        },
-        "techRecord_alterationMarker": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_applicantDetails_name": {
-            "type": "string",
-            "maxLength": 150
-        },
-        "techRecord_applicantDetails_address1": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 60
-        },
-        "techRecord_applicantDetails_address2": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 60
-        },
-        "techRecord_applicantDetails_postTown": {
-            "type": "string",
-            "maxLength": 60
-        },
-        "techRecord_applicantDetails_address3": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 60
-        },
-        "techRecord_applicantDetails_postCode": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 12
-        },
-        "techRecord_applicantDetails_telephoneNumber": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 25
-        },
-        "techRecord_applicantDetails_emailAddress": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 255
-        },
-        "techRecord_applicationId": {
-            "type": "string"
-        },
-        "axles": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "title": "HGV Axles",
-                "additionalProperties": false,
-                "properties": {
-                    "techRecord_parkingBrakeMrk": {
-                        "type": "boolean"
-                    },
-                    "techRecord_axleNumber": {
-                        "type": "integer"
-                    },
-                    "techRecord_weights_gbWeight": {
-                        "type": "integer",
-                        "minimum": 0,
-                        "maximum": 99999
-                    },
-                    "techRecord_weights_designWeight": {
-                        "type": "integer",
-                        "minimum": 0,
-                        "maximum": 99999
-                    },
-                    "techRecord_weights_eecWeight": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ],
-                        "minimum": 0,
-                        "maximum": 99999
-                    },
-                    "techRecord_tyres_tyreCode": {
-                        "type": "integer",
-                        "minimum": 0,
-                        "maximum": 99999
-                    },
-                    "techRecord_tyres_tyreSize": {
-                        "type": "string",
-                        "maxLength": 12
-                    },
-                    "techRecord_tyres_plyRating": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
-                    "techRecord_tyres_fitmentCode": {
-                        "anyOf": [
-                            {
-                                "$ref": "../../../enums/fitmentCode.ignore.json"
-                            }
-                        ]
-                    },
-                    "techRecord_tyres_dataTrAxles": {
-                        "type": [
-                            "null",
-                            "integer"
-                        ],
-                        "minimum": 0,
-                        "maximum": 999
-                    }
-                }
-            }
-        },
-        "techRecord_bodyType_code": {
-            "type": "string"
-        },
-        "techRecord_bodyType_description": {
-            "type": "string"
-        },
-        "techRecord_brakes_antilockBrakingSystem": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_brakes_dtpNumber": {
-            "type": "string",
-            "maxLength": 6
-        },
-        "techRecord_brakes_loadSensingValve": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_conversionRefNo": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 10
-        },
-        "techRecord_createdAt": {
-            "type": "string"
-        },
-        "techRecord_createdById": {
-            "type": "string"
-        },
-        "techRecord_createdByName": {
-            "type": "string"
-        },
-        "techRecord_departmentalVehicleMarker": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_dimensions_axleSpacing_axles": {
-            "type": "string"
-        },
-        "techRecord_dimensions_axleSpacing_value": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_dimensions_length": {
-            "type": "integer",
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_dimensions_width": {
-            "type": "integer",
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_drawbarCouplingFitted": {
+  "title": "GET HGV Technical Record V3 Complete",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "createdTimestamp",
+    "partialVin",
+    "systemNumber",
+    "techRecord_createdAt",
+    "techRecord_createdById",
+    "techRecord_createdByName",
+    "techRecord_reasonForCreation",
+    "techRecord_recordCompleteness",
+    "techRecord_statusCode",
+    "techRecord_vehicleType",
+    "primaryVrm",
+    "vin",
+    "techRecord_vehicleConfiguration",
+    "techRecord_vehicleClass_code",
+    "techRecord_vehicleClass_description",
+    "techRecord_numberOfWheelsDriven",
+    "techRecord_approvalType",
+    "techRecord_manufactureYear",
+    "techRecord_bodyType_code",
+    "techRecord_bodyType_description",
+    "techRecord_grossGbWeight",
+    "techRecord_grossDesignWeight",
+    "techRecord_brakes_dtpNumber",
+    "techRecord_euVehicleCategory",
+    "axles",
+    "techRecord_euroStandard",
+    "techRecord_regnDate",
+    "techRecord_speedLimiterMrk",
+    "techRecord_tachoExemptMrk",
+    "techRecord_fuelPropulsionSystem",
+    "techRecord_make",
+    "techRecord_model",
+    "techRecord_trainGbWeight",
+    "techRecord_maxTrainGbWeight",
+    "techRecord_tyreUseCode",
+    "techRecord_dimensions_length",
+    "techRecord_dimensions_width",
+    "techRecord_frontAxleTo5thWheelMin",
+    "techRecord_frontAxleTo5thWheelMax",
+    "techRecord_frontAxleToRearAxle",
+    "techRecord_notes",
+    "techRecord_roadFriendly",
+    "techRecord_drawbarCouplingFitted",
+    "techRecord_offRoad",
+    "techRecord_applicantDetails_name",
+    "techRecord_applicantDetails_address1",
+    "techRecord_applicantDetails_address2",
+    "techRecord_applicantDetails_postTown"
+  ],
+  "properties": {
+    "createdTimestamp": {
+      "type": "string"
+    },
+    "partialVin": {
+      "type": "string"
+    },
+    "systemNumber": {
+      "type": "string"
+    },
+    "techRecord_adrDetails_vehicleDetails_type": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_vehicleDetails_approvalDate": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_permittedDangerousGoods": {
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "techRecord_adrDetails_compatibilityGroupJ": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_additionalExaminerNotes": {
+      "type": ["string", "null"],
+      "maxLength": 1024
+    },
+    "techRecord_adrDetails_applicantDetails_name": {
+      "type": ["string", "null"],
+      "maxLength": 150
+    },
+    "techRecord_adrDetails_applicantDetails_street": {
+      "type": ["string", "null"],
+      "maxLength": 150
+    },
+    "techRecord_adrDetails_applicantDetails_town": {
+      "type": ["string", "null"],
+      "maxLength": 100
+    },
+    "techRecord_adrDetails_applicantDetails_city": {
+      "type": ["string", "null"],
+      "maxLength": 100
+    },
+    "techRecord_adrDetails_applicantDetails_postcode": {
+      "type": ["string", "null"],
+      "maxLength": 25
+    },
+    "techRecord_adrDetails_memosApply": {
+      "type": ["array", "null"],
+      "items": {
+        "type": ["string"]
+      }
+    },
+    "techRecord_adrDetails_documents": {
+      "type": ["array", "null"],
+      "items": {
+        "type": ["string"]
+      }
+    },
+    "techRecord_adrDetails_listStatementApplicable": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_batteryListNumber": {
+      "type": ["string", "null"],
+      "maxLength": 8
+    },
+    "techRecord_adrDetails_brakeDeclarationsSeen": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_brakeDeclarationIssuer": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_brakeEndurance": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_weight": {
+      "type": ["string", "null"],
+      "maxLength": 8
+    },
+    "techRecord_adrDetails_declarationsSeen": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_additionalNotes_guidanceNotes": {
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "techRecord_adrDetails_additionalNotes_number": {
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "techRecord_adrDetails_adrTypeApprovalNo": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_adrCertificateNotes": {
+      "type": ["string", "null"],
+      "maxLength": 1500
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
+      "type": ["string", "null"],
+      "maxLength": 70
+    },
+    "techRecord_adrDetails_tank_tankDetails_yearOfManufacture": {
+      "type": ["integer", "null"],
+      "maximum": 9999
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo": {
+      "type": ["string", "null"],
+      "maxLength": 50
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankTypeAppNo": {
+      "type": ["string", "null"],
+      "maxLength": 30
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankCode": {
+      "type": ["string", "null"],
+      "maxLength": 30
+    },
+    "techRecord_adrDetails_tank_tankDetails_specialProvisions": {
+      "type": ["string", "null"],
+      "maxLength": 1024
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2Type": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "../../../enums/tc2Types.ignore.json"
+        }
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateApprovalNo": {
+      "type": ["string", "null"],
+      "maxLength": 70
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateExpiryDate": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc3Details_tc3Type": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "../../../enums/tc3Types.ignore.json"
+        }
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicNumber": {
+      "type": ["string", "null"],
+      "maxLength": 75
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicExpiryDate": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_substancesPermitted": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_statement": {
+      "type": ["string", "null"],
+      "maxLength": 1500
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo": {
+      "type": ["array", "null"],
+      "items": {
+        "type": ["string"]
+      }
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_productList": {
+      "type": ["string", "null"],
+      "maxLength": 1500
+    },
+    "techRecord_alterationMarker": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_applicantDetails_name": {
+      "type": "string",
+      "maxLength": 150
+    },
+    "techRecord_applicantDetails_address1": {
+      "type": ["null", "string"],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_address2": {
+      "type": ["null", "string"],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_postTown": {
+      "type": "string",
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_address3": {
+      "type": ["null", "string"],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_postCode": {
+      "type": ["null", "string"],
+      "maxLength": 12
+    },
+    "techRecord_applicantDetails_telephoneNumber": {
+      "type": ["null", "string"],
+      "maxLength": 25
+    },
+    "techRecord_applicantDetails_emailAddress": {
+      "type": ["null", "string"],
+      "maxLength": 255
+    },
+    "techRecord_applicationId": {
+      "type": "string"
+    },
+    "axles": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "title": "HGV Axles",
+        "additionalProperties": false,
+        "properties": {
+          "techRecord_parkingBrakeMrk": {
             "type": "boolean"
-        },
-        "techRecord_emissionsLimit": {
-            "type": [
-                "null",
-                "integer"
-            ],
-            "minimum": 0,
-            "maximum": 99
-        },
-        "techRecord_euroStandard": {
-            "type": [
-                "string"
-            ]
-        },
-        "techRecord_euVehicleCategory": {
-            "anyOf": [
-                {
-                    "$ref": "../../../enums/euVehicleCategory.ignore.json"
-                }
-            ]
-        },
-        "techRecord_frontAxleToRearAxle": {
-            "type": "integer",
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_frontAxleTo5thWheelMin": {
-            "type": "integer",
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_frontAxleTo5thWheelMax": {
-            "type": "integer",
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_frontVehicleTo5thWheelCouplingMin": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_frontVehicleTo5thWheelCouplingMax": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_fuelPropulsionSystem": {
-            "anyOf": [
-                {
-                    "$ref": "../../../enums/fuelPropulsionSystem.ignore.json"
-                }
-            ]
-        },
-        "techRecord_functionCode": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1
-        },
-        "techRecord_grossDesignWeight": {
-            "type": "integer",
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_grossEecWeight": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_grossGbWeight": {
-            "type": "integer",
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_make": {
-            "type": "string",
-            "maxLength": 30
-        },
-        "techRecord_maxTrainGbWeight": {
-            "type": "number",
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_maxTrainEecWeight": {
-            "type": [
-                "number",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_maxTrainDesignWeight": {
-            "type": [
-                "number",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_manufactureYear": {
-            "anyOf": [
-                {
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 9999
-                }
-            ]
-        },
-        "techRecord_microfilm_microfilmDocumentType": {
-            "anyOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "$ref": "../../../enums/microfilmDocumentType.ignore.json"
-                }
-            ]
-        },
-        "techRecord_microfilm_microfilmRollNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 5
-        },
-        "techRecord_microfilm_microfilmSerialNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 4
-        },
-        "techRecord_model": {
-            "type": "string",
-            "maxLength": 30
-        },
-        "techRecord_numberOfWheelsDriven": {
+          },
+          "techRecord_axleNumber": {
             "type": "integer"
-        },
-        "techRecord_noOfAxles": {
-            "anyOf": [
-                {
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 99
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        },
-        "techRecord_notes": {
-            "type": "string"
-        },
-        "techRecord_offRoad": {
-            "type": "boolean"
-        },
-        "plates": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "title": "HGV Plates",
-                "additionalProperties": false,
-                "properties": {
-                    "techRecord_plateSerialNumber": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "maxLength": 12
-                    },
-                    "techRecord_plateIssueDate": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
-                    "techRecord_reasonForIssue": {
-                        "anyOf": [
-                            {
-                                "type": "null"
-                            },
-                            {
-                                "$ref": "../../../enums/plateReasonForIssue.ignore.json"
-                            }
-                        ]
-                    },
-                    "techRecord_plateIssuer": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "maxLength": 150
-                    }
-                }
-            }
-        },
-        "techRecord_reasonForCreation": {
-            "type": "string"
-        },
-        "techRecord_recordCompleteness": {
-            "const": "complete"
-        },
-        "techRecord_regnDate": {
-            "anyOf": [
-                {
-                    "type": "string",
-                    "pattern": "^$"
-                },
-                {
-                    "type": "string",
-                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-                }
-            ]
-        },
-        "techRecord_roadFriendly": {
-            "type": "boolean"
-        },
-        "techRecord_statusCode": {
-            "$ref": "../../../enums/statusCode.ignore.json"
-        },
-        "techRecord_speedLimiterMrk": {
-            "type": "boolean"
-        },
-        "techRecord_tachoExemptMrk": {
-            "type": "boolean"
-        },
-        "techRecord_trainDesignWeight": {
-            "type": [
-                "integer",
-                "null"
-            ],
+          },
+          "techRecord_weights_gbWeight": {
+            "type": "integer",
             "minimum": 0,
             "maximum": 99999
-        },
-        "techRecord_trainEecWeight": {
-            "type": [
-                "number",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_trainGbWeight": {
-            "type": "number",
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_tyreUseCode": {
+          },
+          "techRecord_weights_designWeight": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 99999
+          },
+          "techRecord_weights_eecWeight": {
+            "type": ["integer", "null"],
+            "minimum": 0,
+            "maximum": 99999
+          },
+          "techRecord_tyres_tyreCode": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 99999
+          },
+          "techRecord_tyres_tyreSize": {
             "type": "string",
-            "maxLength": 2
-        },
-        "techRecord_vehicleClass_code": {
-            "type": "string"
-        },
-        "techRecord_vehicleClass_description": {
-            "$ref": "../../../enums/vehicleClassDescription.ignore.json"
-        },
-        "techRecord_vehicleConfiguration": {
+            "maxLength": 12
+          },
+          "techRecord_tyres_plyRating": {
+            "type": ["string", "null"]
+          },
+          "techRecord_tyres_fitmentCode": {
             "anyOf": [
-                {
-                    "$ref": "../../../enums/vehicleConfiguration.ignore.json"
-                }
+              {
+                "$ref": "../../../enums/fitmentCode.ignore.json"
+              }
             ]
-        },
-        "techRecord_approvalType": {
-            "anyOf": [
-                {
-                    "$ref": "../../../enums/approvalType.ignore.json"
-                }
-            ]
-        },
-        "techRecord_approvalTypeNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 25
-        },
-        "techRecord_ntaNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 40
-        },
-        "techRecord_variantNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 25
-        },
-        "techRecord_variantVersionNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 35
-        },
-        "techRecord_lastUpdatedAt": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_lastUpdatedByName": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_lastUpdatedById": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_vehicleType": {
-            "const": "hgv"
-        },
-        "primaryVrm": {
-            "type": "string"
-        },
-        "vin": {
-            "type": "string"
+          },
+          "techRecord_tyres_dataTrAxles": {
+            "type": ["null", "integer"],
+            "minimum": 0,
+            "maximum": 999
+          }
         }
+      }
+    },
+    "techRecord_bodyType_code": {
+      "type": "string"
+    },
+    "techRecord_bodyType_description": {
+      "type": "string"
+    },
+    "techRecord_brakes_antilockBrakingSystem": {
+      "type": ["string", "null"]
+    },
+    "techRecord_brakes_dtpNumber": {
+      "type": "string",
+      "maxLength": 6
+    },
+    "techRecord_brakes_loadSensingValve": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_conversionRefNo": {
+      "type": ["string", "null"],
+      "maxLength": 10
+    },
+    "techRecord_createdAt": {
+      "type": "string"
+    },
+    "techRecord_createdById": {
+      "type": "string"
+    },
+    "techRecord_createdByName": {
+      "type": "string"
+    },
+    "techRecord_departmentalVehicleMarker": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_dimensions_axleSpacing_axles": {
+      "type": "string"
+    },
+    "techRecord_dimensions_axleSpacing_value": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_dimensions_length": {
+      "type": "integer",
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_dimensions_width": {
+      "type": "integer",
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_drawbarCouplingFitted": {
+      "type": "boolean"
+    },
+    "techRecord_emissionsLimit": {
+      "type": ["null", "integer"],
+      "minimum": 0,
+      "maximum": 99
+    },
+    "techRecord_euroStandard": {
+      "type": ["string"]
+    },
+    "techRecord_euVehicleCategory": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/euVehicleCategory.ignore.json"
+        }
+      ]
+    },
+    "techRecord_frontAxleToRearAxle": {
+      "type": "integer",
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_frontAxleTo5thWheelMin": {
+      "type": "integer",
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_frontAxleTo5thWheelMax": {
+      "type": "integer",
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_frontVehicleTo5thWheelCouplingMin": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_frontVehicleTo5thWheelCouplingMax": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_fuelPropulsionSystem": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/fuelPropulsionSystem.ignore.json"
+        }
+      ]
+    },
+    "techRecord_functionCode": {
+      "type": ["string", "null"],
+      "maxLength": 1
+    },
+    "techRecord_grossDesignWeight": {
+      "type": "integer",
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_grossEecWeight": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_grossGbWeight": {
+      "type": "integer",
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_make": {
+      "type": "string",
+      "maxLength": 30
+    },
+    "techRecord_maxTrainGbWeight": {
+      "type": "number",
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_maxTrainEecWeight": {
+      "type": ["number", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_maxTrainDesignWeight": {
+      "type": ["number", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_manufactureYear": {
+      "anyOf": [
+        {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9999
+        }
+      ]
+    },
+    "techRecord_microfilm_microfilmDocumentType": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "../../../enums/microfilmDocumentType.ignore.json"
+        }
+      ]
+    },
+    "techRecord_microfilm_microfilmRollNumber": {
+      "type": ["string", "null"],
+      "maxLength": 5
+    },
+    "techRecord_microfilm_microfilmSerialNumber": {
+      "type": ["string", "null"],
+      "maxLength": 4
+    },
+    "techRecord_model": {
+      "type": "string",
+      "maxLength": 30
+    },
+    "techRecord_numberOfWheelsDriven": {
+      "type": "integer"
+    },
+    "techRecord_noOfAxles": {
+      "anyOf": [
+        {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 99
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_notes": {
+      "type": "string"
+    },
+    "techRecord_offRoad": {
+      "type": "boolean"
+    },
+    "plates": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "title": "HGV Plates",
+        "additionalProperties": false,
+        "properties": {
+          "techRecord_plateSerialNumber": {
+            "type": ["string", "null"],
+            "maxLength": 12
+          },
+          "techRecord_plateIssueDate": {
+            "type": ["string", "null"]
+          },
+          "techRecord_reasonForIssue": {
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "../../../enums/plateReasonForIssue.ignore.json"
+              }
+            ]
+          },
+          "techRecord_plateIssuer": {
+            "type": ["string", "null"],
+            "maxLength": 150
+          }
+        }
+      }
+    },
+    "techRecord_reasonForCreation": {
+      "type": "string"
+    },
+    "techRecord_recordCompleteness": {
+      "const": "complete"
+    },
+    "techRecord_regnDate": {
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^$"
+        },
+        {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+        }
+      ]
+    },
+    "techRecord_roadFriendly": {
+      "type": "boolean"
+    },
+    "techRecord_statusCode": {
+      "$ref": "../../../enums/statusCode.ignore.json"
+    },
+    "techRecord_speedLimiterMrk": {
+      "type": "boolean"
+    },
+    "techRecord_tachoExemptMrk": {
+      "type": "boolean"
+    },
+    "techRecord_trainDesignWeight": {
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "maximum": 99999
+    },
+    "techRecord_trainEecWeight": {
+      "type": ["number", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_trainGbWeight": {
+      "type": "number",
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_tyreUseCode": {
+      "type": "string",
+      "maxLength": 2
+    },
+    "techRecord_vehicleClass_code": {
+      "type": "string"
+    },
+    "techRecord_vehicleClass_description": {
+      "$ref": "../../../enums/vehicleClassDescription.ignore.json"
+    },
+    "techRecord_vehicleConfiguration": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/vehicleConfiguration.ignore.json"
+        }
+      ]
+    },
+    "techRecord_approvalType": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/approvalType.ignore.json"
+        }
+      ]
+    },
+    "techRecord_approvalTypeNumber": {
+      "type": ["string", "null"],
+      "maxLength": 25
+    },
+    "techRecord_ntaNumber": {
+      "type": ["string", "null"],
+      "maxLength": 40
+    },
+    "techRecord_variantNumber": {
+      "type": ["string", "null"],
+      "maxLength": 25
+    },
+    "techRecord_variantVersionNumber": {
+      "type": ["string", "null"],
+      "maxLength": 35
+    },
+    "techRecord_lastUpdatedAt": {
+      "type": ["string", "null"]
+    },
+    "techRecord_lastUpdatedByName": {
+      "type": ["string", "null"]
+    },
+    "techRecord_lastUpdatedById": {
+      "type": ["string", "null"]
+    },
+    "techRecord_vehicleType": {
+      "const": "hgv"
+    },
+    "primaryVrm": {
+      "type": "string"
+    },
+    "vin": {
+      "type": "string"
+    },
+    "techRecord_hiddenInVta": {
+      "type": "boolean"
+    },
+    "techRecord_updateType": {
+      "type": "string"
     }
+  }
 }

--- a/json-definitions/v3/tech-record/get/hgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/skeleton/index.json
@@ -27,211 +27,120 @@
       "type": "string"
     },
     "techRecord_adrDetails_vehicleDetails_type": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_adrDetails_vehicleDetails_approvalDate": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_adrDetails_permittedDangerousGoods": {
-      "type": [
-        "array",
-        "null"
-      ],
+      "type": ["array", "null"],
       "items": {
         "type": "string"
       }
     },
     "techRecord_adrDetails_compatibilityGroupJ": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_adrDetails_additionalExaminerNotes": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 1024
     },
     "techRecord_adrDetails_applicantDetails_name": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 150
     },
     "techRecord_adrDetails_applicantDetails_street": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 150
     },
     "techRecord_adrDetails_applicantDetails_town": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 100
     },
     "techRecord_adrDetails_applicantDetails_city": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 100
     },
     "techRecord_adrDetails_applicantDetails_postcode": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 25
     },
     "techRecord_adrDetails_memosApply": {
-      "type": [
-        "array",
-        "null"
-      ],
+      "type": ["array", "null"],
       "items": {
-        "type": [
-          "string"
-        ]
+        "type": ["string"]
       }
     },
     "techRecord_adrDetails_documents": {
-      "type": [
-        "array",
-        "null"
-      ],
+      "type": ["array", "null"],
       "items": {
-        "type": [
-          "string"
-        ]
+        "type": ["string"]
       }
     },
     "techRecord_adrDetails_listStatementApplicable": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_adrDetails_batteryListNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 8
     },
     "techRecord_adrDetails_brakeDeclarationsSeen": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_adrDetails_brakeDeclarationIssuer": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_adrDetails_brakeEndurance": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_adrDetails_weight": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 8
     },
     "techRecord_adrDetails_declarationsSeen": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_adrDetails_additionalNotes_guidanceNotes": {
-      "type": [
-        "array",
-        "null"
-      ],
+      "type": ["array", "null"],
       "items": {
         "type": "string"
       }
     },
     "techRecord_adrDetails_additionalNotes_number": {
-      "type": [
-        "array",
-        "null"
-      ],
+      "type": ["array", "null"],
       "items": {
         "type": "string"
       }
     },
     "techRecord_adrDetails_adrTypeApprovalNo": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_adrDetails_adrCertificateNotes": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 1500
     },
     "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 70
     },
     "techRecord_adrDetails_tank_tankDetails_yearOfManufacture": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 9999
     },
     "techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 50
     },
     "techRecord_adrDetails_tank_tankDetails_tankTypeAppNo": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 30
     },
     "techRecord_adrDetails_tank_tankDetails_tankCode": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 30
     },
     "techRecord_adrDetails_tank_tankDetails_specialProvisions": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 1024
     },
     "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2Type": {
@@ -245,17 +154,11 @@
       ]
     },
     "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateApprovalNo": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 70
     },
     "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateExpiryDate": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_adrDetails_tank_tankDetails_tc3Details_tc3Type": {
       "anyOf": [
@@ -268,122 +171,69 @@
       ]
     },
     "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 75
     },
     "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicExpiryDate": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_adrDetails_tank_tankDetails_tankStatement_substancesPermitted": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_adrDetails_tank_tankDetails_tankStatement_statement": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 1500
     },
     "techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo": {
-      "type": [
-        "array",
-        "null"
-      ],
+      "type": ["array", "null"],
       "items": {
-        "type": [
-          "string"
-        ]
+        "type": ["string"]
       }
     },
     "techRecord_adrDetails_tank_tankDetails_tankStatement_productList": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 1500
     },
     "techRecord_alterationMarker": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_applicantDetails_name": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 150
     },
     "techRecord_applicantDetails_address1": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 60
     },
     "techRecord_applicantDetails_address2": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 60
     },
     "techRecord_applicantDetails_postTown": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 60
     },
     "techRecord_applicantDetails_address3": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 60
     },
     "techRecord_applicantDetails_postCode": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 12
     },
     "techRecord_applicantDetails_telephoneNumber": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 25
     },
     "techRecord_applicantDetails_emailAddress": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 255
     },
     "techRecord_applicationId": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "axles": {
       "type": "array",
@@ -393,61 +243,37 @@
         "additionalProperties": false,
         "properties": {
           "techRecord_parkingBrakeMrk": {
-            "type": [
-              "boolean",
-              "null"
-            ]
+            "type": ["boolean", "null"]
           },
           "techRecord_axleNumber": {
-            "type": [
-              "integer",
-              "null"
-            ]
+            "type": ["integer", "null"]
           },
           "techRecord_weights_gbWeight": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "minimum": 0,
             "maximum": 99999
           },
           "techRecord_weights_designWeight": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "minimum": 0,
             "maximum": 99999
           },
           "techRecord_weights_eecWeight": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "minimum": 0,
             "maximum": 99999
           },
           "techRecord_tyres_tyreCode": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "minimum": 0,
             "maximum": 99999
           },
           "techRecord_tyres_tyreSize": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "maxLength": 12
           },
           "techRecord_tyres_plyRating": {
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "techRecord_tyres_fitmentCode": {
             "anyOf": [
@@ -460,10 +286,7 @@
             ]
           },
           "techRecord_tyres_dataTrAxles": {
-            "type": [
-              "null",
-              "integer"
-            ],
+            "type": ["null", "integer"],
             "minimum": 0,
             "maximum": 999
           }
@@ -477,29 +300,17 @@
       "type": "string"
     },
     "techRecord_brakes_antilockBrakingSystem": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_brakes_dtpNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 6
     },
     "techRecord_brakes_loadSensingValve": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_conversionRefNo": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 10
     },
     "techRecord_createdAt": {
@@ -512,57 +323,36 @@
       "type": "string"
     },
     "techRecord_departmentalVehicleMarker": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_dimensions_axleSpacing_axles": {
       "type": "string"
     },
     "techRecord_dimensions_axleSpacing_value": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_dimensions_length": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_dimensions_width": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_drawbarCouplingFitted": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_emissionsLimit": {
-      "type": [
-        "null",
-        "integer"
-      ],
+      "type": ["null", "integer"],
       "minimum": 0,
       "maximum": 99
     },
     "techRecord_euroStandard": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_euVehicleCategory": {
       "anyOf": [
@@ -575,42 +365,27 @@
       ]
     },
     "techRecord_frontAxleToRearAxle": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_frontAxleTo5thWheelMin": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_frontAxleTo5thWheelMax": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_frontVehicleTo5thWheelCouplingMin": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_frontVehicleTo5thWheelCouplingMax": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
@@ -625,64 +400,40 @@
       ]
     },
     "techRecord_functionCode": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 1
     },
     "techRecord_grossDesignWeight": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_grossEecWeight": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_grossGbWeight": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_make": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 30
     },
     "techRecord_maxTrainGbWeight": {
-      "type": [
-        "number",
-        "null"
-      ],
+      "type": ["number", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_maxTrainEecWeight": {
-      "type": [
-        "number",
-        "null"
-      ],
+      "type": ["number", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_maxTrainDesignWeight": {
-      "type": [
-        "number",
-        "null"
-      ],
+      "type": ["number", "null"],
       "maximum": 99999,
       "minimum": 0
     },
@@ -709,31 +460,19 @@
       ]
     },
     "techRecord_microfilm_microfilmRollNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 5
     },
     "techRecord_microfilm_microfilmSerialNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 4
     },
     "techRecord_model": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 30
     },
     "techRecord_numberOfWheelsDriven": {
-      "type": [
-        "integer",
-        "null"
-      ]
+      "type": ["integer", "null"]
     },
     "techRecord_noOfAxles": {
       "anyOf": [
@@ -748,16 +487,10 @@
       ]
     },
     "techRecord_notes": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_offRoad": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "plates": {
       "type": "array",
@@ -767,17 +500,11 @@
         "additionalProperties": false,
         "properties": {
           "techRecord_plateSerialNumber": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "maxLength": 12
           },
           "techRecord_plateIssueDate": {
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "techRecord_reasonForIssue": {
             "anyOf": [
@@ -790,10 +517,7 @@
             ]
           },
           "techRecord_plateIssuer": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "maxLength": 150
           }
         }
@@ -821,55 +545,34 @@
       ]
     },
     "techRecord_roadFriendly": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_statusCode": {
       "$ref": "../../../enums/statusCode.ignore.json"
     },
     "techRecord_speedLimiterMrk": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_tachoExemptMrk": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_trainDesignWeight": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "minimum": 0,
       "maximum": 99999
     },
     "techRecord_trainEecWeight": {
-      "type": [
-        "number",
-        "null"
-      ],
+      "type": ["number", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_trainGbWeight": {
-      "type": [
-        "number",
-        "null"
-      ],
+      "type": ["number", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_tyreUseCode": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 2
     },
     "techRecord_vehicleClass_code": {
@@ -899,50 +602,29 @@
       ]
     },
     "techRecord_approvalTypeNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 25
     },
     "techRecord_ntaNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 40
     },
     "techRecord_variantNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 25
     },
     "techRecord_variantVersionNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 35
     },
     "techRecord_lastUpdatedAt": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_lastUpdatedByName": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_lastUpdatedById": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_vehicleType": {
       "const": "hgv"
@@ -951,6 +633,12 @@
       "type": "string"
     },
     "vin": {
+      "type": "string"
+    },
+    "techRecord_hiddenInVta": {
+      "type": "boolean"
+    },
+    "techRecord_updateType": {
       "type": "string"
     }
   }

--- a/json-definitions/v3/tech-record/get/hgv/testable/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/testable/index.json
@@ -1,952 +1,646 @@
 {
-    "title": "GET HGV Technical Record V3 Testable",
-    "type": "object",
-    "additionalProperties": false,
-    "required": [
-        "createdTimestamp",
-        "partialVin",
-        "systemNumber",
-        "techRecord_createdAt",
-        "techRecord_createdById",
-        "techRecord_createdByName",
-        "techRecord_reasonForCreation",
-        "techRecord_recordCompleteness",
-        "techRecord_statusCode",
-        "techRecord_vehicleType",
-        "primaryVrm",
-        "vin",
-        "techRecord_vehicleConfiguration",
-        "techRecord_vehicleClass_code",
-        "techRecord_vehicleClass_description",
-        "techRecord_numberOfWheelsDriven"
-    ],
-    "properties": {
-        "createdTimestamp": {
-            "type": "string"
-        },
-        "partialVin": {
-            "type": "string"
-        },
-        "systemNumber": {
-            "type": "string"
-        },
-        "techRecord_adrDetails_vehicleDetails_type": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_vehicleDetails_approvalDate": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_permittedDangerousGoods": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": "string"
-            }
-        },
-        "techRecord_adrDetails_compatibilityGroupJ": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_additionalExaminerNotes": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1024
-        },
-        "techRecord_adrDetails_applicantDetails_name": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 150
-        },
-        "techRecord_adrDetails_applicantDetails_street": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 150
-        },
-        "techRecord_adrDetails_applicantDetails_town": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 100
-        },
-        "techRecord_adrDetails_applicantDetails_city": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 100
-        },
-        "techRecord_adrDetails_applicantDetails_postcode": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 25
-        },
-        "techRecord_adrDetails_memosApply": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": [
-                    "string"
-                ]
-            }
-        },
-        "techRecord_adrDetails_documents": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": [
-                    "string"
-                ]
-            }
-        },
-        "techRecord_adrDetails_listStatementApplicable": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_batteryListNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 8
-        },
-        "techRecord_adrDetails_brakeDeclarationsSeen": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_brakeDeclarationIssuer": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_brakeEndurance": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_weight": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 8
-        },
-        "techRecord_adrDetails_declarationsSeen": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_additionalNotes_guidanceNotes": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": "string"
-            }
-        },
-        "techRecord_adrDetails_additionalNotes_number": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": "string"
-            }
-        },
-        "techRecord_adrDetails_adrTypeApprovalNo": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_adrCertificateNotes": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1500
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 70
-        },
-        "techRecord_adrDetails_tank_tankDetails_yearOfManufacture": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 9999
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 50
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankTypeAppNo": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 30
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankCode": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 30
-        },
-        "techRecord_adrDetails_tank_tankDetails_specialProvisions": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1024
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2Type": {
-            "anyOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "$ref": "../../../enums/tc2Types.ignore.json"
-                }
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateApprovalNo": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 70
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateExpiryDate": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc3Details_tc3Type": {
-            "anyOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "$ref": "../../../enums/tc3Types.ignore.json"
-                }
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 75
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicExpiryDate": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_substancesPermitted": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_statement": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1500
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": [
-                    "string"
-                ]
-            }
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_productList": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1500
-        },
-        "techRecord_alterationMarker": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_applicantDetails_name": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 150
-        },
-        "techRecord_applicantDetails_address1": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 60
-        },
-        "techRecord_applicantDetails_address2": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 60
-        },
-        "techRecord_applicantDetails_postTown": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 60
-        },
-        "techRecord_applicantDetails_address3": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 60
-        },
-        "techRecord_applicantDetails_postCode": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 12
-        },
-        "techRecord_applicantDetails_telephoneNumber": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 25
-        },
-        "techRecord_applicantDetails_emailAddress": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 255
-        },
-        "techRecord_applicationId": {
-            "type": "string"
-        },
-        "axles": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "title": "HGV Axles",
-                "additionalProperties": false,
-                "properties": {
-                    "techRecord_parkingBrakeMrk": {
-                        "type": [
-                            "boolean",
-                            "null"
-                        ]
-                    },
-                    "techRecord_axleNumber": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ]
-                    },
-                    "techRecord_weights_gbWeight": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ],
-                        "minimum": 0,
-                        "maximum": 99999
-                    },
-                    "techRecord_weights_designWeight": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ],
-                        "minimum": 0,
-                        "maximum": 99999
-                    },
-                    "techRecord_weights_eecWeight": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ],
-                        "minimum": 0,
-                        "maximum": 99999
-                    },
-                    "techRecord_tyres_tyreCode": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ],
-                        "minimum": 0,
-                        "maximum": 99999
-                    },
-                    "techRecord_tyres_tyreSize": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "maxLength": 12
-                    },
-                    "techRecord_tyres_plyRating": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
-                    "techRecord_tyres_fitmentCode": {
-                        "anyOf": [
-                            {
-                                "type": "null"
-                            },
-                            {
-                                "$ref": "../../../enums/fitmentCode.ignore.json"
-                            }
-                        ]
-                    },
-                    "techRecord_tyres_dataTrAxles": {
-                        "type": [
-                            "null",
-                            "integer"
-                        ],
-                        "minimum": 0,
-                        "maximum": 999
-                    }
-                }
-            }
-        },
-        "techRecord_bodyType_code": {
-            "type": "string"
-        },
-        "techRecord_bodyType_description": {
-            "type": "string"
-        },
-        "techRecord_brakes_antilockBrakingSystem": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_brakes_dtpNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 6
-        },
-        "techRecord_brakes_loadSensingValve": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_conversionRefNo": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 10
-        },
-        "techRecord_createdAt": {
-            "type": "string"
-        },
-        "techRecord_createdById": {
-            "type": "string"
-        },
-        "techRecord_createdByName": {
-            "type": "string"
-        },
-        "techRecord_departmentalVehicleMarker": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_dimensions_axleSpacing_axles": {
-            "type": "string"
-        },
-        "techRecord_dimensions_axleSpacing_value": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_dimensions_length": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_dimensions_width": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_drawbarCouplingFitted": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_emissionsLimit": {
-            "type": [
-                "null",
-                "integer"
-            ],
-            "minimum": 0,
-            "maximum": 99
-        },
-        "techRecord_euroStandard": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_euVehicleCategory": {
-            "anyOf": [
-                {
-                    "$ref": "../../../enums/euVehicleCategory.ignore.json"
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        },
-        "techRecord_frontAxleToRearAxle": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_frontAxleTo5thWheelMin": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_frontAxleTo5thWheelMax": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_frontVehicleTo5thWheelCouplingMin": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_frontVehicleTo5thWheelCouplingMax": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_fuelPropulsionSystem": {
-            "anyOf": [
-                {
-                    "$ref": "../../../enums/fuelPropulsionSystem.ignore.json"
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        },
-        "techRecord_functionCode": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1
-        },
-        "techRecord_grossDesignWeight": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_grossEecWeight": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_grossGbWeight": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_make": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 30
-        },
-        "techRecord_maxTrainGbWeight": {
-            "type": [
-                "number",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_maxTrainEecWeight": {
-            "type": [
-                "number",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_maxTrainDesignWeight": {
-            "type": [
-                "number",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_manufactureYear": {
-            "anyOf": [
-                {
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 9999
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        },
-        "techRecord_microfilm_microfilmDocumentType": {
-            "anyOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "$ref": "../../../enums/microfilmDocumentType.ignore.json"
-                }
-            ]
-        },
-        "techRecord_microfilm_microfilmRollNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 5
-        },
-        "techRecord_microfilm_microfilmSerialNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 4
-        },
-        "techRecord_model": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 30
-        },
-        "techRecord_numberOfWheelsDriven": {
-            "type": "integer"
-        },
-        "techRecord_noOfAxles": {
-            "anyOf": [
-                {
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 99
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        },
-        "techRecord_notes": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_offRoad": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "plates": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "title": "HGV Plates",
-                "additionalProperties": false,
-                "properties": {
-                    "techRecord_plateSerialNumber": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "maxLength": 12
-                    },
-                    "techRecord_plateIssueDate": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
-                    "techRecord_reasonForIssue": {
-                        "anyOf": [
-                            {
-                                "type": "null"
-                            },
-                            {
-                                "$ref": "../../../enums/plateReasonForIssue.ignore.json"
-                            }
-                        ]
-                    },
-                    "techRecord_plateIssuer": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "maxLength": 150
-                    }
-                }
-            }
-        },
-        "techRecord_reasonForCreation": {
-            "type": "string"
-        },
-        "techRecord_recordCompleteness": {
-            "const": "testable"
-        },
-        "techRecord_regnDate": {
-            "anyOf": [
-                {
-                    "type": "string",
-                    "pattern": "^$"
-                },
-                {
-                    "type": "string",
-                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        },
-        "techRecord_roadFriendly": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_statusCode": {
-            "$ref": "../../../enums/statusCode.ignore.json"
-        },
-        "techRecord_speedLimiterMrk": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_tachoExemptMrk": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_trainDesignWeight": {
-            "type": [
-                "integer",
-                "null"
-            ],
+  "title": "GET HGV Technical Record V3 Testable",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "createdTimestamp",
+    "partialVin",
+    "systemNumber",
+    "techRecord_createdAt",
+    "techRecord_createdById",
+    "techRecord_createdByName",
+    "techRecord_reasonForCreation",
+    "techRecord_recordCompleteness",
+    "techRecord_statusCode",
+    "techRecord_vehicleType",
+    "primaryVrm",
+    "vin",
+    "techRecord_vehicleConfiguration",
+    "techRecord_vehicleClass_code",
+    "techRecord_vehicleClass_description",
+    "techRecord_numberOfWheelsDriven"
+  ],
+  "properties": {
+    "createdTimestamp": {
+      "type": "string"
+    },
+    "partialVin": {
+      "type": "string"
+    },
+    "systemNumber": {
+      "type": "string"
+    },
+    "techRecord_adrDetails_vehicleDetails_type": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_vehicleDetails_approvalDate": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_permittedDangerousGoods": {
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "techRecord_adrDetails_compatibilityGroupJ": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_additionalExaminerNotes": {
+      "type": ["string", "null"],
+      "maxLength": 1024
+    },
+    "techRecord_adrDetails_applicantDetails_name": {
+      "type": ["string", "null"],
+      "maxLength": 150
+    },
+    "techRecord_adrDetails_applicantDetails_street": {
+      "type": ["string", "null"],
+      "maxLength": 150
+    },
+    "techRecord_adrDetails_applicantDetails_town": {
+      "type": ["string", "null"],
+      "maxLength": 100
+    },
+    "techRecord_adrDetails_applicantDetails_city": {
+      "type": ["string", "null"],
+      "maxLength": 100
+    },
+    "techRecord_adrDetails_applicantDetails_postcode": {
+      "type": ["string", "null"],
+      "maxLength": 25
+    },
+    "techRecord_adrDetails_memosApply": {
+      "type": ["array", "null"],
+      "items": {
+        "type": ["string"]
+      }
+    },
+    "techRecord_adrDetails_documents": {
+      "type": ["array", "null"],
+      "items": {
+        "type": ["string"]
+      }
+    },
+    "techRecord_adrDetails_listStatementApplicable": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_batteryListNumber": {
+      "type": ["string", "null"],
+      "maxLength": 8
+    },
+    "techRecord_adrDetails_brakeDeclarationsSeen": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_brakeDeclarationIssuer": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_brakeEndurance": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_weight": {
+      "type": ["string", "null"],
+      "maxLength": 8
+    },
+    "techRecord_adrDetails_declarationsSeen": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_additionalNotes_guidanceNotes": {
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "techRecord_adrDetails_additionalNotes_number": {
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "techRecord_adrDetails_adrTypeApprovalNo": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_adrCertificateNotes": {
+      "type": ["string", "null"],
+      "maxLength": 1500
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
+      "type": ["string", "null"],
+      "maxLength": 70
+    },
+    "techRecord_adrDetails_tank_tankDetails_yearOfManufacture": {
+      "type": ["integer", "null"],
+      "maximum": 9999
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo": {
+      "type": ["string", "null"],
+      "maxLength": 50
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankTypeAppNo": {
+      "type": ["string", "null"],
+      "maxLength": 30
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankCode": {
+      "type": ["string", "null"],
+      "maxLength": 30
+    },
+    "techRecord_adrDetails_tank_tankDetails_specialProvisions": {
+      "type": ["string", "null"],
+      "maxLength": 1024
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2Type": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "../../../enums/tc2Types.ignore.json"
+        }
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateApprovalNo": {
+      "type": ["string", "null"],
+      "maxLength": 70
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateExpiryDate": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc3Details_tc3Type": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "../../../enums/tc3Types.ignore.json"
+        }
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicNumber": {
+      "type": ["string", "null"],
+      "maxLength": 75
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicExpiryDate": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_substancesPermitted": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_statement": {
+      "type": ["string", "null"],
+      "maxLength": 1500
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo": {
+      "type": ["array", "null"],
+      "items": {
+        "type": ["string"]
+      }
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_productList": {
+      "type": ["string", "null"],
+      "maxLength": 1500
+    },
+    "techRecord_alterationMarker": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_applicantDetails_name": {
+      "type": ["string", "null"],
+      "maxLength": 150
+    },
+    "techRecord_applicantDetails_address1": {
+      "type": ["null", "string"],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_address2": {
+      "type": ["null", "string"],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_postTown": {
+      "type": ["null", "string"],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_address3": {
+      "type": ["null", "string"],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_postCode": {
+      "type": ["null", "string"],
+      "maxLength": 12
+    },
+    "techRecord_applicantDetails_telephoneNumber": {
+      "type": ["null", "string"],
+      "maxLength": 25
+    },
+    "techRecord_applicantDetails_emailAddress": {
+      "type": ["null", "string"],
+      "maxLength": 255
+    },
+    "techRecord_applicationId": {
+      "type": "string"
+    },
+    "axles": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "title": "HGV Axles",
+        "additionalProperties": false,
+        "properties": {
+          "techRecord_parkingBrakeMrk": {
+            "type": ["boolean", "null"]
+          },
+          "techRecord_axleNumber": {
+            "type": ["integer", "null"]
+          },
+          "techRecord_weights_gbWeight": {
+            "type": ["integer", "null"],
             "minimum": 0,
             "maximum": 99999
-        },
-        "techRecord_trainEecWeight": {
-            "type": [
-                "number",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_trainGbWeight": {
-            "type": [
-                "number",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_tyreUseCode": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 2
-        },
-        "techRecord_vehicleClass_code": {
-            "type": "string"
-        },
-        "techRecord_vehicleClass_description": {
-            "$ref": "../../../enums/vehicleClassDescription.ignore.json"
-        },
-        "techRecord_vehicleConfiguration": {
+          },
+          "techRecord_weights_designWeight": {
+            "type": ["integer", "null"],
+            "minimum": 0,
+            "maximum": 99999
+          },
+          "techRecord_weights_eecWeight": {
+            "type": ["integer", "null"],
+            "minimum": 0,
+            "maximum": 99999
+          },
+          "techRecord_tyres_tyreCode": {
+            "type": ["integer", "null"],
+            "minimum": 0,
+            "maximum": 99999
+          },
+          "techRecord_tyres_tyreSize": {
+            "type": ["string", "null"],
+            "maxLength": 12
+          },
+          "techRecord_tyres_plyRating": {
+            "type": ["string", "null"]
+          },
+          "techRecord_tyres_fitmentCode": {
             "anyOf": [
-                {
-                    "$ref": "../../../enums/vehicleConfiguration.ignore.json"
-                }
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "../../../enums/fitmentCode.ignore.json"
+              }
             ]
-        },
-        "techRecord_approvalType": {
-            "anyOf": [
-                {
-                    "$ref": "../../../enums/approvalType.ignore.json"
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        },
-        "techRecord_approvalTypeNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 25
-        },
-        "techRecord_ntaNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 40
-        },
-        "techRecord_variantNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 25
-        },
-        "techRecord_variantVersionNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 35
-        },
-        "techRecord_lastUpdatedAt": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_lastUpdatedByName": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_lastUpdatedById": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_vehicleType": {
-            "const": "hgv"
-        },
-        "primaryVrm": {
-            "type": "string"
-        },
-        "vin": {
-            "type": "string"
+          },
+          "techRecord_tyres_dataTrAxles": {
+            "type": ["null", "integer"],
+            "minimum": 0,
+            "maximum": 999
+          }
         }
+      }
+    },
+    "techRecord_bodyType_code": {
+      "type": "string"
+    },
+    "techRecord_bodyType_description": {
+      "type": "string"
+    },
+    "techRecord_brakes_antilockBrakingSystem": {
+      "type": ["string", "null"]
+    },
+    "techRecord_brakes_dtpNumber": {
+      "type": ["string", "null"],
+      "maxLength": 6
+    },
+    "techRecord_brakes_loadSensingValve": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_conversionRefNo": {
+      "type": ["string", "null"],
+      "maxLength": 10
+    },
+    "techRecord_createdAt": {
+      "type": "string"
+    },
+    "techRecord_createdById": {
+      "type": "string"
+    },
+    "techRecord_createdByName": {
+      "type": "string"
+    },
+    "techRecord_departmentalVehicleMarker": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_dimensions_axleSpacing_axles": {
+      "type": "string"
+    },
+    "techRecord_dimensions_axleSpacing_value": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_dimensions_length": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_dimensions_width": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_drawbarCouplingFitted": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_emissionsLimit": {
+      "type": ["null", "integer"],
+      "minimum": 0,
+      "maximum": 99
+    },
+    "techRecord_euroStandard": {
+      "type": ["string", "null"]
+    },
+    "techRecord_euVehicleCategory": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/euVehicleCategory.ignore.json"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_frontAxleToRearAxle": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_frontAxleTo5thWheelMin": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_frontAxleTo5thWheelMax": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_frontVehicleTo5thWheelCouplingMin": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_frontVehicleTo5thWheelCouplingMax": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_fuelPropulsionSystem": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/fuelPropulsionSystem.ignore.json"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_functionCode": {
+      "type": ["string", "null"],
+      "maxLength": 1
+    },
+    "techRecord_grossDesignWeight": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_grossEecWeight": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_grossGbWeight": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_make": {
+      "type": ["string", "null"],
+      "maxLength": 30
+    },
+    "techRecord_maxTrainGbWeight": {
+      "type": ["number", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_maxTrainEecWeight": {
+      "type": ["number", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_maxTrainDesignWeight": {
+      "type": ["number", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_manufactureYear": {
+      "anyOf": [
+        {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9999
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_microfilm_microfilmDocumentType": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "../../../enums/microfilmDocumentType.ignore.json"
+        }
+      ]
+    },
+    "techRecord_microfilm_microfilmRollNumber": {
+      "type": ["string", "null"],
+      "maxLength": 5
+    },
+    "techRecord_microfilm_microfilmSerialNumber": {
+      "type": ["string", "null"],
+      "maxLength": 4
+    },
+    "techRecord_model": {
+      "type": ["string", "null"],
+      "maxLength": 30
+    },
+    "techRecord_numberOfWheelsDriven": {
+      "type": "integer"
+    },
+    "techRecord_noOfAxles": {
+      "anyOf": [
+        {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 99
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_notes": {
+      "type": ["string", "null"]
+    },
+    "techRecord_offRoad": {
+      "type": ["boolean", "null"]
+    },
+    "plates": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "title": "HGV Plates",
+        "additionalProperties": false,
+        "properties": {
+          "techRecord_plateSerialNumber": {
+            "type": ["string", "null"],
+            "maxLength": 12
+          },
+          "techRecord_plateIssueDate": {
+            "type": ["string", "null"]
+          },
+          "techRecord_reasonForIssue": {
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "../../../enums/plateReasonForIssue.ignore.json"
+              }
+            ]
+          },
+          "techRecord_plateIssuer": {
+            "type": ["string", "null"],
+            "maxLength": 150
+          }
+        }
+      }
+    },
+    "techRecord_reasonForCreation": {
+      "type": "string"
+    },
+    "techRecord_recordCompleteness": {
+      "const": "testable"
+    },
+    "techRecord_regnDate": {
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^$"
+        },
+        {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_roadFriendly": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_statusCode": {
+      "$ref": "../../../enums/statusCode.ignore.json"
+    },
+    "techRecord_speedLimiterMrk": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_tachoExemptMrk": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_trainDesignWeight": {
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "maximum": 99999
+    },
+    "techRecord_trainEecWeight": {
+      "type": ["number", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_trainGbWeight": {
+      "type": ["number", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_tyreUseCode": {
+      "type": ["string", "null"],
+      "maxLength": 2
+    },
+    "techRecord_vehicleClass_code": {
+      "type": "string"
+    },
+    "techRecord_vehicleClass_description": {
+      "$ref": "../../../enums/vehicleClassDescription.ignore.json"
+    },
+    "techRecord_vehicleConfiguration": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/vehicleConfiguration.ignore.json"
+        }
+      ]
+    },
+    "techRecord_approvalType": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/approvalType.ignore.json"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_approvalTypeNumber": {
+      "type": ["string", "null"],
+      "maxLength": 25
+    },
+    "techRecord_ntaNumber": {
+      "type": ["string", "null"],
+      "maxLength": 40
+    },
+    "techRecord_variantNumber": {
+      "type": ["string", "null"],
+      "maxLength": 25
+    },
+    "techRecord_variantVersionNumber": {
+      "type": ["string", "null"],
+      "maxLength": 35
+    },
+    "techRecord_lastUpdatedAt": {
+      "type": ["string", "null"]
+    },
+    "techRecord_lastUpdatedByName": {
+      "type": ["string", "null"]
+    },
+    "techRecord_lastUpdatedById": {
+      "type": ["string", "null"]
+    },
+    "techRecord_vehicleType": {
+      "const": "hgv"
+    },
+    "primaryVrm": {
+      "type": "string"
+    },
+    "vin": {
+      "type": "string"
+    },
+    "techRecord_hiddenInVta": {
+      "type": "boolean"
+    },
+    "techRecord_updateType": {
+      "type": "string"
     }
+  }
 }

--- a/json-definitions/v3/tech-record/get/psv/complete/index.json
+++ b/json-definitions/v3/tech-record/get/psv/complete/index.json
@@ -90,10 +90,7 @@
       "type": "integer"
     },
     "techRecord_numberOfWheelsDriven": {
-      "type": [
-        "integer",
-        "null"
-      ]
+      "type": ["integer", "null"]
     },
     "techRecord_vehicleClass_code": {
       "type": "string"
@@ -146,16 +143,10 @@
       ]
     },
     "techRecord_departmentalVehicleMarker": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_alterationMarker": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_approvalType": {
       "anyOf": [
@@ -168,31 +159,19 @@
       ]
     },
     "techRecord_approvalTypeNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 25
     },
     "techRecord_ntaNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 40
     },
     "techRecord_variantNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 25
     },
     "techRecord_variantVersionNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 35
     },
     "techRecord_bodyType_description": {
@@ -202,144 +181,84 @@
       "type": "string"
     },
     "techRecord_functionCode": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 1
     },
     "techRecord_conversionRefNo": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 10
     },
     "techRecord_grossGbWeight": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_grossDesignWeight": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_createdByName": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_createdById": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_lastUpdatedAt": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_lastUpdatedByName": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_lastUpdatedById": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_dda_certificateIssued": {
       "type": "boolean"
     },
     "techRecord_dda_wheelchairCapacity": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99,
       "minimum": 0
     },
     "techRecord_dda_wheelchairFittings": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 250
     },
     "techRecord_dda_wheelchairLiftPresent": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_dda_wheelchairLiftInformation": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 250
     },
     "techRecord_dda_wheelchairRampPresent": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_dda_wheelchairRampInformation": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 250
     },
     "techRecord_dda_minEmergencyExits": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "minimum": 0,
       "maximum": 99
     },
     "techRecord_dda_outswing": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 250
     },
     "techRecord_dda_ddaSchedules": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 250
     },
     "techRecord_dda_seatbeltsFitted": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "minimum": 0,
       "maximum": 999
     },
     "techRecord_dda_ddaNotes": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 1024
     },
     "techRecord_dda": {
@@ -363,61 +282,38 @@
       "$ref": "../../../enums/fuelPropulsionSystem.ignore.json"
     },
     "techRecord_emissionsLimit": {
-      "type": [
-        "null",
-        "integer"
-      ],
+      "type": ["null", "integer"],
       "minimum": 0,
       "maximum": 99
     },
     "techRecord_trainDesignWeight": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "minimum": 0,
       "maximum": 99999
     },
     "techRecord_numberOfSeatbelts": {
-      "type": [
-        "string"
-      ],
+      "type": ["string"],
       "maxLength": 99
     },
     "techRecord_seatbeltInstallationApprovalDate": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_coifSerialNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 8
     },
     "techRecord_coifCertifierName": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 20
     },
     "techRecord_coifDate": {
       "anyOf": [
         {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": ["string", "null"],
           "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
         },
         {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": ["string", "null"],
           "pattern": "^$"
         }
       ]
@@ -439,17 +335,11 @@
       "maxLength": 20
     },
     "techRecord_modelLiteral": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 30
     },
     "techRecord_speedRestriction": {
-      "type": [
-        "number",
-        "null"
-      ],
+      "type": ["number", "null"],
       "maximum": 99,
       "minimum": 0
     },
@@ -464,18 +354,12 @@
       "minimum": 0
     },
     "techRecord_unladenWeight": {
-      "type": [
-        "number",
-        "null"
-      ],
+      "type": ["number", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_maxTrainGbWeight": {
-      "type": [
-        "number",
-        "null"
-      ],
+      "type": ["number", "null"],
       "maximum": 99999,
       "minimum": 0
     },
@@ -483,49 +367,31 @@
       "type": "null"
     },
     "techRecord_dimensions_length": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "minimum": 0,
       "maximum": 99999
     },
     "techRecord_dimensions_width": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "minimum": 0,
       "maximum": 99999
     },
     "techRecord_dimensions_height": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "minimum": 0,
       "maximum": 99999
     },
     "techRecord_frontAxleToRearAxle": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "minimum": 0,
       "maximum": 99999
     },
     "techRecord_remarks": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 1024
     },
     "techRecord_dispensations": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 160
     },
     "axles": {
@@ -584,19 +450,13 @@
             "maxLength": 12
           },
           "techRecord_tyres_plyRating": {
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "techRecord_tyres_fitmentCode": {
             "$ref": "../../../enums/fitmentCode.ignore.json"
           },
           "techRecord_tyres_dataTrAxles": {
-            "type": [
-              "null",
-              "integer"
-            ],
+            "type": ["null", "integer"],
             "minimum": 0,
             "maximum": 999
           },
@@ -607,66 +467,39 @@
       }
     },
     "techRecord_applicantDetails_name": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 150
     },
     "techRecord_applicantDetails_address1": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 60
     },
     "techRecord_applicantDetails_address2": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 60
     },
     "techRecord_applicantDetails_postTown": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 60
     },
     "techRecord_applicantDetails_address3": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 60
     },
     "techRecord_applicantDetails_postCode": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 12
     },
     "techRecord_applicantDetails_telephoneNumber": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 25
     },
     "techRecord_applicantDetails_emailAddress": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 255
     },
     "techRecord_brakes_dtpNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 6
     },
     "techRecord_brakes_brakeCode": {
@@ -674,28 +507,19 @@
       "maxLength": 6
     },
     "techRecord_brakes_brakeCodeOriginal": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 6
     },
     "techRecord_brakes_dataTrBrakeOne": {
-      "type": [
-        "string"
-      ],
+      "type": ["string"],
       "maxLength": 60
     },
     "techRecord_brakes_dataTrBrakeTwo": {
-      "type": [
-        "string"
-      ],
+      "type": ["string"],
       "maxLength": 60
     },
     "techRecord_brakes_dataTrBrakeThree": {
-      "type": [
-        "string"
-      ],
+      "type": ["string"],
       "maxLength": 60
     },
     "techRecord_brakes_retarderBrakeOne": {
@@ -719,44 +543,32 @@
       ]
     },
     "techRecord_brakes_brakeForceWheelsNotLocked_parkingBrakeForceA": {
-      "type": [
-        "integer"
-      ],
+      "type": ["integer"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_brakes_brakeForceWheelsNotLocked_secondaryBrakeForceA": {
-      "type": [
-        "integer"
-      ],
+      "type": ["integer"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_brakes_brakeForceWheelsNotLocked_serviceBrakeForceA": {
-      "type": [
-        "integer"
-      ],
+      "type": ["integer"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_brakes_brakeForceWheelsUpToHalfLocked_parkingBrakeForceB": {
-      "type": [
-        "integer"
-      ],
+      "type": ["integer"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_brakes_brakeForceWheelsUpToHalfLocked_secondaryBrakeForceB": {
-      "type": [
-        "integer"
-      ],
+      "type": ["integer"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_brakes_brakeForceWheelsUpToHalfLocked_serviceBrakeForceB": {
-      "type": [
-        "integer"
-      ],
+      "type": ["integer"],
       "maximum": 99999,
       "minimum": 0
     },
@@ -774,29 +586,21 @@
       ]
     },
     "techRecord_microfilmRollNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 5
     },
     "techRecord_microfilmSerialNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 4
     },
     "techRecord_brakeCode": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "createdTimestamp": {
-      "type": [
-        "string"
-      ]
+      "type": ["string"]
+    },
+    "techRecord_updateType": {
+      "type": "string"
     }
   }
 }

--- a/json-definitions/v3/tech-record/get/psv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/psv/skeleton/index.json
@@ -50,8 +50,8 @@
     },
     "techRecord_vehicleConfiguration": {
       "anyOf": [
-        {"$ref": "../../../enums/vehicleConfiguration.ignore.json"},
-        {"type": "null"}
+        { "$ref": "../../../enums/vehicleConfiguration.ignore.json" },
+        { "type": "null" }
       ]
     },
     "techRecord_vehicleSize": {
@@ -71,10 +71,7 @@
       "type": ["integer", "null"]
     },
     "techRecord_numberOfWheelsDriven": {
-      "type": [
-        "integer",
-        "null"
-      ]
+      "type": ["integer", "null"]
     },
     "techRecord_vehicleClass_code": {
       "type": "string"
@@ -138,16 +135,10 @@
       ]
     },
     "techRecord_departmentalVehicleMarker": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_alterationMarker": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_approvalType": {
       "anyOf": [
@@ -160,31 +151,19 @@
       ]
     },
     "techRecord_approvalTypeNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 25
     },
     "techRecord_ntaNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 40
     },
     "techRecord_variantNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 25
     },
     "techRecord_variantVersionNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 35
     },
     "techRecord_bodyType_description": {
@@ -194,171 +173,99 @@
       "type": "string"
     },
     "techRecord_functionCode": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 1
     },
     "techRecord_conversionRefNo": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 10
     },
     "techRecord_grossGbWeight": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_grossDesignWeight": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_createdByName": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_createdById": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_lastUpdatedAt": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_lastUpdatedByName": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_lastUpdatedById": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_dda_certificateIssued": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_dda_wheelchairCapacity": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99,
       "minimum": 0
     },
     "techRecord_dda_wheelchairFittings": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 250
     },
     "techRecord_dda_wheelchairLiftPresent": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_dda_wheelchairLiftInformation": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 250
     },
     "techRecord_dda_wheelchairRampPresent": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_dda_wheelchairRampInformation": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 250
     },
     "techRecord_dda_minEmergencyExits": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "minimum": 0,
       "maximum": 99
     },
     "techRecord_dda_outswing": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 250
     },
     "techRecord_dda_ddaSchedules": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 250
     },
     "techRecord_dda_seatbeltsFitted": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "minimum": 0,
       "maximum": 999
     },
     "techRecord_dda_ddaNotes": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 1024
     },
     "techRecord_dda": {
       "type": "null"
     },
     "techRecord_standingCapacity": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "minimum": 0,
       "maximum": 999
     },
     "techRecord_speedLimiterMrk": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_tachoExemptMrk": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_euroStandard": {
       "anyOf": [
@@ -381,137 +288,84 @@
       ]
     },
     "techRecord_emissionsLimit": {
-      "type": [
-        "null",
-        "integer"
-      ],
+      "type": ["null", "integer"],
       "minimum": 0,
       "maximum": 99
     },
     "techRecord_trainDesignWeight": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "minimum": 0,
       "maximum": 99999
     },
     "techRecord_numberOfSeatbelts": {
-      "type": [
-        "string", "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 99
     },
     "techRecord_seatbeltInstallationApprovalDate": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_coifSerialNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 8
     },
     "techRecord_coifCertifierName": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 20
     },
     "techRecord_coifDate": {
       "anyOf": [
         {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": ["string", "null"],
           "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
         },
         {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": ["string", "null"],
           "pattern": "^$"
         }
       ]
     },
     "techRecord_bodyMake": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 20
     },
     "techRecord_bodyModel": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 20
     },
     "techRecord_chassisMake": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 20
     },
     "techRecord_chassisModel": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 20
     },
     "techRecord_modelLiteral": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 30
     },
     "techRecord_speedRestriction": {
-      "type": [
-        "number",
-        "null"
-      ],
+      "type": ["number", "null"],
       "maximum": 99,
       "minimum": 0
     },
     "techRecord_grossKerbWeight": {
-      "type": [
-        "number",
-        "null"
-      ],
+      "type": ["number", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_grossLadenWeight": {
-      "type": [
-        "number",
-        "null"
-      ],
+      "type": ["number", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_unladenWeight": {
-      "type": [
-        "number",
-        "null"
-      ],
+      "type": ["number", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_maxTrainGbWeight": {
-      "type": [
-        "number",
-        "null"
-      ],
+      "type": ["number", "null"],
       "maximum": 99999,
       "minimum": 0
     },
@@ -519,49 +373,31 @@
       "type": "null"
     },
     "techRecord_dimensions_length": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "minimum": 0,
       "maximum": 99999
     },
     "techRecord_dimensions_width": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "minimum": 0,
       "maximum": 99999
     },
     "techRecord_dimensions_height": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "minimum": 0,
       "maximum": 99999
     },
     "techRecord_frontAxleToRearAxle": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "minimum": 0,
       "maximum": 99999
     },
     "techRecord_remarks": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 1024
     },
     "techRecord_dispensations": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 160
     },
     "axles": {
@@ -572,69 +408,42 @@
         "additionalProperties": false,
         "properties": {
           "techRecord_parkingBrakeMrk": {
-            "type": [
-              "boolean",
-              "null"
-            ]
+            "type": ["boolean", "null"]
           },
           "techRecord_axleNumber": {
-            "type": [
-              "integer",
-              "null"
-            ]
+            "type": ["integer", "null"]
           },
           "techRecord_weights_gbWeight": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "minimum": 0,
             "maximum": 99999
           },
           "techRecord_weights_designWeight": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "minimum": 0,
             "maximum": 99999
           },
           "techRecord_weights_ladenWeight": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "minimum": 0,
             "maximum": 99999
           },
           "techRecord_weights_kerbWeight": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "minimum": 0,
             "maximum": 99999
           },
           "techRecord_tyres_tyreCode": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "minimum": 0,
             "maximum": 99999
           },
           "techRecord_tyres_tyreSize": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "maxLength": 12
           },
           "techRecord_tyres_plyRating": {
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "techRecord_tyres_fitmentCode": {
             "anyOf": [
@@ -647,10 +456,7 @@
             ]
           },
           "techRecord_tyres_dataTrAxles": {
-            "type": [
-              "null",
-              "integer"
-            ],
+            "type": ["null", "integer"],
             "minimum": 0,
             "maximum": 999
           },
@@ -668,101 +474,59 @@
       }
     },
     "techRecord_applicantDetails_name": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 150
     },
     "techRecord_applicantDetails_address1": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 60
     },
     "techRecord_applicantDetails_address2": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 60
     },
     "techRecord_applicantDetails_postTown": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 60
     },
     "techRecord_applicantDetails_address3": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 60
     },
     "techRecord_applicantDetails_postCode": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 12
     },
     "techRecord_applicantDetails_telephoneNumber": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 25
     },
     "techRecord_applicantDetails_emailAddress": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 255
     },
     "techRecord_brakes_dtpNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 6
     },
     "techRecord_brakes_brakeCode": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 6
     },
     "techRecord_brakes_brakeCodeOriginal": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 6
     },
     "techRecord_brakes_dataTrBrakeOne": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 60
     },
     "techRecord_brakes_dataTrBrakeTwo": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 60
     },
     "techRecord_brakes_dataTrBrakeThree": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 60
     },
     "techRecord_brakes_retarderBrakeOne": {
@@ -786,50 +550,32 @@
       ]
     },
     "techRecord_brakes_brakeForceWheelsNotLocked_parkingBrakeForceA": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_brakes_brakeForceWheelsNotLocked_secondaryBrakeForceA": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_brakes_brakeForceWheelsNotLocked_serviceBrakeForceA": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_brakes_brakeForceWheelsUpToHalfLocked_parkingBrakeForceB": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_brakes_brakeForceWheelsUpToHalfLocked_secondaryBrakeForceB": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_brakes_brakeForceWheelsUpToHalfLocked_serviceBrakeForceB": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
@@ -847,24 +593,15 @@
       ]
     },
     "techRecord_microfilmRollNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 5
     },
     "techRecord_microfilmSerialNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 4
     },
     "techRecord_brakeCode": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "createdTimestamp": {
       "type": ["string"]
@@ -877,6 +614,9 @@
       "items": {
         "type": "string"
       }
+    },
+    "techRecord_updateType": {
+      "type": "string"
     }
   }
 }

--- a/json-definitions/v3/tech-record/get/psv/testable/index.json
+++ b/json-definitions/v3/tech-record/get/psv/testable/index.json
@@ -588,6 +588,9 @@
       "items": {
         "type": "string"
       }
+    },
+    "techRecord_updateType": {
+      "type": "string"
     }
   }
 }

--- a/json-definitions/v3/tech-record/get/trl/complete/index.json
+++ b/json-definitions/v3/tech-record/get/trl/complete/index.json
@@ -50,211 +50,120 @@
       "type": "string"
     },
     "techRecord_adrDetails_vehicleDetails_type": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_adrDetails_vehicleDetails_approvalDate": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_adrDetails_permittedDangerousGoods": {
-      "type": [
-        "array",
-        "null"
-      ],
+      "type": ["array", "null"],
       "items": {
         "type": "string"
       }
     },
     "techRecord_adrDetails_compatibilityGroupJ": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_adrDetails_additionalExaminerNotes": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 1024
     },
     "techRecord_adrDetails_applicantDetails_name": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 150
     },
     "techRecord_adrDetails_applicantDetails_street": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 150
     },
     "techRecord_adrDetails_applicantDetails_town": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 100
     },
     "techRecord_adrDetails_applicantDetails_city": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 100
     },
     "techRecord_adrDetails_applicantDetails_postcode": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 25
     },
     "techRecord_adrDetails_memosApply": {
-      "type": [
-        "array",
-        "null"
-      ],
+      "type": ["array", "null"],
       "items": {
-        "type": [
-          "string"
-        ]
+        "type": ["string"]
       }
     },
     "techRecord_adrDetails_documents": {
-      "type": [
-        "array",
-        "null"
-      ],
+      "type": ["array", "null"],
       "items": {
-        "type": [
-          "string"
-        ]
+        "type": ["string"]
       }
     },
     "techRecord_adrDetails_listStatementApplicable": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_adrDetails_batteryListNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 8
     },
     "techRecord_adrDetails_brakeDeclarationsSeen": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_adrDetails_brakeDeclarationIssuer": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_adrDetails_brakeEndurance": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_adrDetails_weight": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 8
     },
     "techRecord_adrDetails_declarationsSeen": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_adrDetails_additionalNotes_guidanceNotes": {
-      "type": [
-        "array",
-        "null"
-      ],
+      "type": ["array", "null"],
       "items": {
         "type": "string"
       }
     },
     "techRecord_adrDetails_additionalNotes_number": {
-      "type": [
-        "array",
-        "null"
-      ],
+      "type": ["array", "null"],
       "items": {
         "type": "string"
       }
     },
     "techRecord_adrDetails_adrTypeApprovalNo": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_adrDetails_adrCertificateNotes": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 1500
     },
     "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 70
     },
     "techRecord_adrDetails_tank_tankDetails_yearOfManufacture": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 9999
     },
     "techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 50
     },
     "techRecord_adrDetails_tank_tankDetails_tankTypeAppNo": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 30
     },
     "techRecord_adrDetails_tank_tankDetails_tankCode": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 30
     },
     "techRecord_adrDetails_tank_tankDetails_specialProvisions": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 1024
     },
     "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2Type": {
@@ -268,17 +177,11 @@
       ]
     },
     "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateApprovalNo": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 70
     },
     "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateExpiryDate": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_adrDetails_tank_tankDetails_tc3Details_tc3Type": {
       "anyOf": [
@@ -291,122 +194,69 @@
       ]
     },
     "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 75
     },
     "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicExpiryDate": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_adrDetails_tank_tankDetails_tankStatement_substancesPermitted": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_adrDetails_tank_tankDetails_tankStatement_statement": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 1500
     },
     "techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo": {
-      "type": [
-        "array",
-        "null"
-      ],
+      "type": ["array", "null"],
       "items": {
-        "type": [
-          "string"
-        ]
+        "type": ["string"]
       }
     },
     "techRecord_adrDetails_tank_tankDetails_tankStatement_productList": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 1500
     },
     "techRecord_alterationMarker": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_applicantDetails_name": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 150
     },
     "techRecord_applicantDetails_address1": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 60
     },
     "techRecord_applicantDetails_address2": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 60
     },
     "techRecord_applicantDetails_postTown": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 60
     },
     "techRecord_applicantDetails_address3": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 60
     },
     "techRecord_applicantDetails_postCode": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 12
     },
     "techRecord_applicantDetails_telephoneNumber": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 25
     },
     "techRecord_applicantDetails_emailAddress": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 255
     },
     "techRecord_applicationId": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_approvalType": {
       "anyOf": [
@@ -419,23 +269,14 @@
       ]
     },
     "techRecord_approvalTypeNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 25
     },
     "techRecord_authIntoService": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_batchId": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_bodyType_code": {
       "type": "string"
@@ -444,74 +285,44 @@
       "type": "string"
     },
     "techRecord_brakes_antilockBrakingSystem": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_brakes_dtpNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 6
     },
     "techRecord_brakes_loadSensingValve": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_centreOfRearmostAxleToRearOfTrl": {
-      "type": [
-        "integer",
-        "null"
-      ]
+      "type": ["integer", "null"]
     },
     "techRecord_conversionRefNo": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 10
     },
     "techRecord_couplingCenterToRearAxleMax": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_couplingCenterToRearAxleMin": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_couplingCenterToRearTrlMax": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_couplingCenterToRearTrlMin": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_couplingType": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 1
     },
     "techRecord_createdAt": {
@@ -524,24 +335,15 @@
       "type": "string"
     },
     "techRecord_departmentalVehicleMarker": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_dimensions_length": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_dimensions_width": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
@@ -549,10 +351,7 @@
       "type": "string"
     },
     "techRecord_emissionsLimit": {
-      "type": [
-        "null",
-        "integer"
-      ],
+      "type": ["null", "integer"],
       "minimum": 0,
       "maximum": 99
     },
@@ -570,22 +369,13 @@
       "$ref": "../../../enums/euroStandard.ignore.json"
     },
     "frontAxleTo5thWheelMax": {
-      "type": [
-        "integer",
-        "null"
-      ]
+      "type": ["integer", "null"]
     },
     "techRecord_frontAxleTo5thWheelMin": {
-      "type": [
-        "integer",
-        "null"
-      ]
+      "type": ["integer", "null"]
     },
     "techRecord_firstUseDate": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_frameDescription": {
       "anyOf": [
@@ -598,70 +388,43 @@
       ]
     },
     "techRecord_frontAxleToRearAxle": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_frontVehicleTo5thWheelCouplingMax": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_frontVehicleTo5thWheelCouplingMin": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_fuelPropulsionSystem": {
       "$ref": "../../../enums/fuelPropulsionSystem.ignore.json"
     },
     "techRecord_functionCode": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 1
     },
     "techRecord_grossDesignWeight": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_grossEecWeight": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_grossGbWeight": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_letterOfAuth": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_make": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 30
     },
     "techRecord_manufactureYear": {
@@ -686,24 +449,15 @@
       "type": "integer"
     },
     "techRecord_manufacturerDetails": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_maxLoadOnCoupling": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "minimum": 0,
       "maximum": 99999
     },
     "techRecord_microfilm": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_microfilm_microfilmDocumentType": {
       "anyOf": [
@@ -716,24 +470,15 @@
       ]
     },
     "techRecord_microfilm_microfilmRollNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 5
     },
     "techRecord_microfilm_microfilmSerialNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 4
     },
     "techRecord_model": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 30
     },
     "techRecord_noOfAxles": {
@@ -755,10 +500,7 @@
       "type": "string"
     },
     "techRecord_numberOfWheelsDriven": {
-      "type": [
-        "integer",
-        "null"
-      ]
+      "type": ["integer", "null"]
     },
     "techRecord_offRoad": {
       "type": "boolean"
@@ -771,17 +513,11 @@
         "additionalProperties": false,
         "properties": {
           "techRecord_plateSerialNumber": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "maxLength": 12
           },
           "techRecord_plateIssueDate": {
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "techRecord_reasonForIssue": {
             "anyOf": [
@@ -794,98 +530,53 @@
             ]
           },
           "techRecord_plateIssuer": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "maxLength": 150
           }
         }
       }
     },
     "techRecord_purchaserDetails_address1": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_purchaserDetails_address2": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_purchaserDetails_address3": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_purchaserDetails_emailAddress": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_purchaserDetails_faxNumber": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_purchaserDetails_name": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_purchaserDetails_postCode": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_purchaserDetails_postTown": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_purchaserDetails_purchaserNotes": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_purchaserDetails_telephoneNumber": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_lastUpdatedAt": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_lastUpdatedByName": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_lastUpdatedById": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_rearAxleToRearTrl": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
@@ -911,10 +602,7 @@
       ]
     },
     "techRecord_roadFriendly": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_speedLimiterMrk": {
       "type": "boolean"
@@ -926,17 +614,11 @@
       "type": "boolean"
     },
     "techRecord_suspensionType": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 1
     },
     "techRecord_tyreUseCode": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 2
     },
     "techRecord_variantNumber": {
@@ -978,16 +660,10 @@
         "additionalProperties": false,
         "properties": {
           "techRecord_parkingBrakeMrk": {
-            "type": [
-              "boolean",
-              "null"
-            ]
+            "type": ["boolean", "null"]
           },
           "techRecord_axleNumber": {
-            "type": [
-              "integer",
-              "null"
-            ]
+            "type": ["integer", "null"]
           },
           "techRecord_brakes": {
             "type": "array",
@@ -1011,57 +687,36 @@
             }
           },
           "techRecord_weights_gbWeight": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "minimum": 0,
             "maximum": 99999
           },
           "techRecord_weights_designWeight": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "minimum": 0,
             "maximum": 99999
           },
           "techRecord_weights_ladenWeight": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "minimum": 0,
             "maximum": 99999
           },
           "techRecord_weights_kerbWeight": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "minimum": 0,
             "maximum": 99999
           },
           "techRecord_tyres_tyreCode": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "minimum": 0,
             "maximum": 99999
           },
           "techRecord_tyres_tyreSize": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "maxLength": 12
           },
           "techRecord_tyres_plyRating": {
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "techRecord_tyres_fitmentCode": {
             "anyOf": [
@@ -1074,10 +729,7 @@
             ]
           },
           "techRecord_tyres_dataTrAxles": {
-            "type": [
-              "null",
-              "integer"
-            ],
+            "type": ["null", "integer"],
             "minimum": 0,
             "maximum": 999
           },
@@ -1090,6 +742,12 @@
                 "type": "null"
               }
             ]
+          },
+          "techRecord_hiddenInVta": {
+            "type": "boolean"
+          },
+          "techRecord_updateType": {
+            "type": "string"
           }
         }
       }

--- a/json-definitions/v3/tech-record/get/trl/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/trl/skeleton/index.json
@@ -30,211 +30,120 @@
       "type": "string"
     },
     "techRecord_adrDetails_vehicleDetails_type": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_adrDetails_vehicleDetails_approvalDate": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_adrDetails_permittedDangerousGoods": {
-      "type": [
-        "array",
-        "null"
-      ],
+      "type": ["array", "null"],
       "items": {
         "type": "string"
       }
     },
     "techRecord_adrDetails_compatibilityGroupJ": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_adrDetails_additionalExaminerNotes": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 1024
     },
     "techRecord_adrDetails_applicantDetails_name": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 150
     },
     "techRecord_adrDetails_applicantDetails_street": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 150
     },
     "techRecord_adrDetails_applicantDetails_town": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 100
     },
     "techRecord_adrDetails_applicantDetails_city": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 100
     },
     "techRecord_adrDetails_applicantDetails_postcode": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 25
     },
     "techRecord_adrDetails_memosApply": {
-      "type": [
-        "array",
-        "null"
-      ],
+      "type": ["array", "null"],
       "items": {
-        "type": [
-          "string"
-        ]
+        "type": ["string"]
       }
     },
     "techRecord_adrDetails_documents": {
-      "type": [
-        "array",
-        "null"
-      ],
+      "type": ["array", "null"],
       "items": {
-        "type": [
-          "string"
-        ]
+        "type": ["string"]
       }
     },
     "techRecord_adrDetails_listStatementApplicable": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_adrDetails_batteryListNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 8
     },
     "techRecord_adrDetails_brakeDeclarationsSeen": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_adrDetails_brakeDeclarationIssuer": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_adrDetails_brakeEndurance": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_adrDetails_weight": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 8
     },
     "techRecord_adrDetails_declarationsSeen": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_adrDetails_additionalNotes_guidanceNotes": {
-      "type": [
-        "array",
-        "null"
-      ],
+      "type": ["array", "null"],
       "items": {
         "type": "string"
       }
     },
     "techRecord_adrDetails_additionalNotes_number": {
-      "type": [
-        "array",
-        "null"
-      ],
+      "type": ["array", "null"],
       "items": {
         "type": "string"
       }
     },
     "techRecord_adrDetails_adrTypeApprovalNo": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_adrDetails_adrCertificateNotes": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 1500
     },
     "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 70
     },
     "techRecord_adrDetails_tank_tankDetails_yearOfManufacture": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 9999
     },
     "techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 50
     },
     "techRecord_adrDetails_tank_tankDetails_tankTypeAppNo": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 30
     },
     "techRecord_adrDetails_tank_tankDetails_tankCode": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 30
     },
     "techRecord_adrDetails_tank_tankDetails_specialProvisions": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 1024
     },
     "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2Type": {
@@ -248,17 +157,11 @@
       ]
     },
     "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateApprovalNo": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 70
     },
     "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateExpiryDate": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_adrDetails_tank_tankDetails_tc3Details_tc3Type": {
       "anyOf": [
@@ -271,131 +174,75 @@
       ]
     },
     "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 75
     },
     "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicExpiryDate": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_adrDetails_tank_tankDetails_tankStatement_substancesPermitted": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_adrDetails_tank_tankDetails_tankStatement_statement": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 1500
     },
     "techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo": {
-      "type": [
-        "array",
-        "null"
-      ],
+      "type": ["array", "null"],
       "items": {
-        "type": [
-          "string"
-        ]
+        "type": ["string"]
       }
     },
     "techRecord_adrDetails_tank_tankDetails_tankStatement_productList": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 1500
     },
     "techRecord_alterationMarker": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_applicantDetails_name": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 150
     },
     "techRecord_applicantDetails_address1": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 60
     },
     "techRecord_applicantDetails_address2": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 60
     },
     "techRecord_applicantDetails_postTown": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 60
     },
     "techRecord_applicantDetails_address3": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 60
     },
     "techRecord_applicantDetails_postCode": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 12
     },
     "techRecord_applicantDetails_telephoneNumber": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 25
     },
     "techRecord_applicantDetails_emailAddress": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 255
     },
     "techRecord_applicationId": {
       "type": "string"
     },
     "techRecord_authIntoService": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_batchId": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_bodyType_code": {
       "type": "string"
@@ -404,74 +251,44 @@
       "type": "string"
     },
     "techRecord_brakes_antilockBrakingSystem": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_brakes_dtpNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 6
     },
     "techRecord_brakes_loadSensingValve": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_centreOfRearmostAxleToRearOfTrl": {
-      "type": [
-        "integer",
-        "null"
-      ]
+      "type": ["integer", "null"]
     },
     "techRecord_conversionRefNo": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 10
     },
     "techRecord_couplingCenterToRearAxleMax": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_couplingCenterToRearAxleMin": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_couplingCenterToRearTrlMax": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_couplingCenterToRearTrlMin": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_couplingType": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 1
     },
     "techRecord_createdAt": {
@@ -484,24 +301,15 @@
       "type": "string"
     },
     "techRecord_departmentalVehicleMarker": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_dimensions_length": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_dimensions_width": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
@@ -516,10 +324,7 @@
       ]
     },
     "techRecord_firstUseDate": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_frameDescription": {
       "anyOf": [
@@ -532,55 +337,34 @@
       ]
     },
     "techRecord_frontAxleToRearAxle": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_functionCode": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 1
     },
     "techRecord_grossDesignWeight": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_grossEecWeight": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_grossGbWeight": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_letterOfAuth": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_make": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 30
     },
     "techRecord_manufactureYear": {
@@ -596,24 +380,15 @@
       ]
     },
     "techRecord_manufacturerDetails": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_maxLoadOnCoupling": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "minimum": 0,
       "maximum": 99999
     },
     "techRecord_microfilm": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_microfilm_microfilmDocumentType": {
       "anyOf": [
@@ -626,24 +401,15 @@
       ]
     },
     "techRecord_microfilm_microfilmRollNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 5
     },
     "techRecord_microfilm_microfilmSerialNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 4
     },
     "techRecord_model": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 30
     },
     "techRecord_noOfAxles": {
@@ -666,17 +432,11 @@
         "additionalProperties": false,
         "properties": {
           "techRecord_plateSerialNumber": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "maxLength": 12
           },
           "techRecord_plateIssueDate": {
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "techRecord_reasonForIssue": {
             "anyOf": [
@@ -689,98 +449,53 @@
             ]
           },
           "techRecord_plateIssuer": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "maxLength": 150
           }
         }
       }
     },
     "techRecord_purchaserDetails_address1": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_purchaserDetails_address2": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_purchaserDetails_address3": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_purchaserDetails_emailAddress": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_purchaserDetails_faxNumber": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_purchaserDetails_name": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_purchaserDetails_postCode": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_purchaserDetails_postTown": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_purchaserDetails_purchaserNotes": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_purchaserDetails_telephoneNumber": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_lastUpdatedAt": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_lastUpdatedByName": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_lastUpdatedById": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_rearAxleToRearTrl": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
@@ -806,26 +521,17 @@
       ]
     },
     "techRecord_roadFriendly": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_statusCode": {
       "$ref": "../../../enums/statusCode.ignore.json"
     },
     "techRecord_suspensionType": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 1
     },
     "techRecord_tyreUseCode": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 2
     },
     "techRecord_vehicleClass_code": {
@@ -851,6 +557,12 @@
       "type": "string"
     },
     "vin": {
+      "type": "string"
+    },
+    "techRecord_hiddenInVta": {
+      "type": "boolean"
+    },
+    "techRecord_updateType": {
       "type": "string"
     }
   }

--- a/json-definitions/v3/tech-record/get/trl/testable/index.json
+++ b/json-definitions/v3/tech-record/get/trl/testable/index.json
@@ -33,211 +33,120 @@
       "type": "string"
     },
     "techRecord_adrDetails_vehicleDetails_type": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_adrDetails_vehicleDetails_approvalDate": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_adrDetails_permittedDangerousGoods": {
-      "type": [
-        "array",
-        "null"
-      ],
+      "type": ["array", "null"],
       "items": {
         "type": "string"
       }
     },
     "techRecord_adrDetails_compatibilityGroupJ": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_adrDetails_additionalExaminerNotes": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 1024
     },
     "techRecord_adrDetails_applicantDetails_name": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 150
     },
     "techRecord_adrDetails_applicantDetails_street": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 150
     },
     "techRecord_adrDetails_applicantDetails_town": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 100
     },
     "techRecord_adrDetails_applicantDetails_city": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 100
     },
     "techRecord_adrDetails_applicantDetails_postcode": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 25
     },
     "techRecord_adrDetails_memosApply": {
-      "type": [
-        "array",
-        "null"
-      ],
+      "type": ["array", "null"],
       "items": {
-        "type": [
-          "string"
-        ]
+        "type": ["string"]
       }
     },
     "techRecord_adrDetails_documents": {
-      "type": [
-        "array",
-        "null"
-      ],
+      "type": ["array", "null"],
       "items": {
-        "type": [
-          "string"
-        ]
+        "type": ["string"]
       }
     },
     "techRecord_adrDetails_listStatementApplicable": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_adrDetails_batteryListNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 8
     },
     "techRecord_adrDetails_brakeDeclarationsSeen": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_adrDetails_brakeDeclarationIssuer": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_adrDetails_brakeEndurance": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_adrDetails_weight": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 8
     },
     "techRecord_adrDetails_declarationsSeen": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_adrDetails_additionalNotes_guidanceNotes": {
-      "type": [
-        "array",
-        "null"
-      ],
+      "type": ["array", "null"],
       "items": {
         "type": "string"
       }
     },
     "techRecord_adrDetails_additionalNotes_number": {
-      "type": [
-        "array",
-        "null"
-      ],
+      "type": ["array", "null"],
       "items": {
         "type": "string"
       }
     },
     "techRecord_adrDetails_adrTypeApprovalNo": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_adrDetails_adrCertificateNotes": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 1500
     },
     "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 70
     },
     "techRecord_adrDetails_tank_tankDetails_yearOfManufacture": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 9999
     },
     "techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 50
     },
     "techRecord_adrDetails_tank_tankDetails_tankTypeAppNo": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 30
     },
     "techRecord_adrDetails_tank_tankDetails_tankCode": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 30
     },
     "techRecord_adrDetails_tank_tankDetails_specialProvisions": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 1024
     },
     "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2Type": {
@@ -251,17 +160,11 @@
       ]
     },
     "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateApprovalNo": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 70
     },
     "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateExpiryDate": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_adrDetails_tank_tankDetails_tc3Details_tc3Type": {
       "anyOf": [
@@ -274,134 +177,75 @@
       ]
     },
     "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 75
     },
     "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicExpiryDate": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_adrDetails_tank_tankDetails_tankStatement_substancesPermitted": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_adrDetails_tank_tankDetails_tankStatement_statement": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 1500
     },
     "techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo": {
-      "type": [
-        "array",
-        "null"
-      ],
+      "type": ["array", "null"],
       "items": {
-        "type": [
-          "string"
-        ]
+        "type": ["string"]
       }
     },
     "techRecord_adrDetails_tank_tankDetails_tankStatement_productList": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 1500
     },
     "techRecord_alterationMarker": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_applicantDetails_name": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 150
     },
     "techRecord_applicantDetails_address1": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 60
     },
     "techRecord_applicantDetails_address2": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 60
     },
     "techRecord_applicantDetails_postTown": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 60
     },
     "techRecord_applicantDetails_address3": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 60
     },
     "techRecord_applicantDetails_postCode": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 12
     },
     "techRecord_applicantDetails_telephoneNumber": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 25
     },
     "techRecord_applicantDetails_emailAddress": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 255
     },
     "techRecord_applicationId": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_authIntoService": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_batchId": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_bodyType_code": {
       "type": "string"
@@ -410,74 +254,44 @@
       "type": "string"
     },
     "techRecord_brakes_antilockBrakingSystem": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_brakes_dtpNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 6
     },
     "techRecord_brakes_loadSensingValve": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_centreOfRearmostAxleToRearOfTrl": {
-      "type": [
-        "integer",
-        "null"
-      ]
+      "type": ["integer", "null"]
     },
     "techRecord_conversionRefNo": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 10
     },
     "techRecord_couplingCenterToRearAxleMax": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_couplingCenterToRearAxleMin": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_couplingCenterToRearTrlMax": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_couplingCenterToRearTrlMin": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_couplingType": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 1
     },
     "techRecord_createdAt": {
@@ -490,24 +304,15 @@
       "type": "string"
     },
     "techRecord_departmentalVehicleMarker": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_dimensions_length": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_dimensions_width": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
@@ -522,10 +327,7 @@
       ]
     },
     "techRecord_firstUseDate": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_frameDescription": {
       "anyOf": [
@@ -538,55 +340,34 @@
       ]
     },
     "techRecord_frontAxleToRearAxle": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_functionCode": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 1
     },
     "techRecord_grossDesignWeight": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_grossEecWeight": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_grossGbWeight": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_letterOfAuth": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_make": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 30
     },
     "techRecord_manufactureYear": {
@@ -602,24 +383,15 @@
       ]
     },
     "techRecord_manufacturerDetails": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_maxLoadOnCoupling": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "minimum": 0,
       "maximum": 99999
     },
     "techRecord_microfilm": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_microfilm_microfilmDocumentType": {
       "anyOf": [
@@ -632,24 +404,15 @@
       ]
     },
     "techRecord_microfilm_microfilmRollNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 5
     },
     "techRecord_microfilm_microfilmSerialNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 4
     },
     "techRecord_model": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 30
     },
     "techRecord_noOfAxles": {
@@ -672,17 +435,11 @@
         "additionalProperties": false,
         "properties": {
           "techRecord_plateSerialNumber": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "maxLength": 12
           },
           "techRecord_plateIssueDate": {
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "techRecord_reasonForIssue": {
             "anyOf": [
@@ -695,98 +452,53 @@
             ]
           },
           "techRecord_plateIssuer": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "maxLength": 150
           }
         }
       }
     },
     "techRecord_purchaserDetails_address1": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_purchaserDetails_address2": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_purchaserDetails_address3": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_purchaserDetails_emailAddress": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_purchaserDetails_faxNumber": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_purchaserDetails_name": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_purchaserDetails_postCode": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_purchaserDetails_postTown": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_purchaserDetails_purchaserNotes": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_purchaserDetails_telephoneNumber": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_lastUpdatedAt": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_lastUpdatedByName": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_lastUpdatedById": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_rearAxleToRearTrl": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
@@ -812,26 +524,17 @@
       ]
     },
     "techRecord_roadFriendly": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_statusCode": {
       "$ref": "../../../enums/statusCode.ignore.json"
     },
     "techRecord_suspensionType": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 1
     },
     "techRecord_tyreUseCode": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 2
     },
     "techRecord_vehicleClass_code": {
@@ -867,16 +570,10 @@
         "additionalProperties": false,
         "properties": {
           "techRecord_parkingBrakeMrk": {
-            "type": [
-              "boolean",
-              "null"
-            ]
+            "type": ["boolean", "null"]
           },
           "techRecord_axleNumber": {
-            "type": [
-              "integer",
-              "null"
-            ]
+            "type": ["integer", "null"]
           }
         }
       }
@@ -903,57 +600,36 @@
       }
     },
     "techRecord_weights_gbWeight": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "minimum": 0,
       "maximum": 99999
     },
     "techRecord_weights_designWeight": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "minimum": 0,
       "maximum": 99999
     },
     "techRecord_weights_ladenWeight": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "minimum": 0,
       "maximum": 99999
     },
     "techRecord_weights_kerbWeight": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "minimum": 0,
       "maximum": 99999
     },
     "techRecord_tyres_tyreCode": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "minimum": 0,
       "maximum": 99999
     },
     "techRecord_tyres_tyreSize": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 12
     },
     "techRecord_tyres_plyRating": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_tyres_fitmentCode": {
       "anyOf": [
@@ -966,10 +642,7 @@
       ]
     },
     "techRecord_tyres_dataTrAxles": {
-      "type": [
-        "null",
-        "integer"
-      ],
+      "type": ["null", "integer"],
       "minimum": 0,
       "maximum": 999
     },
@@ -982,6 +655,12 @@
           "type": "null"
         }
       ]
+    },
+    "techRecord_hiddenInVta": {
+      "type": "boolean"
+    },
+    "techRecord_updateType": {
+      "type": "string"
     }
   }
 }

--- a/json-definitions/v3/tech-record/put/car/complete/index.json
+++ b/json-definitions/v3/tech-record/put/car/complete/index.json
@@ -33,6 +33,12 @@
     },
     "vehicleSubclass": {
       "$ref": "../../../enums/vehicleSubclass.ignore.json"
+    },
+    "techRecord_hiddenInVta": {
+      "type": "boolean"
+    },
+    "techRecord_updateType": {
+      "type": "string"
     }
   }
 }

--- a/json-definitions/v3/tech-record/put/car/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/car/skeleton/index.json
@@ -30,6 +30,12 @@
     },
     "techRecord_noOfAxles": {
       "type": ["integer", "null"]
+    },
+    "techRecord_hiddenInVta": {
+      "type": "boolean"
+    },
+    "techRecord_updateType": {
+      "type": "string"
     }
   }
 }

--- a/json-definitions/v3/tech-record/put/hgv/complete/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/complete/index.json
@@ -1,842 +1,627 @@
 {
-    "title": "PUT HGV Technical Record V3 Complete",
-    "type": "object",
-    "additionalProperties": false,
-    "required": [
-        "partialVin",
-        "techRecord_reasonForCreation",
-        "techRecord_statusCode",
-        "techRecord_vehicleType",
-        "primaryVrm",
-        "vin",
-        "techRecord_vehicleConfiguration",
-        "techRecord_vehicleClass_code",
-        "techRecord_vehicleClass_description",
-        "techRecord_numberOfWheelsDriven",
-        "techRecord_approvalType",
-        "techRecord_manufactureYear",
-        "techRecord_bodyType_code",
-        "techRecord_bodyType_description",
-        "techRecord_grossGbWeight",
-        "techRecord_grossDesignWeight",
-        "techRecord_brakes_dtpNumber",
-        "techRecord_euVehicleCategory",
-        "axles",
-        "techRecord_euroStandard",
-        "techRecord_regnDate",
-        "techRecord_speedLimiterMrk",
-        "techRecord_tachoExemptMrk",
-        "techRecord_fuelPropulsionSystem",
-        "techRecord_make",
-        "techRecord_model",
-        "techRecord_trainGbWeight",
-        "techRecord_maxTrainGbWeight",
-        "techRecord_tyreUseCode",
-        "techRecord_dimensions_length",
-        "techRecord_dimensions_width",
-        "techRecord_frontAxleTo5thWheelMin",
-        "techRecord_frontAxleTo5thWheelMax",
-        "techRecord_frontAxleToRearAxle",
-        "techRecord_notes",
-        "techRecord_roadFriendly",
-        "techRecord_drawbarCouplingFitted",
-        "techRecord_offRoad",
-        "techRecord_applicantDetails_name",
-        "techRecord_applicantDetails_address1",
-        "techRecord_applicantDetails_address2",
-        "techRecord_applicantDetails_postTown"
-    ],
-    "properties": {
-        "partialVin": {
-            "type": "string"
+  "title": "PUT HGV Technical Record V3 Complete",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "partialVin",
+    "techRecord_reasonForCreation",
+    "techRecord_statusCode",
+    "techRecord_vehicleType",
+    "primaryVrm",
+    "vin",
+    "techRecord_vehicleConfiguration",
+    "techRecord_vehicleClass_code",
+    "techRecord_vehicleClass_description",
+    "techRecord_numberOfWheelsDriven",
+    "techRecord_approvalType",
+    "techRecord_manufactureYear",
+    "techRecord_bodyType_code",
+    "techRecord_bodyType_description",
+    "techRecord_grossGbWeight",
+    "techRecord_grossDesignWeight",
+    "techRecord_brakes_dtpNumber",
+    "techRecord_euVehicleCategory",
+    "axles",
+    "techRecord_euroStandard",
+    "techRecord_regnDate",
+    "techRecord_speedLimiterMrk",
+    "techRecord_tachoExemptMrk",
+    "techRecord_fuelPropulsionSystem",
+    "techRecord_make",
+    "techRecord_model",
+    "techRecord_trainGbWeight",
+    "techRecord_maxTrainGbWeight",
+    "techRecord_tyreUseCode",
+    "techRecord_dimensions_length",
+    "techRecord_dimensions_width",
+    "techRecord_frontAxleTo5thWheelMin",
+    "techRecord_frontAxleTo5thWheelMax",
+    "techRecord_frontAxleToRearAxle",
+    "techRecord_notes",
+    "techRecord_roadFriendly",
+    "techRecord_drawbarCouplingFitted",
+    "techRecord_offRoad",
+    "techRecord_applicantDetails_name",
+    "techRecord_applicantDetails_address1",
+    "techRecord_applicantDetails_address2",
+    "techRecord_applicantDetails_postTown"
+  ],
+  "properties": {
+    "partialVin": {
+      "type": "string"
+    },
+    "techRecord_adrDetails_vehicleDetails_type": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_vehicleDetails_approvalDate": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_permittedDangerousGoods": {
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "techRecord_adrDetails_compatibilityGroupJ": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_additionalExaminerNotes": {
+      "type": ["string", "null"],
+      "maxLength": 1024
+    },
+    "techRecord_adrDetails_applicantDetails_name": {
+      "type": ["string", "null"],
+      "maxLength": 150
+    },
+    "techRecord_adrDetails_applicantDetails_street": {
+      "type": ["string", "null"],
+      "maxLength": 150
+    },
+    "techRecord_adrDetails_applicantDetails_town": {
+      "type": ["string", "null"],
+      "maxLength": 100
+    },
+    "techRecord_adrDetails_applicantDetails_city": {
+      "type": ["string", "null"],
+      "maxLength": 100
+    },
+    "techRecord_adrDetails_applicantDetails_postcode": {
+      "type": ["string", "null"],
+      "maxLength": 25
+    },
+    "techRecord_adrDetails_memosApply": {
+      "type": ["array", "null"],
+      "items": {
+        "type": ["string"]
+      }
+    },
+    "techRecord_adrDetails_documents": {
+      "type": ["array", "null"],
+      "items": {
+        "type": ["string"]
+      }
+    },
+    "techRecord_adrDetails_listStatementApplicable": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_batteryListNumber": {
+      "type": ["string", "null"],
+      "maxLength": 8
+    },
+    "techRecord_adrDetails_brakeDeclarationsSeen": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_brakeDeclarationIssuer": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_brakeEndurance": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_weight": {
+      "type": ["string", "null"],
+      "maxLength": 8
+    },
+    "techRecord_adrDetails_declarationsSeen": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_additionalNotes_guidanceNotes": {
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "techRecord_adrDetails_additionalNotes_number": {
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "techRecord_adrDetails_adrTypeApprovalNo": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_adrCertificateNotes": {
+      "type": ["string", "null"],
+      "maxLength": 1500
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
+      "type": ["string", "null"],
+      "maxLength": 70
+    },
+    "techRecord_adrDetails_tank_tankDetails_yearOfManufacture": {
+      "type": ["integer", "null"],
+      "maximum": 9999
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo": {
+      "type": ["string", "null"],
+      "maxLength": 50
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankTypeAppNo": {
+      "type": ["string", "null"],
+      "maxLength": 30
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankCode": {
+      "type": ["string", "null"],
+      "maxLength": 30
+    },
+    "techRecord_adrDetails_tank_tankDetails_specialProvisions": {
+      "type": ["string", "null"],
+      "maxLength": 1024
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2Type": {
+      "anyOf": [
+        {
+          "type": "null"
         },
-        "techRecord_adrDetails_vehicleDetails_type": {
-            "type": [
-                "string",
-                "null"
-            ]
+        {
+          "$ref": "../../../enums/tc2Types.ignore.json"
+        }
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateApprovalNo": {
+      "type": ["string", "null"],
+      "maxLength": 70
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateExpiryDate": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc3Details_tc3Type": {
+      "anyOf": [
+        {
+          "type": "null"
         },
-        "techRecord_adrDetails_vehicleDetails_approvalDate": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_permittedDangerousGoods": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": "string"
-            }
-        },
-        "techRecord_adrDetails_compatibilityGroupJ": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_additionalExaminerNotes": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1024
-        },
-        "techRecord_adrDetails_applicantDetails_name": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 150
-        },
-        "techRecord_adrDetails_applicantDetails_street": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 150
-        },
-        "techRecord_adrDetails_applicantDetails_town": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 100
-        },
-        "techRecord_adrDetails_applicantDetails_city": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 100
-        },
-        "techRecord_adrDetails_applicantDetails_postcode": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 25
-        },
-        "techRecord_adrDetails_memosApply": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": [
-                    "string"
-                ]
-            }
-        },
-        "techRecord_adrDetails_documents": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": [
-                    "string"
-                ]
-            }
-        },
-        "techRecord_adrDetails_listStatementApplicable": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_batteryListNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 8
-        },
-        "techRecord_adrDetails_brakeDeclarationsSeen": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_brakeDeclarationIssuer": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_brakeEndurance": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_weight": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 8
-        },
-        "techRecord_adrDetails_declarationsSeen": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_additionalNotes_guidanceNotes": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": "string"
-            }
-        },
-        "techRecord_adrDetails_additionalNotes_number": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": "string"
-            }
-        },
-        "techRecord_adrDetails_adrTypeApprovalNo": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_adrCertificateNotes": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1500
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 70
-        },
-        "techRecord_adrDetails_tank_tankDetails_yearOfManufacture": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 9999
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 50
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankTypeAppNo": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 30
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankCode": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 30
-        },
-        "techRecord_adrDetails_tank_tankDetails_specialProvisions": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1024
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2Type": {
-            "anyOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "$ref": "../../../enums/tc2Types.ignore.json"
-                }
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateApprovalNo": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 70
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateExpiryDate": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc3Details_tc3Type": {
-            "anyOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "$ref": "../../../enums/tc3Types.ignore.json"
-                }
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 75
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicExpiryDate": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_substancesPermitted": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_statement": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1500
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": [
-                    "string"
-                ]
-            }
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_productList": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1500
-        },
-        "techRecord_alterationMarker": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_applicantDetails_name": {
-            "type": "string",
-            "maxLength": 150
-        },
-        "techRecord_applicantDetails_address1": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 60
-        },
-        "techRecord_applicantDetails_address2": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 60
-        },
-        "techRecord_applicantDetails_postTown": {
-            "type": "string",
-            "maxLength": 60
-        },
-        "techRecord_applicantDetails_address3": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 60
-        },
-        "techRecord_applicantDetails_postCode": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 12
-        },
-        "techRecord_applicantDetails_telephoneNumber": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 25
-        },
-        "techRecord_applicantDetails_emailAddress": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 255
-        },
-        "techRecord_applicationId": {
-            "type": "string"
-        },
-        "axles": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "title": "HGV Axles",
-                "additionalProperties": false,
-                "properties": {
-                    "techRecord_parkingBrakeMrk": {
-                        "type": "boolean"
-                    },
-                    "techRecord_axleNumber": {
-                        "type": "integer"
-                    },
-                    "techRecord_weights_gbWeight": {
-                        "type": "integer",
-                        "minimum": 0,
-                        "maximum": 99999
-                    },
-                    "techRecord_weights_designWeight": {
-                        "type": "integer",
-                        "minimum": 0,
-                        "maximum": 99999
-                    },
-                    "techRecord_weights_eecWeight": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ],
-                        "minimum": 0,
-                        "maximum": 99999
-                    },
-                    "techRecord_tyres_tyreCode": {
-                        "type": "integer",
-                        "minimum": 0,
-                        "maximum": 99999
-                    },
-                    "techRecord_tyres_tyreSize": {
-                        "type": "string",
-                        "maxLength": 12
-                    },
-                    "techRecord_tyres_plyRating": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
-                    "techRecord_tyres_fitmentCode": {
-                        "anyOf": [
-                            {
-                                "$ref": "../../../enums/fitmentCode.ignore.json"
-                            }
-                        ]
-                    },
-                    "techRecord_tyres_dataTrAxles": {
-                        "type": [
-                            "null",
-                            "integer"
-                        ],
-                        "minimum": 0,
-                        "maximum": 999
-                    }
-                }
-            }
-        },
-        "techRecord_bodyType_code": {
-            "type": "string"
-        },
-        "techRecord_bodyType_description": {
-            "type": "string"
-        },
-        "techRecord_brakes_antilockBrakingSystem": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_brakes_dtpNumber": {
-            "type": "string",
-            "maxLength": 6
-        },
-        "techRecord_brakes_loadSensingValve": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_conversionRefNo": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 10
-        },
-        "techRecord_departmentalVehicleMarker": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_dimensions_axleSpacing_axles": {
-            "type": "string"
-        },
-        "techRecord_dimensions_axleSpacing_value": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_dimensions_length": {
-            "type": "integer",
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_dimensions_width": {
-            "type": "integer",
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_drawbarCouplingFitted": {
+        {
+          "$ref": "../../../enums/tc3Types.ignore.json"
+        }
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicNumber": {
+      "type": ["string", "null"],
+      "maxLength": 75
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicExpiryDate": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_substancesPermitted": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_statement": {
+      "type": ["string", "null"],
+      "maxLength": 1500
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo": {
+      "type": ["array", "null"],
+      "items": {
+        "type": ["string"]
+      }
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_productList": {
+      "type": ["string", "null"],
+      "maxLength": 1500
+    },
+    "techRecord_alterationMarker": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_applicantDetails_name": {
+      "type": "string",
+      "maxLength": 150
+    },
+    "techRecord_applicantDetails_address1": {
+      "type": ["null", "string"],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_address2": {
+      "type": ["null", "string"],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_postTown": {
+      "type": "string",
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_address3": {
+      "type": ["null", "string"],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_postCode": {
+      "type": ["null", "string"],
+      "maxLength": 12
+    },
+    "techRecord_applicantDetails_telephoneNumber": {
+      "type": ["null", "string"],
+      "maxLength": 25
+    },
+    "techRecord_applicantDetails_emailAddress": {
+      "type": ["null", "string"],
+      "maxLength": 255
+    },
+    "techRecord_applicationId": {
+      "type": "string"
+    },
+    "axles": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "title": "HGV Axles",
+        "additionalProperties": false,
+        "properties": {
+          "techRecord_parkingBrakeMrk": {
             "type": "boolean"
-        },
-        "techRecord_emissionsLimit": {
-            "type": [
-                "null",
-                "integer"
-            ],
-            "minimum": 0,
-            "maximum": 99
-        },
-        "techRecord_euroStandard": {
-            "type": [
-                "string"
-            ]
-        },
-        "techRecord_euVehicleCategory": {
-            "anyOf": [
-                {
-                    "$ref": "../../../enums/euVehicleCategory.ignore.json"
-                }
-            ]
-        },
-        "techRecord_frontAxleToRearAxle": {
-            "type": "integer",
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_frontAxleTo5thWheelMin": {
-            "type": "integer",
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_frontAxleTo5thWheelMax": {
-            "type": "integer",
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_frontVehicleTo5thWheelCouplingMin": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_frontVehicleTo5thWheelCouplingMax": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_fuelPropulsionSystem": {
-            "anyOf": [
-                {
-                    "$ref": "../../../enums/fuelPropulsionSystem.ignore.json"
-                }
-            ]
-        },
-        "techRecord_functionCode": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1
-        },
-        "techRecord_grossDesignWeight": {
-            "type": "integer",
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_grossEecWeight": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_grossGbWeight": {
-            "type": "integer",
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_make": {
-            "type": "string",
-            "maxLength": 30
-        },
-        "techRecord_maxTrainGbWeight": {
-            "type": "number",
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_maxTrainEecWeight": {
-            "type": [
-                "number",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_maxTrainDesignWeight": {
-            "type": [
-                "number",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_manufactureYear": {
-            "anyOf": [
-                {
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 9999
-                }
-            ]
-        },
-        "techRecord_microfilm_microfilmDocumentType": {
-            "anyOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "$ref": "../../../enums/microfilmDocumentType.ignore.json"
-                }
-            ]
-        },
-        "techRecord_microfilm_microfilmRollNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 5
-        },
-        "techRecord_microfilm_microfilmSerialNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 4
-        },
-        "techRecord_model": {
-            "type": "string",
-            "maxLength": 30
-        },
-        "techRecord_numberOfWheelsDriven": {
+          },
+          "techRecord_axleNumber": {
             "type": "integer"
-        },
-        "techRecord_noOfAxles": {
-            "anyOf": [
-                {
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 99
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        },
-        "techRecord_notes": {
-            "type": "string"
-        },
-        "techRecord_offRoad": {
-            "type": "boolean"
-        },
-        "plates": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "title": "HGV Plates",
-                "additionalProperties": false,
-                "properties": {
-                    "techRecord_plateSerialNumber": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "maxLength": 12
-                    },
-                    "techRecord_plateIssueDate": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
-                    "techRecord_reasonForIssue": {
-                        "anyOf": [
-                            {
-                                "type": "null"
-                            },
-                            {
-                                "$ref": "../../../enums/plateReasonForIssue.ignore.json"
-                            }
-                        ]
-                    },
-                    "techRecord_plateIssuer": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "maxLength": 150
-                    }
-                }
-            }
-        },
-        "techRecord_reasonForCreation": {
-            "type": "string"
-        },
-        "techRecord_regnDate": {
-            "anyOf": [
-                {
-                    "type": "string",
-                    "pattern": "^$"
-                },
-                {
-                    "type": "string",
-                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-                }
-            ]
-        },
-        "techRecord_roadFriendly": {
-            "type": "boolean"
-        },
-        "techRecord_statusCode": {
-            "$ref": "../../../enums/statusCode.ignore.json"
-        },
-        "techRecord_speedLimiterMrk": {
-            "type": "boolean"
-        },
-        "techRecord_tachoExemptMrk": {
-            "type": "boolean"
-        },
-        "techRecord_trainDesignWeight": {
-            "type": [
-                "integer",
-                "null"
-            ],
+          },
+          "techRecord_weights_gbWeight": {
+            "type": "integer",
             "minimum": 0,
             "maximum": 99999
-        },
-        "techRecord_trainEecWeight": {
-            "type": [
-                "number",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_trainGbWeight": {
-            "type": "number",
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_tyreUseCode": {
+          },
+          "techRecord_weights_designWeight": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 99999
+          },
+          "techRecord_weights_eecWeight": {
+            "type": ["integer", "null"],
+            "minimum": 0,
+            "maximum": 99999
+          },
+          "techRecord_tyres_tyreCode": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 99999
+          },
+          "techRecord_tyres_tyreSize": {
             "type": "string",
-            "maxLength": 2
-        },
-        "techRecord_vehicleClass_code": {
-            "type": "string"
-        },
-        "techRecord_vehicleClass_description": {
-            "$ref": "../../../enums/vehicleClassDescription.ignore.json"
-        },
-        "techRecord_vehicleConfiguration": {
+            "maxLength": 12
+          },
+          "techRecord_tyres_plyRating": {
+            "type": ["string", "null"]
+          },
+          "techRecord_tyres_fitmentCode": {
             "anyOf": [
-                {
-                    "$ref": "../../../enums/vehicleConfiguration.ignore.json"
-                }
+              {
+                "$ref": "../../../enums/fitmentCode.ignore.json"
+              }
             ]
-        },
-        "techRecord_approvalType": {
-            "anyOf": [
-                {
-                    "$ref": "../../../enums/approvalType.ignore.json"
-                }
-            ]
-        },
-        "techRecord_approvalTypeNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 25
-        },
-        "techRecord_ntaNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 40
-        },
-        "techRecord_variantNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 25
-        },
-        "techRecord_variantVersionNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 35
-        },
-        "techRecord_vehicleType": {
-            "const": "hgv"
-        },
-        "primaryVrm": {
-            "type": "string"
-        },
-        "vin": {
-            "type": "string"
+          },
+          "techRecord_tyres_dataTrAxles": {
+            "type": ["null", "integer"],
+            "minimum": 0,
+            "maximum": 999
+          }
         }
+      }
+    },
+    "techRecord_bodyType_code": {
+      "type": "string"
+    },
+    "techRecord_bodyType_description": {
+      "type": "string"
+    },
+    "techRecord_brakes_antilockBrakingSystem": {
+      "type": ["string", "null"]
+    },
+    "techRecord_brakes_dtpNumber": {
+      "type": "string",
+      "maxLength": 6
+    },
+    "techRecord_brakes_loadSensingValve": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_conversionRefNo": {
+      "type": ["string", "null"],
+      "maxLength": 10
+    },
+    "techRecord_departmentalVehicleMarker": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_dimensions_axleSpacing_axles": {
+      "type": "string"
+    },
+    "techRecord_dimensions_axleSpacing_value": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_dimensions_length": {
+      "type": "integer",
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_dimensions_width": {
+      "type": "integer",
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_drawbarCouplingFitted": {
+      "type": "boolean"
+    },
+    "techRecord_emissionsLimit": {
+      "type": ["null", "integer"],
+      "minimum": 0,
+      "maximum": 99
+    },
+    "techRecord_euroStandard": {
+      "type": ["string"]
+    },
+    "techRecord_euVehicleCategory": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/euVehicleCategory.ignore.json"
+        }
+      ]
+    },
+    "techRecord_frontAxleToRearAxle": {
+      "type": "integer",
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_frontAxleTo5thWheelMin": {
+      "type": "integer",
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_frontAxleTo5thWheelMax": {
+      "type": "integer",
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_frontVehicleTo5thWheelCouplingMin": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_frontVehicleTo5thWheelCouplingMax": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_fuelPropulsionSystem": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/fuelPropulsionSystem.ignore.json"
+        }
+      ]
+    },
+    "techRecord_functionCode": {
+      "type": ["string", "null"],
+      "maxLength": 1
+    },
+    "techRecord_grossDesignWeight": {
+      "type": "integer",
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_grossEecWeight": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_grossGbWeight": {
+      "type": "integer",
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_make": {
+      "type": "string",
+      "maxLength": 30
+    },
+    "techRecord_maxTrainGbWeight": {
+      "type": "number",
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_maxTrainEecWeight": {
+      "type": ["number", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_maxTrainDesignWeight": {
+      "type": ["number", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_manufactureYear": {
+      "anyOf": [
+        {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9999
+        }
+      ]
+    },
+    "techRecord_microfilm_microfilmDocumentType": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "../../../enums/microfilmDocumentType.ignore.json"
+        }
+      ]
+    },
+    "techRecord_microfilm_microfilmRollNumber": {
+      "type": ["string", "null"],
+      "maxLength": 5
+    },
+    "techRecord_microfilm_microfilmSerialNumber": {
+      "type": ["string", "null"],
+      "maxLength": 4
+    },
+    "techRecord_model": {
+      "type": "string",
+      "maxLength": 30
+    },
+    "techRecord_numberOfWheelsDriven": {
+      "type": "integer"
+    },
+    "techRecord_noOfAxles": {
+      "anyOf": [
+        {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 99
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_notes": {
+      "type": "string"
+    },
+    "techRecord_offRoad": {
+      "type": "boolean"
+    },
+    "plates": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "title": "HGV Plates",
+        "additionalProperties": false,
+        "properties": {
+          "techRecord_plateSerialNumber": {
+            "type": ["string", "null"],
+            "maxLength": 12
+          },
+          "techRecord_plateIssueDate": {
+            "type": ["string", "null"]
+          },
+          "techRecord_reasonForIssue": {
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "../../../enums/plateReasonForIssue.ignore.json"
+              }
+            ]
+          },
+          "techRecord_plateIssuer": {
+            "type": ["string", "null"],
+            "maxLength": 150
+          }
+        }
+      }
+    },
+    "techRecord_reasonForCreation": {
+      "type": "string"
+    },
+    "techRecord_regnDate": {
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^$"
+        },
+        {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+        }
+      ]
+    },
+    "techRecord_roadFriendly": {
+      "type": "boolean"
+    },
+    "techRecord_statusCode": {
+      "$ref": "../../../enums/statusCode.ignore.json"
+    },
+    "techRecord_speedLimiterMrk": {
+      "type": "boolean"
+    },
+    "techRecord_tachoExemptMrk": {
+      "type": "boolean"
+    },
+    "techRecord_trainDesignWeight": {
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "maximum": 99999
+    },
+    "techRecord_trainEecWeight": {
+      "type": ["number", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_trainGbWeight": {
+      "type": "number",
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_tyreUseCode": {
+      "type": "string",
+      "maxLength": 2
+    },
+    "techRecord_vehicleClass_code": {
+      "type": "string"
+    },
+    "techRecord_vehicleClass_description": {
+      "$ref": "../../../enums/vehicleClassDescription.ignore.json"
+    },
+    "techRecord_vehicleConfiguration": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/vehicleConfiguration.ignore.json"
+        }
+      ]
+    },
+    "techRecord_approvalType": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/approvalType.ignore.json"
+        }
+      ]
+    },
+    "techRecord_approvalTypeNumber": {
+      "type": ["string", "null"],
+      "maxLength": 25
+    },
+    "techRecord_ntaNumber": {
+      "type": ["string", "null"],
+      "maxLength": 40
+    },
+    "techRecord_variantNumber": {
+      "type": ["string", "null"],
+      "maxLength": 25
+    },
+    "techRecord_variantVersionNumber": {
+      "type": ["string", "null"],
+      "maxLength": 35
+    },
+    "techRecord_vehicleType": {
+      "const": "hgv"
+    },
+    "primaryVrm": {
+      "type": "string"
+    },
+    "vin": {
+      "type": "string"
+    },
+    "techRecord_hiddenInVta": {
+      "type": "boolean"
+    },
+    "techRecord_updateType": {
+      "type": "string"
     }
+  }
 }

--- a/json-definitions/v3/tech-record/put/hgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/skeleton/index.json
@@ -1,915 +1,612 @@
 {
-    "title": "PUT HGV Technical Record V3 Skeleton",
-    "type": "object",
-    "additionalProperties": false,
-    "required": [
-        "partialVin",
-        "techRecord_reasonForCreation",
-        "techRecord_statusCode",
-        "techRecord_vehicleType",
-        "primaryVrm",
-        "vin"
-    ],
-    "properties": {
-        "partialVin": {
-            "type": "string"
-        },
-        "techRecord_adrDetails_vehicleDetails_type": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_vehicleDetails_approvalDate": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_permittedDangerousGoods": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": "string"
-            }
-        },
-        "techRecord_adrDetails_compatibilityGroupJ": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_additionalExaminerNotes": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1024
-        },
-        "techRecord_adrDetails_applicantDetails_name": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 150
-        },
-        "techRecord_adrDetails_applicantDetails_street": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 150
-        },
-        "techRecord_adrDetails_applicantDetails_town": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 100
-        },
-        "techRecord_adrDetails_applicantDetails_city": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 100
-        },
-        "techRecord_adrDetails_applicantDetails_postcode": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 25
-        },
-        "techRecord_adrDetails_memosApply": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": [
-                    "string"
-                ]
-            }
-        },
-        "techRecord_adrDetails_documents": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": [
-                    "string"
-                ]
-            }
-        },
-        "techRecord_adrDetails_listStatementApplicable": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_batteryListNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 8
-        },
-        "techRecord_adrDetails_brakeDeclarationsSeen": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_brakeDeclarationIssuer": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_brakeEndurance": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_weight": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 8
-        },
-        "techRecord_adrDetails_declarationsSeen": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_additionalNotes_guidanceNotes": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": "string"
-            }
-        },
-        "techRecord_adrDetails_additionalNotes_number": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": "string"
-            }
-        },
-        "techRecord_adrDetails_adrTypeApprovalNo": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_adrCertificateNotes": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1500
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 70
-        },
-        "techRecord_adrDetails_tank_tankDetails_yearOfManufacture": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 9999
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 50
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankTypeAppNo": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 30
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankCode": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 30
-        },
-        "techRecord_adrDetails_tank_tankDetails_specialProvisions": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1024
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2Type": {
-            "anyOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "$ref": "../../../enums/tc2Types.ignore.json"
-                }
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateApprovalNo": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 70
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateExpiryDate": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc3Details_tc3Type": {
-            "anyOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "$ref": "../../../enums/tc3Types.ignore.json"
-                }
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 75
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicExpiryDate": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_substancesPermitted": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_statement": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1500
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": [
-                    "string"
-                ]
-            }
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_productList": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1500
-        },
-        "techRecord_alterationMarker": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_applicantDetails_name": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 150
-        },
-        "techRecord_applicantDetails_address1": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 60
-        },
-        "techRecord_applicantDetails_address2": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 60
-        },
-        "techRecord_applicantDetails_postTown": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 60
-        },
-        "techRecord_applicantDetails_address3": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 60
-        },
-        "techRecord_applicantDetails_postCode": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 12
-        },
-        "techRecord_applicantDetails_telephoneNumber": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 25
-        },
-        "techRecord_applicantDetails_emailAddress": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 255
-        },
-        "techRecord_applicationId": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "axles": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "title": "HGV Axles",
-                "additionalProperties": false,
-                "properties": {
-                    "techRecord_parkingBrakeMrk": {
-                        "type": [
-                            "boolean",
-                            "null"
-                        ]
-                    },
-                    "techRecord_axleNumber": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ]
-                    },
-                    "techRecord_weights_gbWeight": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ],
-                        "minimum": 0,
-                        "maximum": 99999
-                    },
-                    "techRecord_weights_designWeight": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ],
-                        "minimum": 0,
-                        "maximum": 99999
-                    },
-                    "techRecord_weights_eecWeight": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ],
-                        "minimum": 0,
-                        "maximum": 99999
-                    },
-                    "techRecord_tyres_tyreCode": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ],
-                        "minimum": 0,
-                        "maximum": 99999
-                    },
-                    "techRecord_tyres_tyreSize": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "maxLength": 12
-                    },
-                    "techRecord_tyres_plyRating": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
-                    "techRecord_tyres_fitmentCode": {
-                        "anyOf": [
-                            {
-                                "type": "null"
-                            },
-                            {
-                                "$ref": "../../../enums/fitmentCode.ignore.json"
-                            }
-                        ]
-                    },
-                    "techRecord_tyres_dataTrAxles": {
-                        "type": [
-                            "null",
-                            "integer"
-                        ],
-                        "minimum": 0,
-                        "maximum": 999
-                    }
-                }
-            }
-        },
-        "techRecord_bodyType_code": {
-            "type": "string"
-        },
-        "techRecord_bodyType_description": {
-            "type": "string"
-        },
-        "techRecord_brakes_antilockBrakingSystem": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_brakes_dtpNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 6
-        },
-        "techRecord_brakes_loadSensingValve": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_conversionRefNo": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 10
-        },
-        "techRecord_departmentalVehicleMarker": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_dimensions_axleSpacing_axles": {
-            "type": "string"
-        },
-        "techRecord_dimensions_axleSpacing_value": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_dimensions_length": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_dimensions_width": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_drawbarCouplingFitted": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_emissionsLimit": {
-            "type": [
-                "null",
-                "integer"
-            ],
-            "minimum": 0,
-            "maximum": 99
-        },
-        "techRecord_euroStandard": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_euVehicleCategory": {
-            "anyOf": [
-                {
-                    "$ref": "../../../enums/euVehicleCategory.ignore.json"
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        },
-        "techRecord_frontAxleToRearAxle": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_frontAxleTo5thWheelMin": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_frontAxleTo5thWheelMax": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_frontVehicleTo5thWheelCouplingMin": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_frontVehicleTo5thWheelCouplingMax": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_fuelPropulsionSystem": {
-            "anyOf": [
-                {
-                    "$ref": "../../../enums/fuelPropulsionSystem.ignore.json"
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        },
-        "techRecord_functionCode": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1
-        },
-        "techRecord_grossDesignWeight": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_grossEecWeight": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_grossGbWeight": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_make": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 30
-        },
-        "techRecord_maxTrainGbWeight": {
-            "type": [
-                "number",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_maxTrainEecWeight": {
-            "type": [
-                "number",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_maxTrainDesignWeight": {
-            "type": [
-                "number",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_manufactureYear": {
-            "anyOf": [
-                {
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 9999
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        },
-        "techRecord_microfilm_microfilmDocumentType": {
-            "anyOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "$ref": "../../../enums/microfilmDocumentType.ignore.json"
-                }
-            ]
-        },
-        "techRecord_microfilm_microfilmRollNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 5
-        },
-        "techRecord_microfilm_microfilmSerialNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 4
-        },
-        "techRecord_model": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 30
-        },
-        "techRecord_numberOfWheelsDriven": {
-            "type": [
-                "integer",
-                "null"
-            ]
-        },
-        "techRecord_noOfAxles": {
-            "anyOf": [
-                {
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 99
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        },
-        "techRecord_notes": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_offRoad": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "plates": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "title": "HGV Plates",
-                "additionalProperties": false,
-                "properties": {
-                    "techRecord_plateSerialNumber": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "maxLength": 12
-                    },
-                    "techRecord_plateIssueDate": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
-                    "techRecord_reasonForIssue": {
-                        "anyOf": [
-                            {
-                                "type": "null"
-                            },
-                            {
-                                "$ref": "../../../enums/plateReasonForIssue.ignore.json"
-                            }
-                        ]
-                    },
-                    "techRecord_plateIssuer": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "maxLength": 150
-                    }
-                }
-            }
-        },
-        "techRecord_reasonForCreation": {
-            "type": "string"
-        },
-        "techRecord_regnDate": {
-            "anyOf": [
-                {
-                    "type": "string",
-                    "pattern": "^$"
-                },
-                {
-                    "type": "string",
-                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        },
-        "techRecord_roadFriendly": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_statusCode": {
-            "$ref": "../../../enums/statusCode.ignore.json"
-        },
-        "techRecord_speedLimiterMrk": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_tachoExemptMrk": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_trainDesignWeight": {
-            "type": [
-                "integer",
-                "null"
-            ],
+  "title": "PUT HGV Technical Record V3 Skeleton",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "partialVin",
+    "techRecord_reasonForCreation",
+    "techRecord_statusCode",
+    "techRecord_vehicleType",
+    "primaryVrm",
+    "vin"
+  ],
+  "properties": {
+    "partialVin": {
+      "type": "string"
+    },
+    "techRecord_adrDetails_vehicleDetails_type": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_vehicleDetails_approvalDate": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_permittedDangerousGoods": {
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "techRecord_adrDetails_compatibilityGroupJ": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_additionalExaminerNotes": {
+      "type": ["string", "null"],
+      "maxLength": 1024
+    },
+    "techRecord_adrDetails_applicantDetails_name": {
+      "type": ["string", "null"],
+      "maxLength": 150
+    },
+    "techRecord_adrDetails_applicantDetails_street": {
+      "type": ["string", "null"],
+      "maxLength": 150
+    },
+    "techRecord_adrDetails_applicantDetails_town": {
+      "type": ["string", "null"],
+      "maxLength": 100
+    },
+    "techRecord_adrDetails_applicantDetails_city": {
+      "type": ["string", "null"],
+      "maxLength": 100
+    },
+    "techRecord_adrDetails_applicantDetails_postcode": {
+      "type": ["string", "null"],
+      "maxLength": 25
+    },
+    "techRecord_adrDetails_memosApply": {
+      "type": ["array", "null"],
+      "items": {
+        "type": ["string"]
+      }
+    },
+    "techRecord_adrDetails_documents": {
+      "type": ["array", "null"],
+      "items": {
+        "type": ["string"]
+      }
+    },
+    "techRecord_adrDetails_listStatementApplicable": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_batteryListNumber": {
+      "type": ["string", "null"],
+      "maxLength": 8
+    },
+    "techRecord_adrDetails_brakeDeclarationsSeen": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_brakeDeclarationIssuer": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_brakeEndurance": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_weight": {
+      "type": ["string", "null"],
+      "maxLength": 8
+    },
+    "techRecord_adrDetails_declarationsSeen": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_additionalNotes_guidanceNotes": {
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "techRecord_adrDetails_additionalNotes_number": {
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "techRecord_adrDetails_adrTypeApprovalNo": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_adrCertificateNotes": {
+      "type": ["string", "null"],
+      "maxLength": 1500
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
+      "type": ["string", "null"],
+      "maxLength": 70
+    },
+    "techRecord_adrDetails_tank_tankDetails_yearOfManufacture": {
+      "type": ["integer", "null"],
+      "maximum": 9999
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo": {
+      "type": ["string", "null"],
+      "maxLength": 50
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankTypeAppNo": {
+      "type": ["string", "null"],
+      "maxLength": 30
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankCode": {
+      "type": ["string", "null"],
+      "maxLength": 30
+    },
+    "techRecord_adrDetails_tank_tankDetails_specialProvisions": {
+      "type": ["string", "null"],
+      "maxLength": 1024
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2Type": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "../../../enums/tc2Types.ignore.json"
+        }
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateApprovalNo": {
+      "type": ["string", "null"],
+      "maxLength": 70
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateExpiryDate": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc3Details_tc3Type": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "../../../enums/tc3Types.ignore.json"
+        }
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicNumber": {
+      "type": ["string", "null"],
+      "maxLength": 75
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicExpiryDate": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_substancesPermitted": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_statement": {
+      "type": ["string", "null"],
+      "maxLength": 1500
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo": {
+      "type": ["array", "null"],
+      "items": {
+        "type": ["string"]
+      }
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_productList": {
+      "type": ["string", "null"],
+      "maxLength": 1500
+    },
+    "techRecord_alterationMarker": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_applicantDetails_name": {
+      "type": ["string", "null"],
+      "maxLength": 150
+    },
+    "techRecord_applicantDetails_address1": {
+      "type": ["null", "string"],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_address2": {
+      "type": ["null", "string"],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_postTown": {
+      "type": ["null", "string"],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_address3": {
+      "type": ["null", "string"],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_postCode": {
+      "type": ["null", "string"],
+      "maxLength": 12
+    },
+    "techRecord_applicantDetails_telephoneNumber": {
+      "type": ["null", "string"],
+      "maxLength": 25
+    },
+    "techRecord_applicantDetails_emailAddress": {
+      "type": ["null", "string"],
+      "maxLength": 255
+    },
+    "techRecord_applicationId": {
+      "type": ["string", "null"]
+    },
+    "axles": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "title": "HGV Axles",
+        "additionalProperties": false,
+        "properties": {
+          "techRecord_parkingBrakeMrk": {
+            "type": ["boolean", "null"]
+          },
+          "techRecord_axleNumber": {
+            "type": ["integer", "null"]
+          },
+          "techRecord_weights_gbWeight": {
+            "type": ["integer", "null"],
             "minimum": 0,
             "maximum": 99999
-        },
-        "techRecord_trainEecWeight": {
-            "type": [
-                "number",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_trainGbWeight": {
-            "type": [
-                "number",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_tyreUseCode": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 2
-        },
-        "techRecord_vehicleClass_code": {
-            "type": "string"
-        },
-        "techRecord_vehicleClass_description": {
-            "$ref": "../../../enums/vehicleClassDescription.ignore.json"
-        },
-        "techRecord_vehicleConfiguration": {
+          },
+          "techRecord_weights_designWeight": {
+            "type": ["integer", "null"],
+            "minimum": 0,
+            "maximum": 99999
+          },
+          "techRecord_weights_eecWeight": {
+            "type": ["integer", "null"],
+            "minimum": 0,
+            "maximum": 99999
+          },
+          "techRecord_tyres_tyreCode": {
+            "type": ["integer", "null"],
+            "minimum": 0,
+            "maximum": 99999
+          },
+          "techRecord_tyres_tyreSize": {
+            "type": ["string", "null"],
+            "maxLength": 12
+          },
+          "techRecord_tyres_plyRating": {
+            "type": ["string", "null"]
+          },
+          "techRecord_tyres_fitmentCode": {
             "anyOf": [
-                {
-                    "$ref": "../../../enums/vehicleConfiguration.ignore.json"
-                },
-                {
-                    "type": "null"
-                }
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "../../../enums/fitmentCode.ignore.json"
+              }
             ]
-        },
-        "techRecord_approvalType": {
-            "anyOf": [
-                {
-                    "$ref": "../../../enums/approvalType.ignore.json"
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        },
-        "techRecord_approvalTypeNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 25
-        },
-        "techRecord_ntaNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 40
-        },
-        "techRecord_variantNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 25
-        },
-        "techRecord_variantVersionNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 35
-        },
-        "techRecord_vehicleType": {
-            "const": "hgv"
-        },
-        "primaryVrm": {
-            "type": "string"
-        },
-        "vin": {
-            "type": "string"
+          },
+          "techRecord_tyres_dataTrAxles": {
+            "type": ["null", "integer"],
+            "minimum": 0,
+            "maximum": 999
+          }
         }
+      }
+    },
+    "techRecord_bodyType_code": {
+      "type": "string"
+    },
+    "techRecord_bodyType_description": {
+      "type": "string"
+    },
+    "techRecord_brakes_antilockBrakingSystem": {
+      "type": ["string", "null"]
+    },
+    "techRecord_brakes_dtpNumber": {
+      "type": ["string", "null"],
+      "maxLength": 6
+    },
+    "techRecord_brakes_loadSensingValve": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_conversionRefNo": {
+      "type": ["string", "null"],
+      "maxLength": 10
+    },
+    "techRecord_departmentalVehicleMarker": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_dimensions_axleSpacing_axles": {
+      "type": "string"
+    },
+    "techRecord_dimensions_axleSpacing_value": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_dimensions_length": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_dimensions_width": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_drawbarCouplingFitted": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_emissionsLimit": {
+      "type": ["null", "integer"],
+      "minimum": 0,
+      "maximum": 99
+    },
+    "techRecord_euroStandard": {
+      "type": ["string", "null"]
+    },
+    "techRecord_euVehicleCategory": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/euVehicleCategory.ignore.json"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_frontAxleToRearAxle": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_frontAxleTo5thWheelMin": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_frontAxleTo5thWheelMax": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_frontVehicleTo5thWheelCouplingMin": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_frontVehicleTo5thWheelCouplingMax": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_fuelPropulsionSystem": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/fuelPropulsionSystem.ignore.json"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_functionCode": {
+      "type": ["string", "null"],
+      "maxLength": 1
+    },
+    "techRecord_grossDesignWeight": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_grossEecWeight": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_grossGbWeight": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_make": {
+      "type": ["string", "null"],
+      "maxLength": 30
+    },
+    "techRecord_maxTrainGbWeight": {
+      "type": ["number", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_maxTrainEecWeight": {
+      "type": ["number", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_maxTrainDesignWeight": {
+      "type": ["number", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_manufactureYear": {
+      "anyOf": [
+        {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9999
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_microfilm_microfilmDocumentType": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "../../../enums/microfilmDocumentType.ignore.json"
+        }
+      ]
+    },
+    "techRecord_microfilm_microfilmRollNumber": {
+      "type": ["string", "null"],
+      "maxLength": 5
+    },
+    "techRecord_microfilm_microfilmSerialNumber": {
+      "type": ["string", "null"],
+      "maxLength": 4
+    },
+    "techRecord_model": {
+      "type": ["string", "null"],
+      "maxLength": 30
+    },
+    "techRecord_numberOfWheelsDriven": {
+      "type": ["integer", "null"]
+    },
+    "techRecord_noOfAxles": {
+      "anyOf": [
+        {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 99
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_notes": {
+      "type": ["string", "null"]
+    },
+    "techRecord_offRoad": {
+      "type": ["boolean", "null"]
+    },
+    "plates": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "title": "HGV Plates",
+        "additionalProperties": false,
+        "properties": {
+          "techRecord_plateSerialNumber": {
+            "type": ["string", "null"],
+            "maxLength": 12
+          },
+          "techRecord_plateIssueDate": {
+            "type": ["string", "null"]
+          },
+          "techRecord_reasonForIssue": {
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "../../../enums/plateReasonForIssue.ignore.json"
+              }
+            ]
+          },
+          "techRecord_plateIssuer": {
+            "type": ["string", "null"],
+            "maxLength": 150
+          }
+        }
+      }
+    },
+    "techRecord_reasonForCreation": {
+      "type": "string"
+    },
+    "techRecord_regnDate": {
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^$"
+        },
+        {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_roadFriendly": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_statusCode": {
+      "$ref": "../../../enums/statusCode.ignore.json"
+    },
+    "techRecord_speedLimiterMrk": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_tachoExemptMrk": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_trainDesignWeight": {
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "maximum": 99999
+    },
+    "techRecord_trainEecWeight": {
+      "type": ["number", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_trainGbWeight": {
+      "type": ["number", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_tyreUseCode": {
+      "type": ["string", "null"],
+      "maxLength": 2
+    },
+    "techRecord_vehicleClass_code": {
+      "type": "string"
+    },
+    "techRecord_vehicleClass_description": {
+      "$ref": "../../../enums/vehicleClassDescription.ignore.json"
+    },
+    "techRecord_vehicleConfiguration": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/vehicleConfiguration.ignore.json"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_approvalType": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/approvalType.ignore.json"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_approvalTypeNumber": {
+      "type": ["string", "null"],
+      "maxLength": 25
+    },
+    "techRecord_ntaNumber": {
+      "type": ["string", "null"],
+      "maxLength": 40
+    },
+    "techRecord_variantNumber": {
+      "type": ["string", "null"],
+      "maxLength": 25
+    },
+    "techRecord_variantVersionNumber": {
+      "type": ["string", "null"],
+      "maxLength": 35
+    },
+    "techRecord_vehicleType": {
+      "const": "hgv"
+    },
+    "primaryVrm": {
+      "type": "string"
+    },
+    "vin": {
+      "type": "string"
+    },
+    "techRecord_hiddenInVta": {
+      "type": "boolean"
+    },
+    "techRecord_updateType": {
+      "type": "string"
     }
+  }
 }

--- a/json-definitions/v3/tech-record/put/hgv/testable/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/testable/index.json
@@ -1,910 +1,613 @@
 {
-    "title": "PUT HGV Technical Record V3 Testable",
-    "type": "object",
-    "additionalProperties": false,
-    "required": [
-        "partialVin",
-        "techRecord_reasonForCreation",
-        "techRecord_statusCode",
-        "techRecord_vehicleType",
-        "primaryVrm",
-        "vin",
-        "techRecord_vehicleConfiguration",
-        "techRecord_vehicleClass_code",
-        "techRecord_vehicleClass_description",
-        "techRecord_numberOfWheelsDriven"
-    ],
-    "properties": {
-        "partialVin": {
-            "type": "string"
-        },
-        "techRecord_adrDetails_vehicleDetails_type": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_vehicleDetails_approvalDate": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_permittedDangerousGoods": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": "string"
-            }
-        },
-        "techRecord_adrDetails_compatibilityGroupJ": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_additionalExaminerNotes": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1024
-        },
-        "techRecord_adrDetails_applicantDetails_name": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 150
-        },
-        "techRecord_adrDetails_applicantDetails_street": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 150
-        },
-        "techRecord_adrDetails_applicantDetails_town": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 100
-        },
-        "techRecord_adrDetails_applicantDetails_city": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 100
-        },
-        "techRecord_adrDetails_applicantDetails_postcode": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 25
-        },
-        "techRecord_adrDetails_memosApply": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": [
-                    "string"
-                ]
-            }
-        },
-        "techRecord_adrDetails_documents": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": [
-                    "string"
-                ]
-            }
-        },
-        "techRecord_adrDetails_listStatementApplicable": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_batteryListNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 8
-        },
-        "techRecord_adrDetails_brakeDeclarationsSeen": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_brakeDeclarationIssuer": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_brakeEndurance": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_weight": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 8
-        },
-        "techRecord_adrDetails_declarationsSeen": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_additionalNotes_guidanceNotes": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": "string"
-            }
-        },
-        "techRecord_adrDetails_additionalNotes_number": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": "string"
-            }
-        },
-        "techRecord_adrDetails_adrTypeApprovalNo": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_adrCertificateNotes": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1500
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 70
-        },
-        "techRecord_adrDetails_tank_tankDetails_yearOfManufacture": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 9999
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 50
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankTypeAppNo": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 30
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankCode": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 30
-        },
-        "techRecord_adrDetails_tank_tankDetails_specialProvisions": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1024
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2Type": {
-            "anyOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "$ref": "../../../enums/tc2Types.ignore.json"
-                }
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateApprovalNo": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 70
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateExpiryDate": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc3Details_tc3Type": {
-            "anyOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "$ref": "../../../enums/tc3Types.ignore.json"
-                }
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 75
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicExpiryDate": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_substancesPermitted": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_statement": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1500
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": [
-                    "string"
-                ]
-            }
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_productList": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1500
-        },
-        "techRecord_alterationMarker": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_applicantDetails_name": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 150
-        },
-        "techRecord_applicantDetails_address1": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 60
-        },
-        "techRecord_applicantDetails_address2": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 60
-        },
-        "techRecord_applicantDetails_postTown": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 60
-        },
-        "techRecord_applicantDetails_address3": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 60
-        },
-        "techRecord_applicantDetails_postCode": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 12
-        },
-        "techRecord_applicantDetails_telephoneNumber": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 25
-        },
-        "techRecord_applicantDetails_emailAddress": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 255
-        },
-        "techRecord_applicationId": {
-            "type": "string"
-        },
-        "axles": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "title": "HGV Axles",
-                "additionalProperties": false,
-                "properties": {
-                    "techRecord_parkingBrakeMrk": {
-                        "type": [
-                            "boolean",
-                            "null"
-                        ]
-                    },
-                    "techRecord_axleNumber": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ]
-                    },
-                    "techRecord_weights_gbWeight": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ],
-                        "minimum": 0,
-                        "maximum": 99999
-                    },
-                    "techRecord_weights_designWeight": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ],
-                        "minimum": 0,
-                        "maximum": 99999
-                    },
-                    "techRecord_weights_eecWeight": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ],
-                        "minimum": 0,
-                        "maximum": 99999
-                    },
-                    "techRecord_tyres_tyreCode": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ],
-                        "minimum": 0,
-                        "maximum": 99999
-                    },
-                    "techRecord_tyres_tyreSize": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "maxLength": 12
-                    },
-                    "techRecord_tyres_plyRating": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
-                    "techRecord_tyres_fitmentCode": {
-                        "anyOf": [
-                            {
-                                "type": "null"
-                            },
-                            {
-                                "$ref": "../../../enums/fitmentCode.ignore.json"
-                            }
-                        ]
-                    },
-                    "techRecord_tyres_dataTrAxles": {
-                        "type": [
-                            "null",
-                            "integer"
-                        ],
-                        "minimum": 0,
-                        "maximum": 999
-                    }
-                }
-            }
-        },
-        "techRecord_bodyType_code": {
-            "type": "string"
-        },
-        "techRecord_bodyType_description": {
-            "type": "string"
-        },
-        "techRecord_brakes_antilockBrakingSystem": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_brakes_dtpNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 6
-        },
-        "techRecord_brakes_loadSensingValve": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_conversionRefNo": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 10
-        },
-        "techRecord_departmentalVehicleMarker": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_dimensions_axleSpacing_axles": {
-            "type": "string"
-        },
-        "techRecord_dimensions_axleSpacing_value": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_dimensions_length": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_dimensions_width": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_drawbarCouplingFitted": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_emissionsLimit": {
-            "type": [
-                "null",
-                "integer"
-            ],
-            "minimum": 0,
-            "maximum": 99
-        },
-        "techRecord_euroStandard": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_euVehicleCategory": {
-            "anyOf": [
-                {
-                    "$ref": "../../../enums/euVehicleCategory.ignore.json"
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        },
-        "techRecord_frontAxleToRearAxle": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_frontAxleTo5thWheelMin": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_frontAxleTo5thWheelMax": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_frontVehicleTo5thWheelCouplingMin": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_frontVehicleTo5thWheelCouplingMax": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_fuelPropulsionSystem": {
-            "anyOf": [
-                {
-                    "$ref": "../../../enums/fuelPropulsionSystem.ignore.json"
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        },
-        "techRecord_functionCode": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1
-        },
-        "techRecord_grossDesignWeight": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_grossEecWeight": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_grossGbWeight": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_make": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 30
-        },
-        "techRecord_maxTrainGbWeight": {
-            "type": [
-                "number",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_maxTrainEecWeight": {
-            "type": [
-                "number",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_maxTrainDesignWeight": {
-            "type": [
-                "number",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_manufactureYear": {
-            "anyOf": [
-                {
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 9999
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        },
-        "techRecord_microfilm_microfilmDocumentType": {
-            "anyOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "$ref": "../../../enums/microfilmDocumentType.ignore.json"
-                }
-            ]
-        },
-        "techRecord_microfilm_microfilmRollNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 5
-        },
-        "techRecord_microfilm_microfilmSerialNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 4
-        },
-        "techRecord_model": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 30
-        },
-        "techRecord_numberOfWheelsDriven": {
-            "type": "integer"
-        },
-        "techRecord_noOfAxles": {
-            "anyOf": [
-                {
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 99
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        },
-        "techRecord_notes": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_offRoad": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "plates": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "title": "HGV Plates",
-                "additionalProperties": false,
-                "properties": {
-                    "techRecord_plateSerialNumber": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "maxLength": 12
-                    },
-                    "techRecord_plateIssueDate": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
-                    "techRecord_reasonForIssue": {
-                        "anyOf": [
-                            {
-                                "type": "null"
-                            },
-                            {
-                                "$ref": "../../../enums/plateReasonForIssue.ignore.json"
-                            }
-                        ]
-                    },
-                    "techRecord_plateIssuer": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "maxLength": 150
-                    }
-                }
-            }
-        },
-        "techRecord_reasonForCreation": {
-            "type": "string"
-        },
-        "techRecord_regnDate": {
-            "anyOf": [
-                {
-                    "type": "string",
-                    "pattern": "^$"
-                },
-                {
-                    "type": "string",
-                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        },
-        "techRecord_roadFriendly": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_statusCode": {
-            "$ref": "../../../enums/statusCode.ignore.json"
-        },
-        "techRecord_speedLimiterMrk": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_tachoExemptMrk": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_trainDesignWeight": {
-            "type": [
-                "integer",
-                "null"
-            ],
+  "title": "PUT HGV Technical Record V3 Testable",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "partialVin",
+    "techRecord_reasonForCreation",
+    "techRecord_statusCode",
+    "techRecord_vehicleType",
+    "primaryVrm",
+    "vin",
+    "techRecord_vehicleConfiguration",
+    "techRecord_vehicleClass_code",
+    "techRecord_vehicleClass_description",
+    "techRecord_numberOfWheelsDriven"
+  ],
+  "properties": {
+    "partialVin": {
+      "type": "string"
+    },
+    "techRecord_adrDetails_vehicleDetails_type": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_vehicleDetails_approvalDate": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_permittedDangerousGoods": {
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "techRecord_adrDetails_compatibilityGroupJ": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_additionalExaminerNotes": {
+      "type": ["string", "null"],
+      "maxLength": 1024
+    },
+    "techRecord_adrDetails_applicantDetails_name": {
+      "type": ["string", "null"],
+      "maxLength": 150
+    },
+    "techRecord_adrDetails_applicantDetails_street": {
+      "type": ["string", "null"],
+      "maxLength": 150
+    },
+    "techRecord_adrDetails_applicantDetails_town": {
+      "type": ["string", "null"],
+      "maxLength": 100
+    },
+    "techRecord_adrDetails_applicantDetails_city": {
+      "type": ["string", "null"],
+      "maxLength": 100
+    },
+    "techRecord_adrDetails_applicantDetails_postcode": {
+      "type": ["string", "null"],
+      "maxLength": 25
+    },
+    "techRecord_adrDetails_memosApply": {
+      "type": ["array", "null"],
+      "items": {
+        "type": ["string"]
+      }
+    },
+    "techRecord_adrDetails_documents": {
+      "type": ["array", "null"],
+      "items": {
+        "type": ["string"]
+      }
+    },
+    "techRecord_adrDetails_listStatementApplicable": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_batteryListNumber": {
+      "type": ["string", "null"],
+      "maxLength": 8
+    },
+    "techRecord_adrDetails_brakeDeclarationsSeen": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_brakeDeclarationIssuer": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_brakeEndurance": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_weight": {
+      "type": ["string", "null"],
+      "maxLength": 8
+    },
+    "techRecord_adrDetails_declarationsSeen": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_additionalNotes_guidanceNotes": {
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "techRecord_adrDetails_additionalNotes_number": {
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "techRecord_adrDetails_adrTypeApprovalNo": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_adrCertificateNotes": {
+      "type": ["string", "null"],
+      "maxLength": 1500
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
+      "type": ["string", "null"],
+      "maxLength": 70
+    },
+    "techRecord_adrDetails_tank_tankDetails_yearOfManufacture": {
+      "type": ["integer", "null"],
+      "maximum": 9999
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo": {
+      "type": ["string", "null"],
+      "maxLength": 50
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankTypeAppNo": {
+      "type": ["string", "null"],
+      "maxLength": 30
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankCode": {
+      "type": ["string", "null"],
+      "maxLength": 30
+    },
+    "techRecord_adrDetails_tank_tankDetails_specialProvisions": {
+      "type": ["string", "null"],
+      "maxLength": 1024
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2Type": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "../../../enums/tc2Types.ignore.json"
+        }
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateApprovalNo": {
+      "type": ["string", "null"],
+      "maxLength": 70
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateExpiryDate": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc3Details_tc3Type": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "../../../enums/tc3Types.ignore.json"
+        }
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicNumber": {
+      "type": ["string", "null"],
+      "maxLength": 75
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicExpiryDate": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_substancesPermitted": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_statement": {
+      "type": ["string", "null"],
+      "maxLength": 1500
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo": {
+      "type": ["array", "null"],
+      "items": {
+        "type": ["string"]
+      }
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_productList": {
+      "type": ["string", "null"],
+      "maxLength": 1500
+    },
+    "techRecord_alterationMarker": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_applicantDetails_name": {
+      "type": ["string", "null"],
+      "maxLength": 150
+    },
+    "techRecord_applicantDetails_address1": {
+      "type": ["null", "string"],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_address2": {
+      "type": ["null", "string"],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_postTown": {
+      "type": ["null", "string"],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_address3": {
+      "type": ["null", "string"],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_postCode": {
+      "type": ["null", "string"],
+      "maxLength": 12
+    },
+    "techRecord_applicantDetails_telephoneNumber": {
+      "type": ["null", "string"],
+      "maxLength": 25
+    },
+    "techRecord_applicantDetails_emailAddress": {
+      "type": ["null", "string"],
+      "maxLength": 255
+    },
+    "techRecord_applicationId": {
+      "type": "string"
+    },
+    "axles": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "title": "HGV Axles",
+        "additionalProperties": false,
+        "properties": {
+          "techRecord_parkingBrakeMrk": {
+            "type": ["boolean", "null"]
+          },
+          "techRecord_axleNumber": {
+            "type": ["integer", "null"]
+          },
+          "techRecord_weights_gbWeight": {
+            "type": ["integer", "null"],
             "minimum": 0,
             "maximum": 99999
-        },
-        "techRecord_trainEecWeight": {
-            "type": [
-                "number",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_trainGbWeight": {
-            "type": [
-                "number",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_tyreUseCode": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 2
-        },
-        "techRecord_vehicleClass_code": {
-            "type": "string"
-        },
-        "techRecord_vehicleClass_description": {
-            "$ref": "../../../enums/vehicleClassDescription.ignore.json"
-        },
-        "techRecord_vehicleConfiguration": {
+          },
+          "techRecord_weights_designWeight": {
+            "type": ["integer", "null"],
+            "minimum": 0,
+            "maximum": 99999
+          },
+          "techRecord_weights_eecWeight": {
+            "type": ["integer", "null"],
+            "minimum": 0,
+            "maximum": 99999
+          },
+          "techRecord_tyres_tyreCode": {
+            "type": ["integer", "null"],
+            "minimum": 0,
+            "maximum": 99999
+          },
+          "techRecord_tyres_tyreSize": {
+            "type": ["string", "null"],
+            "maxLength": 12
+          },
+          "techRecord_tyres_plyRating": {
+            "type": ["string", "null"]
+          },
+          "techRecord_tyres_fitmentCode": {
             "anyOf": [
-                {
-                    "$ref": "../../../enums/vehicleConfiguration.ignore.json"
-                }
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "../../../enums/fitmentCode.ignore.json"
+              }
             ]
-        },
-        "techRecord_approvalType": {
-            "anyOf": [
-                {
-                    "$ref": "../../../enums/approvalType.ignore.json"
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        },
-        "techRecord_approvalTypeNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 25
-        },
-        "techRecord_ntaNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 40
-        },
-        "techRecord_variantNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 25
-        },
-        "techRecord_variantVersionNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 35
-        },
-        "techRecord_vehicleType": {
-            "const": "hgv"
-        },
-        "primaryVrm": {
-            "type": "string"
-        },
-        "vin": {
-            "type": "string"
+          },
+          "techRecord_tyres_dataTrAxles": {
+            "type": ["null", "integer"],
+            "minimum": 0,
+            "maximum": 999
+          }
         }
+      }
+    },
+    "techRecord_bodyType_code": {
+      "type": "string"
+    },
+    "techRecord_bodyType_description": {
+      "type": "string"
+    },
+    "techRecord_brakes_antilockBrakingSystem": {
+      "type": ["string", "null"]
+    },
+    "techRecord_brakes_dtpNumber": {
+      "type": ["string", "null"],
+      "maxLength": 6
+    },
+    "techRecord_brakes_loadSensingValve": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_conversionRefNo": {
+      "type": ["string", "null"],
+      "maxLength": 10
+    },
+    "techRecord_departmentalVehicleMarker": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_dimensions_axleSpacing_axles": {
+      "type": "string"
+    },
+    "techRecord_dimensions_axleSpacing_value": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_dimensions_length": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_dimensions_width": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_drawbarCouplingFitted": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_emissionsLimit": {
+      "type": ["null", "integer"],
+      "minimum": 0,
+      "maximum": 99
+    },
+    "techRecord_euroStandard": {
+      "type": ["string", "null"]
+    },
+    "techRecord_euVehicleCategory": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/euVehicleCategory.ignore.json"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_frontAxleToRearAxle": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_frontAxleTo5thWheelMin": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_frontAxleTo5thWheelMax": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_frontVehicleTo5thWheelCouplingMin": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_frontVehicleTo5thWheelCouplingMax": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_fuelPropulsionSystem": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/fuelPropulsionSystem.ignore.json"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_functionCode": {
+      "type": ["string", "null"],
+      "maxLength": 1
+    },
+    "techRecord_grossDesignWeight": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_grossEecWeight": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_grossGbWeight": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_make": {
+      "type": ["string", "null"],
+      "maxLength": 30
+    },
+    "techRecord_maxTrainGbWeight": {
+      "type": ["number", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_maxTrainEecWeight": {
+      "type": ["number", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_maxTrainDesignWeight": {
+      "type": ["number", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_manufactureYear": {
+      "anyOf": [
+        {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9999
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_microfilm_microfilmDocumentType": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "../../../enums/microfilmDocumentType.ignore.json"
+        }
+      ]
+    },
+    "techRecord_microfilm_microfilmRollNumber": {
+      "type": ["string", "null"],
+      "maxLength": 5
+    },
+    "techRecord_microfilm_microfilmSerialNumber": {
+      "type": ["string", "null"],
+      "maxLength": 4
+    },
+    "techRecord_model": {
+      "type": ["string", "null"],
+      "maxLength": 30
+    },
+    "techRecord_numberOfWheelsDriven": {
+      "type": "integer"
+    },
+    "techRecord_noOfAxles": {
+      "anyOf": [
+        {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 99
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_notes": {
+      "type": ["string", "null"]
+    },
+    "techRecord_offRoad": {
+      "type": ["boolean", "null"]
+    },
+    "plates": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "title": "HGV Plates",
+        "additionalProperties": false,
+        "properties": {
+          "techRecord_plateSerialNumber": {
+            "type": ["string", "null"],
+            "maxLength": 12
+          },
+          "techRecord_plateIssueDate": {
+            "type": ["string", "null"]
+          },
+          "techRecord_reasonForIssue": {
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "../../../enums/plateReasonForIssue.ignore.json"
+              }
+            ]
+          },
+          "techRecord_plateIssuer": {
+            "type": ["string", "null"],
+            "maxLength": 150
+          }
+        }
+      }
+    },
+    "techRecord_reasonForCreation": {
+      "type": "string"
+    },
+    "techRecord_regnDate": {
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^$"
+        },
+        {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_roadFriendly": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_statusCode": {
+      "$ref": "../../../enums/statusCode.ignore.json"
+    },
+    "techRecord_speedLimiterMrk": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_tachoExemptMrk": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_trainDesignWeight": {
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "maximum": 99999
+    },
+    "techRecord_trainEecWeight": {
+      "type": ["number", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_trainGbWeight": {
+      "type": ["number", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_tyreUseCode": {
+      "type": ["string", "null"],
+      "maxLength": 2
+    },
+    "techRecord_vehicleClass_code": {
+      "type": "string"
+    },
+    "techRecord_vehicleClass_description": {
+      "$ref": "../../../enums/vehicleClassDescription.ignore.json"
+    },
+    "techRecord_vehicleConfiguration": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/vehicleConfiguration.ignore.json"
+        }
+      ]
+    },
+    "techRecord_approvalType": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/approvalType.ignore.json"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_approvalTypeNumber": {
+      "type": ["string", "null"],
+      "maxLength": 25
+    },
+    "techRecord_ntaNumber": {
+      "type": ["string", "null"],
+      "maxLength": 40
+    },
+    "techRecord_variantNumber": {
+      "type": ["string", "null"],
+      "maxLength": 25
+    },
+    "techRecord_variantVersionNumber": {
+      "type": ["string", "null"],
+      "maxLength": 35
+    },
+    "techRecord_vehicleType": {
+      "const": "hgv"
+    },
+    "primaryVrm": {
+      "type": "string"
+    },
+    "vin": {
+      "type": "string"
+    },
+    "techRecord_hiddenInVta": {
+      "type": "boolean"
+    },
+    "techRecord_updateType": {
+      "type": "string"
     }
+  }
 }

--- a/json-definitions/v3/tech-record/put/psv/complete/index.json
+++ b/json-definitions/v3/tech-record/put/psv/complete/index.json
@@ -583,6 +583,9 @@
       "items": {
         "type": "string"
       }
+    },
+    "techRecord_updateType": {
+      "type": "string"
     }
   }
 }

--- a/json-definitions/v3/tech-record/put/psv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/psv/skeleton/index.json
@@ -61,22 +61,13 @@
       ]
     },
     "techRecord_seatsLowerDeck": {
-      "type": [
-        "integer",
-        "null"
-      ]
+      "type": ["integer", "null"]
     },
     "techRecord_seatsUpperDeck": {
-      "type": [
-        "integer",
-        "null"
-      ]
+      "type": ["integer", "null"]
     },
     "techRecord_numberOfWheelsDriven": {
-      "type": [
-        "integer",
-        "null"
-      ]
+      "type": ["integer", "null"]
     },
     "techRecord_vehicleClass_code": {
       "type": "string"
@@ -140,16 +131,10 @@
       ]
     },
     "techRecord_departmentalVehicleMarker": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_alterationMarker": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_approvalType": {
       "anyOf": [
@@ -162,31 +147,19 @@
       ]
     },
     "techRecord_approvalTypeNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 25
     },
     "techRecord_ntaNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 40
     },
     "techRecord_variantNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 25
     },
     "techRecord_variantVersionNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 35
     },
     "techRecord_bodyType_description": {
@@ -196,171 +169,99 @@
       "type": "string"
     },
     "techRecord_functionCode": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 1
     },
     "techRecord_conversionRefNo": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 10
     },
     "techRecord_grossGbWeight": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_grossDesignWeight": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_createdByName": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_createdById": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_lastUpdatedAt": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_lastUpdatedByName": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_lastUpdatedById": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_dda_certificateIssued": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_dda_wheelchairCapacity": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99,
       "minimum": 0
     },
     "techRecord_dda_wheelchairFittings": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 250
     },
     "techRecord_dda_wheelchairLiftPresent": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_dda_wheelchairLiftInformation": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 250
     },
     "techRecord_dda_wheelchairRampPresent": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_dda_wheelchairRampInformation": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 250
     },
     "techRecord_dda_minEmergencyExits": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "minimum": 0,
       "maximum": 99
     },
     "techRecord_dda_outswing": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 250
     },
     "techRecord_dda_ddaSchedules": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 250
     },
     "techRecord_dda_seatbeltsFitted": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "minimum": 0,
       "maximum": 999
     },
     "techRecord_dda_ddaNotes": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 1024
     },
     "techRecord_dda": {
       "type": "null"
     },
     "techRecord_standingCapacity": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "minimum": 0,
       "maximum": 999
     },
     "techRecord_speedLimiterMrk": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_tachoExemptMrk": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": ["boolean", "null"]
     },
     "techRecord_euroStandard": {
       "anyOf": [
@@ -383,138 +284,84 @@
       ]
     },
     "techRecord_emissionsLimit": {
-      "type": [
-        "null",
-        "integer"
-      ],
+      "type": ["null", "integer"],
       "minimum": 0,
       "maximum": 99
     },
     "techRecord_trainDesignWeight": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "minimum": 0,
       "maximum": 99999
     },
     "techRecord_numberOfSeatbelts": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 99
     },
     "techRecord_seatbeltInstallationApprovalDate": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "techRecord_coifSerialNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 8
     },
     "techRecord_coifCertifierName": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 20
     },
     "techRecord_coifDate": {
       "anyOf": [
         {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": ["string", "null"],
           "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
         },
         {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": ["string", "null"],
           "pattern": "^$"
         }
       ]
     },
     "techRecord_bodyMake": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 20
     },
     "techRecord_bodyModel": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 20
     },
     "techRecord_chassisMake": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 20
     },
     "techRecord_chassisModel": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 20
     },
     "techRecord_modelLiteral": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 30
     },
     "techRecord_speedRestriction": {
-      "type": [
-        "number",
-        "null"
-      ],
+      "type": ["number", "null"],
       "maximum": 99,
       "minimum": 0
     },
     "techRecord_grossKerbWeight": {
-      "type": [
-        "number",
-        "null"
-      ],
+      "type": ["number", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_grossLadenWeight": {
-      "type": [
-        "number",
-        "null"
-      ],
+      "type": ["number", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_unladenWeight": {
-      "type": [
-        "number",
-        "null"
-      ],
+      "type": ["number", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_maxTrainGbWeight": {
-      "type": [
-        "number",
-        "null"
-      ],
+      "type": ["number", "null"],
       "maximum": 99999,
       "minimum": 0
     },
@@ -522,49 +369,31 @@
       "type": "null"
     },
     "techRecord_dimensions_length": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "minimum": 0,
       "maximum": 99999
     },
     "techRecord_dimensions_width": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "minimum": 0,
       "maximum": 99999
     },
     "techRecord_dimensions_height": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "minimum": 0,
       "maximum": 99999
     },
     "techRecord_frontAxleToRearAxle": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "minimum": 0,
       "maximum": 99999
     },
     "techRecord_remarks": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 1024
     },
     "techRecord_dispensations": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 160
     },
     "axles": {
@@ -575,69 +404,42 @@
         "additionalProperties": false,
         "properties": {
           "techRecord_parkingBrakeMrk": {
-            "type": [
-              "boolean",
-              "null"
-            ]
+            "type": ["boolean", "null"]
           },
           "techRecord_axleNumber": {
-            "type": [
-              "integer",
-              "null"
-            ]
+            "type": ["integer", "null"]
           },
           "techRecord_weights_gbWeight": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "minimum": 0,
             "maximum": 99999
           },
           "techRecord_weights_designWeight": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "minimum": 0,
             "maximum": 99999
           },
           "techRecord_weights_ladenWeight": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "minimum": 0,
             "maximum": 99999
           },
           "techRecord_weights_kerbWeight": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "minimum": 0,
             "maximum": 99999
           },
           "techRecord_tyres_tyreCode": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "minimum": 0,
             "maximum": 99999
           },
           "techRecord_tyres_tyreSize": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "maxLength": 12
           },
           "techRecord_tyres_plyRating": {
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "techRecord_tyres_fitmentCode": {
             "anyOf": [
@@ -650,10 +452,7 @@
             ]
           },
           "techRecord_tyres_dataTrAxles": {
-            "type": [
-              "null",
-              "integer"
-            ],
+            "type": ["null", "integer"],
             "minimum": 0,
             "maximum": 999
           },
@@ -671,101 +470,59 @@
       }
     },
     "techRecord_applicantDetails_name": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 150
     },
     "techRecord_applicantDetails_address1": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 60
     },
     "techRecord_applicantDetails_address2": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 60
     },
     "techRecord_applicantDetails_postTown": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 60
     },
     "techRecord_applicantDetails_address3": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 60
     },
     "techRecord_applicantDetails_postCode": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 12
     },
     "techRecord_applicantDetails_telephoneNumber": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 25
     },
     "techRecord_applicantDetails_emailAddress": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "maxLength": 255
     },
     "techRecord_brakes_dtpNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 6
     },
     "techRecord_brakes_brakeCode": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 6
     },
     "techRecord_brakes_brakeCodeOriginal": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 6
     },
     "techRecord_brakes_dataTrBrakeOne": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 60
     },
     "techRecord_brakes_dataTrBrakeTwo": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 60
     },
     "techRecord_brakes_dataTrBrakeThree": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 60
     },
     "techRecord_brakes_retarderBrakeOne": {
@@ -789,50 +546,32 @@
       ]
     },
     "techRecord_brakes_brakeForceWheelsNotLocked_parkingBrakeForceA": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_brakes_brakeForceWheelsNotLocked_secondaryBrakeForceA": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_brakes_brakeForceWheelsNotLocked_serviceBrakeForceA": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_brakes_brakeForceWheelsUpToHalfLocked_parkingBrakeForceB": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_brakes_brakeForceWheelsUpToHalfLocked_secondaryBrakeForceB": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
     "techRecord_brakes_brakeForceWheelsUpToHalfLocked_serviceBrakeForceB": {
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 0
     },
@@ -850,29 +589,18 @@
       ]
     },
     "techRecord_microfilmRollNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 5
     },
     "techRecord_microfilmSerialNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "maxLength": 4
     },
     "techRecord_brakeCode": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "createdTimestamp": {
-      "type": [
-        "string"
-      ]
+      "type": ["string"]
     },
     "techRecord_applicationId": {
       "type": "string"
@@ -882,7 +610,10 @@
       "items": {
         "type": "string"
       }
+    },
+
+    "techRecord_updateType": {
+      "type": "string"
     }
   }
 }
-

--- a/json-definitions/v3/tech-record/put/psv/testable/index.json
+++ b/json-definitions/v3/tech-record/put/psv/testable/index.json
@@ -545,6 +545,9 @@
       "items": {
         "type": "string"
       }
+    },
+    "techRecord_updateType": {
+      "type": "string"
     }
   }
 }

--- a/json-definitions/v3/tech-record/put/trl/complete/index.json
+++ b/json-definitions/v3/tech-record/put/trl/complete/index.json
@@ -1,1056 +1,723 @@
 {
-    "title": "PUT TRL Technical Record V3 Complete",
-    "type": "object",
-    "additionalProperties": false,
-    "required": [
-        "partialVin",
-        "techRecord_noOfAxles",
-        "techRecord_make",
-        "techRecord_model",
-        "techRecord_firstUseDate",
-        "techRecord_maxLoadOnCoupling",
-        "techRecord_tyreUseCode",
-        "techRecord_suspensionType",
-        "techRecord_couplingType",
-        "techRecord_dimensions_length",
-        "techRecord_dimensions_width",
-        "techRecord_frontAxleToRearAxle",
-        "techRecord_rearAxleToRearTrl",
-        "techRecord_couplingCenterToRearAxleMin",
-        "techRecord_couplingCenterToRearAxleMax",
-        "techRecord_couplingCenterToRearTrlMax",
-        "techRecord_couplingCenterToRearTrlMin",
-        "techRecord_notes",
-        "techRecord_roadFriendly",
-        "trailerId",
-        "techRecord_reasonForCreation",
-        "techRecord_statusCode",
-        "techRecord_vehicleClass_code",
-        "techRecord_vehicleClass_description",
-        "techRecord_vehicleType",
-        "techRecord_bodyType_description",
-        "techRecord_bodyType_code",
-        "techRecord_vehicleConfiguration",
-        "vin"
-    ],
-    "properties": {
-        "partialVin": {
-            "type": "string"
+  "title": "PUT TRL Technical Record V3 Complete",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "partialVin",
+    "techRecord_noOfAxles",
+    "techRecord_make",
+    "techRecord_model",
+    "techRecord_firstUseDate",
+    "techRecord_maxLoadOnCoupling",
+    "techRecord_tyreUseCode",
+    "techRecord_suspensionType",
+    "techRecord_couplingType",
+    "techRecord_dimensions_length",
+    "techRecord_dimensions_width",
+    "techRecord_frontAxleToRearAxle",
+    "techRecord_rearAxleToRearTrl",
+    "techRecord_couplingCenterToRearAxleMin",
+    "techRecord_couplingCenterToRearAxleMax",
+    "techRecord_couplingCenterToRearTrlMax",
+    "techRecord_couplingCenterToRearTrlMin",
+    "techRecord_notes",
+    "techRecord_roadFriendly",
+    "trailerId",
+    "techRecord_reasonForCreation",
+    "techRecord_statusCode",
+    "techRecord_vehicleClass_code",
+    "techRecord_vehicleClass_description",
+    "techRecord_vehicleType",
+    "techRecord_bodyType_description",
+    "techRecord_bodyType_code",
+    "techRecord_vehicleConfiguration",
+    "vin"
+  ],
+  "properties": {
+    "partialVin": {
+      "type": "string"
+    },
+    "techRecord_adrDetails_vehicleDetails_type": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_vehicleDetails_approvalDate": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_permittedDangerousGoods": {
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "techRecord_adrDetails_compatibilityGroupJ": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_additionalExaminerNotes": {
+      "type": ["string", "null"],
+      "maxLength": 1024
+    },
+    "techRecord_adrDetails_applicantDetails_name": {
+      "type": ["string", "null"],
+      "maxLength": 150
+    },
+    "techRecord_adrDetails_applicantDetails_street": {
+      "type": ["string", "null"],
+      "maxLength": 150
+    },
+    "techRecord_adrDetails_applicantDetails_town": {
+      "type": ["string", "null"],
+      "maxLength": 100
+    },
+    "techRecord_adrDetails_applicantDetails_city": {
+      "type": ["string", "null"],
+      "maxLength": 100
+    },
+    "techRecord_adrDetails_applicantDetails_postcode": {
+      "type": ["string", "null"],
+      "maxLength": 25
+    },
+    "techRecord_adrDetails_memosApply": {
+      "type": ["array", "null"],
+      "items": {
+        "type": ["string"]
+      }
+    },
+    "techRecord_adrDetails_documents": {
+      "type": ["array", "null"],
+      "items": {
+        "type": ["string"]
+      }
+    },
+    "techRecord_adrDetails_listStatementApplicable": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_batteryListNumber": {
+      "type": ["string", "null"],
+      "maxLength": 8
+    },
+    "techRecord_adrDetails_brakeDeclarationsSeen": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_brakeDeclarationIssuer": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_brakeEndurance": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_weight": {
+      "type": ["string", "null"],
+      "maxLength": 8
+    },
+    "techRecord_adrDetails_declarationsSeen": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_additionalNotes_guidanceNotes": {
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "techRecord_adrDetails_additionalNotes_number": {
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "techRecord_adrDetails_adrTypeApprovalNo": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_adrCertificateNotes": {
+      "type": ["string", "null"],
+      "maxLength": 1500
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
+      "type": ["string", "null"],
+      "maxLength": 70
+    },
+    "techRecord_adrDetails_tank_tankDetails_yearOfManufacture": {
+      "type": ["integer", "null"],
+      "maximum": 9999
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo": {
+      "type": ["string", "null"],
+      "maxLength": 50
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankTypeAppNo": {
+      "type": ["string", "null"],
+      "maxLength": 30
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankCode": {
+      "type": ["string", "null"],
+      "maxLength": 30
+    },
+    "techRecord_adrDetails_tank_tankDetails_specialProvisions": {
+      "type": ["string", "null"],
+      "maxLength": 1024
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2Type": {
+      "anyOf": [
+        {
+          "type": "null"
         },
-        "techRecord_adrDetails_vehicleDetails_type": {
-            "type": [
-                "string",
-                "null"
-            ]
+        {
+          "$ref": "../../../enums/tc2Types.ignore.json"
+        }
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateApprovalNo": {
+      "type": ["string", "null"],
+      "maxLength": 70
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateExpiryDate": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc3Details_tc3Type": {
+      "anyOf": [
+        {
+          "type": "null"
         },
-        "techRecord_adrDetails_vehicleDetails_approvalDate": {
-            "type": [
-                "string",
-                "null"
-            ]
+        {
+          "$ref": "../../../enums/tc3Types.ignore.json"
+        }
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicNumber": {
+      "type": ["string", "null"],
+      "maxLength": 75
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicExpiryDate": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_substancesPermitted": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_statement": {
+      "type": ["string", "null"],
+      "maxLength": 1500
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo": {
+      "type": ["array", "null"],
+      "items": {
+        "type": ["string"]
+      }
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_productList": {
+      "type": ["string", "null"],
+      "maxLength": 1500
+    },
+    "techRecord_alterationMarker": {
+      "type": ["string", "null"]
+    },
+    "techRecord_applicantDetails_name": {
+      "type": ["string", "null"],
+      "maxLength": 150
+    },
+    "techRecord_applicantDetails_address1": {
+      "type": ["null", "string"],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_address2": {
+      "type": ["null", "string"],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_postTown": {
+      "type": ["null", "string"],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_address3": {
+      "type": ["null", "string"],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_postCode": {
+      "type": ["null", "string"],
+      "maxLength": 12
+    },
+    "techRecord_applicantDetails_telephoneNumber": {
+      "type": ["null", "string"],
+      "maxLength": 25
+    },
+    "techRecord_applicantDetails_emailAddress": {
+      "type": ["null", "string"],
+      "maxLength": 255
+    },
+    "techRecord_applicationId": {
+      "type": ["string", "null"]
+    },
+    "techRecord_approvalType": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/approvalType.ignore.json"
         },
-        "techRecord_adrDetails_permittedDangerousGoods": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": "string"
-            }
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_approvalTypeNumber": {
+      "type": ["string", "null"],
+      "maxLength": 25
+    },
+    "techRecord_authIntoService": {
+      "type": ["string", "null"]
+    },
+    "techRecord_batchId": {
+      "type": ["string", "null"]
+    },
+    "techRecord_bodyType_code": {
+      "type": "string"
+    },
+    "techRecord_bodyType_description": {
+      "type": "string"
+    },
+    "techRecord_brakes_antilockBrakingSystem": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_brakes_dtpNumber": {
+      "type": ["string", "null"],
+      "maxLength": 6
+    },
+    "techRecord_brakes_loadSensingValve": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_centreOfRearmostAxleToRearOfTrl": {
+      "type": ["integer", "null"]
+    },
+    "techRecord_conversionRefNo": {
+      "type": ["string", "null"],
+      "maxLength": 10
+    },
+    "techRecord_couplingCenterToRearAxleMax": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_couplingCenterToRearAxleMin": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_couplingCenterToRearTrlMax": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_couplingCenterToRearTrlMin": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_couplingType": {
+      "type": ["string", "null"],
+      "maxLength": 1
+    },
+    "techRecord_departmentalVehicleMarker": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_dimensions_length": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_dimensions_width": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "drawbarCouplingFitted": {
+      "type": "string"
+    },
+    "techRecord_emissionsLimit": {
+      "type": ["null", "integer"],
+      "minimum": 0,
+      "maximum": 99
+    },
+    "techRecord_euVehicleCategory": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/euVehicleCategory.ignore.json"
         },
-        "techRecord_adrDetails_compatibilityGroupJ": {
-            "type": [
-                "boolean",
-                "null"
-            ]
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_euroStandard": {
+      "$ref": "../../../enums/euroStandard.ignore.json"
+    },
+    "frontAxleTo5thWheelMax": {
+      "type": ["integer", "null"]
+    },
+    "techRecord_frontAxleTo5thWheelMin": {
+      "type": ["integer", "null"]
+    },
+    "techRecord_firstUseDate": {
+      "type": ["string", "null"]
+    },
+    "techRecord_frameDescription": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/frameDescription.ignore.json"
         },
-        "techRecord_adrDetails_additionalExaminerNotes": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1024
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_frontAxleToRearAxle": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_frontVehicleTo5thWheelCouplingMax": {
+      "type": ["string", "null"]
+    },
+    "techRecord_frontVehicleTo5thWheelCouplingMin": {
+      "type": ["string", "null"]
+    },
+    "techRecord_fuelPropulsionSystem": {
+      "$ref": "../../../enums/fuelPropulsionSystem.ignore.json"
+    },
+    "techRecord_functionCode": {
+      "type": ["string", "null"],
+      "maxLength": 1
+    },
+    "techRecord_grossDesignWeight": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_grossEecWeight": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_grossGbWeight": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_letterOfAuth": {
+      "type": ["string", "null"]
+    },
+    "techRecord_make": {
+      "type": ["string", "null"],
+      "maxLength": 30
+    },
+    "techRecord_manufactureYear": {
+      "anyOf": [
+        {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9999
         },
-        "techRecord_adrDetails_applicantDetails_name": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 150
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_maxTrainDesignWeight": {
+      "type": "integer"
+    },
+    "techRecord_maxTrainEecWeight": {
+      "type": "integer"
+    },
+    "techRecord_maxTrainGbWeight": {
+      "type": "integer"
+    },
+    "techRecord_manufacturerDetails": {
+      "type": ["string", "null"]
+    },
+    "techRecord_maxLoadOnCoupling": {
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "maximum": 99999
+    },
+    "techRecord_microfilm": {
+      "type": ["string", "null"]
+    },
+    "techRecord_microfilm_microfilmDocumentType": {
+      "anyOf": [
+        {
+          "type": "null"
         },
-        "techRecord_adrDetails_applicantDetails_street": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 150
+        {
+          "$ref": "../../../enums/microfilmDocumentType.ignore.json"
+        }
+      ]
+    },
+    "techRecord_microfilm_microfilmRollNumber": {
+      "type": ["string", "null"],
+      "maxLength": 5
+    },
+    "techRecord_microfilm_microfilmSerialNumber": {
+      "type": ["string", "null"],
+      "maxLength": 4
+    },
+    "techRecord_model": {
+      "type": ["string", "null"],
+      "maxLength": 30
+    },
+    "techRecord_noOfAxles": {
+      "anyOf": [
+        {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 99
         },
-        "techRecord_adrDetails_applicantDetails_town": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 100
-        },
-        "techRecord_adrDetails_applicantDetails_city": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 100
-        },
-        "techRecord_adrDetails_applicantDetails_postcode": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 25
-        },
-        "techRecord_adrDetails_memosApply": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": [
-                    "string"
-                ]
-            }
-        },
-        "techRecord_adrDetails_documents": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": [
-                    "string"
-                ]
-            }
-        },
-        "techRecord_adrDetails_listStatementApplicable": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_batteryListNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 8
-        },
-        "techRecord_adrDetails_brakeDeclarationsSeen": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_brakeDeclarationIssuer": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_brakeEndurance": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_weight": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 8
-        },
-        "techRecord_adrDetails_declarationsSeen": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_additionalNotes_guidanceNotes": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": "string"
-            }
-        },
-        "techRecord_adrDetails_additionalNotes_number": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": "string"
-            }
-        },
-        "techRecord_adrDetails_adrTypeApprovalNo": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_adrCertificateNotes": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1500
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 70
-        },
-        "techRecord_adrDetails_tank_tankDetails_yearOfManufacture": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 9999
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 50
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankTypeAppNo": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 30
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankCode": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 30
-        },
-        "techRecord_adrDetails_tank_tankDetails_specialProvisions": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1024
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2Type": {
-            "anyOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "$ref": "../../../enums/tc2Types.ignore.json"
-                }
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateApprovalNo": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 70
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateExpiryDate": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc3Details_tc3Type": {
-            "anyOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "$ref": "../../../enums/tc3Types.ignore.json"
-                }
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 75
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicExpiryDate": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_substancesPermitted": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_statement": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1500
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": [
-                    "string"
-                ]
-            }
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_productList": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1500
-        },
-        "techRecord_alterationMarker": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_applicantDetails_name": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 150
-        },
-        "techRecord_applicantDetails_address1": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 60
-        },
-        "techRecord_applicantDetails_address2": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 60
-        },
-        "techRecord_applicantDetails_postTown": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 60
-        },
-        "techRecord_applicantDetails_address3": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 60
-        },
-        "techRecord_applicantDetails_postCode": {
-            "type": [
-                "null",
-                "string"
-            ],
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_notes": {
+      "type": "string"
+    },
+    "techRecord_ntaNumber": {
+      "type": "string"
+    },
+    "techRecord_numberOfWheelsDriven": {
+      "type": ["integer", "null"]
+    },
+    "techRecord_offRoad": {
+      "type": "boolean"
+    },
+    "plates": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "title": "TRL Plates",
+        "additionalProperties": false,
+        "properties": {
+          "techRecord_plateSerialNumber": {
+            "type": ["string", "null"],
             "maxLength": 12
-        },
-        "techRecord_applicantDetails_telephoneNumber": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 25
-        },
-        "techRecord_applicantDetails_emailAddress": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 255
-        },
-        "techRecord_applicationId": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_approvalType": {
+          },
+          "techRecord_plateIssueDate": {
+            "type": ["string", "null"]
+          },
+          "techRecord_reasonForIssue": {
             "anyOf": [
-                {
-                    "$ref": "../../../enums/approvalType.ignore.json"
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "../../../enums/plateReasonForIssue.ignore.json"
+              }
+            ]
+          },
+          "techRecord_plateIssuer": {
+            "type": ["string", "null"],
+            "maxLength": 150
+          }
+        }
+      }
+    },
+    "techRecord_purchaserDetails_address1": {
+      "type": ["string", "null"]
+    },
+    "techRecord_purchaserDetails_address2": {
+      "type": ["string", "null"]
+    },
+    "techRecord_purchaserDetails_address3": {
+      "type": ["string", "null"]
+    },
+    "techRecord_purchaserDetails_emailAddress": {
+      "type": ["string", "null"]
+    },
+    "techRecord_purchaserDetails_faxNumber": {
+      "type": ["string", "null"]
+    },
+    "techRecord_purchaserDetails_name": {
+      "type": ["string", "null"]
+    },
+    "techRecord_purchaserDetails_postCode": {
+      "type": ["string", "null"]
+    },
+    "techRecord_purchaserDetails_postTown": {
+      "type": ["string", "null"]
+    },
+    "techRecord_purchaserDetails_purchaserNotes": {
+      "type": ["string", "null"]
+    },
+    "techRecord_purchaserDetails_telephoneNumber": {
+      "type": ["string", "null"]
+    },
+    "techRecord_rearAxleToRearTrl": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_reasonForCreation": {
+      "type": "string"
+    },
+    "techRecord_regnDate": {
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^$"
+        },
+        {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_roadFriendly": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_speedLimiterMrk": {
+      "type": "boolean"
+    },
+    "techRecord_statusCode": {
+      "$ref": "../../../enums/statusCode.ignore.json"
+    },
+    "techRecord_tachoExemptMrk": {
+      "type": "boolean"
+    },
+    "techRecord_suspensionType": {
+      "type": ["string", "null"],
+      "maxLength": 1
+    },
+    "techRecord_tyreUseCode": {
+      "type": ["string", "null"],
+      "maxLength": 2
+    },
+    "techRecord_variantNumber": {
+      "type": "string"
+    },
+    "techRecord_variantVersionNumber": {
+      "type": "string"
+    },
+    "techRecord_vehicleClass_code": {
+      "type": "string"
+    },
+    "techRecord_vehicleClass_description": {
+      "$ref": "../../../enums/vehicleClassDescription.ignore.json"
+    },
+    "techRecord_vehicleConfiguration": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/vehicleConfiguration.ignore.json"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_vehicleType": {
+      "const": "trl"
+    },
+    "trailerId": {
+      "type": "string"
+    },
+    "vin": {
+      "type": "string"
+    },
+    "axles": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "title": "PSV Axles",
+        "additionalProperties": false,
+        "properties": {
+          "techRecord_parkingBrakeMrk": {
+            "type": ["boolean", "null"]
+          },
+          "techRecord_axleNumber": {
+            "type": ["integer", "null"]
+          },
+          "techRecord_brakes": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "brakeActuator": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 999
                 },
-                {
-                    "type": "null"
-                }
-            ]
-        },
-        "techRecord_approvalTypeNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 25
-        },
-        "techRecord_authIntoService": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_batchId": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_bodyType_code": {
-            "type": "string"
-        },
-        "techRecord_bodyType_description": {
-            "type": "string"
-        },
-        "techRecord_brakes_antilockBrakingSystem": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_brakes_dtpNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 6
-        },
-        "techRecord_brakes_loadSensingValve": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_centreOfRearmostAxleToRearOfTrl": {
-            "type": [
-                "integer",
-                "null"
-            ]
-        },
-        "techRecord_conversionRefNo": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 10
-        },
-        "techRecord_couplingCenterToRearAxleMax": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_couplingCenterToRearAxleMin": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_couplingCenterToRearTrlMax": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_couplingCenterToRearTrlMin": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_couplingType": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1
-        },
-        "techRecord_departmentalVehicleMarker": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_dimensions_length": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_dimensions_width": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "drawbarCouplingFitted": {
-            "type": "string"
-        },
-        "techRecord_emissionsLimit": {
-            "type": [
-                "null",
-                "integer"
-            ],
-            "minimum": 0,
-            "maximum": 99
-        },
-        "techRecord_euVehicleCategory": {
-            "anyOf": [
-                {
-                    "$ref": "../../../enums/euVehicleCategory.ignore.json"
+                "leverLength": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 999
                 },
-                {
-                    "type": "null"
+                "springBrakeParking": {
+                  "type": "boolean"
                 }
-            ]
-        },
-        "techRecord_euroStandard": {
-            "$ref": "../../../enums/euroStandard.ignore.json"
-        },
-        "frontAxleTo5thWheelMax": {
-            "type": [
-                "integer",
-                "null"
-            ]
-        },
-        "techRecord_frontAxleTo5thWheelMin": {
-            "type": [
-                "integer",
-                "null"
-            ]
-        },
-        "techRecord_firstUseDate": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_frameDescription": {
-            "anyOf": [
-                {
-                    "$ref": "../../../enums/frameDescription.ignore.json"
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        },
-        "techRecord_frontAxleToRearAxle": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_frontVehicleTo5thWheelCouplingMax": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_frontVehicleTo5thWheelCouplingMin": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_fuelPropulsionSystem": {
-            "$ref": "../../../enums/fuelPropulsionSystem.ignore.json"
-        },
-        "techRecord_functionCode": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1
-        },
-        "techRecord_grossDesignWeight": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_grossEecWeight": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_grossGbWeight": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_letterOfAuth": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_make": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 30
-        },
-        "techRecord_manufactureYear": {
-            "anyOf": [
-                {
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 9999
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        },
-        "techRecord_maxTrainDesignWeight": {
-            "type": "integer"
-        },
-        "techRecord_maxTrainEecWeight": {
-            "type": "integer"
-        },
-        "techRecord_maxTrainGbWeight": {
-            "type": "integer"
-        },
-        "techRecord_manufacturerDetails": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_maxLoadOnCoupling": {
-            "type": [
-                "integer",
-                "null"
-            ],
+              }
+            }
+          },
+          "techRecord_weights_gbWeight": {
+            "type": ["integer", "null"],
             "minimum": 0,
             "maximum": 99999
-        },
-        "techRecord_microfilm": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_microfilm_microfilmDocumentType": {
+          },
+          "techRecord_weights_designWeight": {
+            "type": ["integer", "null"],
+            "minimum": 0,
+            "maximum": 99999
+          },
+          "techRecord_weights_ladenWeight": {
+            "type": ["integer", "null"],
+            "minimum": 0,
+            "maximum": 99999
+          },
+          "techRecord_weights_kerbWeight": {
+            "type": ["integer", "null"],
+            "minimum": 0,
+            "maximum": 99999
+          },
+          "techRecord_tyres_tyreCode": {
+            "type": ["integer", "null"],
+            "minimum": 0,
+            "maximum": 99999
+          },
+          "techRecord_tyres_tyreSize": {
+            "type": ["string", "null"],
+            "maxLength": 12
+          },
+          "techRecord_tyres_plyRating": {
+            "type": ["string", "null"]
+          },
+          "techRecord_tyres_fitmentCode": {
             "anyOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "$ref": "../../../enums/microfilmDocumentType.ignore.json"
-                }
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "../../../enums/fitmentCode.ignore.json"
+              }
             ]
-        },
-        "techRecord_microfilm_microfilmRollNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 5
-        },
-        "techRecord_microfilm_microfilmSerialNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 4
-        },
-        "techRecord_model": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 30
-        },
-        "techRecord_noOfAxles": {
+          },
+          "techRecord_tyres_dataTrAxles": {
+            "type": ["null", "integer"],
+            "minimum": 0,
+            "maximum": 999
+          },
+          "techRecord_tyres_speedCategorySymbol": {
             "anyOf": [
-                {
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 99
-                },
-                {
-                    "type": "null"
-                }
+              {
+                "$ref": "../../../enums/speedCategorySymbol.ignore.json"
+              },
+              {
+                "type": "null"
+              }
             ]
-        },
-        "techRecord_notes": {
-            "type": "string"
-        },
-        "techRecord_ntaNumber": {
-            "type": "string"
-        },
-        "techRecord_numberOfWheelsDriven": {
-            "type": [
-                "integer",
-                "null"
-            ]
-        },
-        "techRecord_offRoad": {
+          },
+          "techRecord_hiddenInVta": {
             "type": "boolean"
-        },
-        "plates": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "title": "TRL Plates",
-                "additionalProperties": false,
-                "properties": {
-                    "techRecord_plateSerialNumber": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "maxLength": 12
-                    },
-                    "techRecord_plateIssueDate": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
-                    "techRecord_reasonForIssue": {
-                        "anyOf": [
-                            {
-                                "type": "null"
-                            },
-                            {
-                                "$ref": "../../../enums/plateReasonForIssue.ignore.json"
-                            }
-                        ]
-                    },
-                    "techRecord_plateIssuer": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "maxLength": 150
-                    }
-                }
-            }
-        },
-        "techRecord_purchaserDetails_address1": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_purchaserDetails_address2": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_purchaserDetails_address3": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_purchaserDetails_emailAddress": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_purchaserDetails_faxNumber": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_purchaserDetails_name": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_purchaserDetails_postCode": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_purchaserDetails_postTown": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_purchaserDetails_purchaserNotes": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_purchaserDetails_telephoneNumber": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_rearAxleToRearTrl": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_reasonForCreation": {
+          },
+          "techRecord_updateType": {
             "type": "string"
-        },
-        "techRecord_regnDate": {
-            "anyOf": [
-                {
-                    "type": "string",
-                    "pattern": "^$"
-                },
-                {
-                    "type": "string",
-                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        },
-        "techRecord_roadFriendly": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_speedLimiterMrk": {
-            "type": "boolean"
-        },
-        "techRecord_statusCode": {
-            "$ref": "../../../enums/statusCode.ignore.json"
-        },
-        "techRecord_tachoExemptMrk": {
-            "type": "boolean"
-        },
-        "techRecord_suspensionType": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1
-        },
-        "techRecord_tyreUseCode": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 2
-        },
-        "techRecord_variantNumber": {
-            "type": "string"
-        },
-        "techRecord_variantVersionNumber": {
-            "type": "string"
-        },
-        "techRecord_vehicleClass_code": {
-            "type": "string"
-        },
-        "techRecord_vehicleClass_description": {
-            "$ref": "../../../enums/vehicleClassDescription.ignore.json"
-        },
-        "techRecord_vehicleConfiguration": {
-            "anyOf": [
-                {
-                    "$ref": "../../../enums/vehicleConfiguration.ignore.json"
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        },
-        "techRecord_vehicleType": {
-            "const": "trl"
-        },
-        "trailerId": {
-            "type": "string"
-        },
-        "vin": {
-            "type": "string"
-        },
-        "axles": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "title": "PSV Axles",
-                "additionalProperties": false,
-                "properties": {
-                    "techRecord_parkingBrakeMrk": {
-                        "type": [
-                            "boolean",
-                            "null"
-                        ]
-                    },
-                    "techRecord_axleNumber": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ]
-                    },
-                    "techRecord_brakes": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "brakeActuator": {
-                                    "type": "integer",
-                                    "minimum": 0,
-                                    "maximum": 999
-                                },
-                                "leverLength": {
-                                    "type": "integer",
-                                    "minimum": 0,
-                                    "maximum": 999
-                                },
-                                "springBrakeParking": {
-                                    "type": "boolean"
-                                }
-                            }
-                        }
-                    },
-                    "techRecord_weights_gbWeight": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ],
-                        "minimum": 0,
-                        "maximum": 99999
-                    },
-                    "techRecord_weights_designWeight": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ],
-                        "minimum": 0,
-                        "maximum": 99999
-                    },
-                    "techRecord_weights_ladenWeight": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ],
-                        "minimum": 0,
-                        "maximum": 99999
-                    },
-                    "techRecord_weights_kerbWeight": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ],
-                        "minimum": 0,
-                        "maximum": 99999
-                    },
-                    "techRecord_tyres_tyreCode": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ],
-                        "minimum": 0,
-                        "maximum": 99999
-                    },
-                    "techRecord_tyres_tyreSize": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "maxLength": 12
-                    },
-                    "techRecord_tyres_plyRating": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
-                    "techRecord_tyres_fitmentCode": {
-                        "anyOf": [
-                            {
-                                "type": "null"
-                            },
-                            {
-                                "$ref": "../../../enums/fitmentCode.ignore.json"
-                            }
-                        ]
-                    },
-                    "techRecord_tyres_dataTrAxles": {
-                        "type": [
-                            "null",
-                            "integer"
-                        ],
-                        "minimum": 0,
-                        "maximum": 999
-                    },
-                    "techRecord_tyres_speedCategorySymbol": {
-                        "anyOf": [
-                            {
-                                "$ref": "../../../enums/speedCategorySymbol.ignore.json"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    }
-                }
-            }
+          }
         }
+      }
     }
+  }
 }

--- a/json-definitions/v3/tech-record/put/trl/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/trl/skeleton/index.json
@@ -1,833 +1,545 @@
 {
-    "title": "GET TRL Technical Record V3 Skeleton",
-    "type": "object",
-    "additionalProperties": false,
-    "required": [
-        "partialVin",
-        "techRecord_reasonForCreation",
-        "techRecord_statusCode",
-        "techRecord_vehicleClass_code",
-        "techRecord_vehicleClass_description",
-        "techRecord_vehicleConfiguration",
-        "techRecord_vehicleType",
-        "trailerId",
-        "vin"
-    ],
-    "properties": {
-        "partialVin": {
-            "type": "string"
-        },
-        "techRecord_adrDetails_vehicleDetails_type": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_vehicleDetails_approvalDate": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_permittedDangerousGoods": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": "string"
-            }
-        },
-        "techRecord_adrDetails_compatibilityGroupJ": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_additionalExaminerNotes": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1024
-        },
-        "techRecord_adrDetails_applicantDetails_name": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 150
-        },
-        "techRecord_adrDetails_applicantDetails_street": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 150
-        },
-        "techRecord_adrDetails_applicantDetails_town": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 100
-        },
-        "techRecord_adrDetails_applicantDetails_city": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 100
-        },
-        "techRecord_adrDetails_applicantDetails_postcode": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 25
-        },
-        "techRecord_adrDetails_memosApply": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": [
-                    "string"
-                ]
-            }
-        },
-        "techRecord_adrDetails_documents": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": [
-                    "string"
-                ]
-            }
-        },
-        "techRecord_adrDetails_listStatementApplicable": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_batteryListNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 8
-        },
-        "techRecord_adrDetails_brakeDeclarationsSeen": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_brakeDeclarationIssuer": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_brakeEndurance": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_weight": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 8
-        },
-        "techRecord_adrDetails_declarationsSeen": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_additionalNotes_guidanceNotes": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": "string"
-            }
-        },
-        "techRecord_adrDetails_additionalNotes_number": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": "string"
-            }
-        },
-        "techRecord_adrDetails_adrTypeApprovalNo": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_adrCertificateNotes": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1500
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 70
-        },
-        "techRecord_adrDetails_tank_tankDetails_yearOfManufacture": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 9999
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 50
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankTypeAppNo": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 30
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankCode": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 30
-        },
-        "techRecord_adrDetails_tank_tankDetails_specialProvisions": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1024
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2Type": {
-            "anyOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "$ref": "../../../enums/tc2Types.ignore.json"
-                }
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateApprovalNo": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 70
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateExpiryDate": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc3Details_tc3Type": {
-            "anyOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "$ref": "../../../enums/tc3Types.ignore.json"
-                }
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 75
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicExpiryDate": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_substancesPermitted": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_statement": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1500
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": [
-                    "string"
-                ]
-            }
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_productList": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1500
-        },
-        "techRecord_alterationMarker": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_applicantDetails_name": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 150
-        },
-        "techRecord_applicantDetails_address1": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 60
-        },
-        "techRecord_applicantDetails_address2": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 60
-        },
-        "techRecord_applicantDetails_postTown": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 60
-        },
-        "techRecord_applicantDetails_address3": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 60
-        },
-        "techRecord_applicantDetails_postCode": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 12
-        },
-        "techRecord_applicantDetails_telephoneNumber": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 25
-        },
-        "techRecord_applicantDetails_emailAddress": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 255
-        },
-        "techRecord_applicationId": {
-            "type": "string"
-        },
-        "techRecord_authIntoService": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_batchId": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_bodyType_code": {
-            "type": "string"
-        },
-        "techRecord_bodyType_description": {
-            "type": "string"
-        },
-        "techRecord_brakes_antilockBrakingSystem": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_brakes_dtpNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 6
-        },
-        "techRecord_brakes_loadSensingValve": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_centreOfRearmostAxleToRearOfTrl": {
-            "type": [
-                "integer",
-                "null"
-            ]
-        },
-        "techRecord_conversionRefNo": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 10
-        },
-        "techRecord_couplingCenterToRearAxleMax": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_couplingCenterToRearAxleMin": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_couplingCenterToRearTrlMax": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_couplingCenterToRearTrlMin": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_couplingType": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1
-        },
-        "techRecord_departmentalVehicleMarker": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_dimensions_length": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_dimensions_width": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_euVehicleCategory": {
-            "anyOf": [
-                {
-                    "$ref": "../../../enums/euVehicleCategory.ignore.json"
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        },
-        "techRecord_firstUseDate": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_frameDescription": {
-            "anyOf": [
-                {
-                    "$ref": "../../../enums/frameDescription.ignore.json"
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        },
-        "techRecord_frontAxleToRearAxle": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_functionCode": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1
-        },
-        "techRecord_grossDesignWeight": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_grossEecWeight": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_grossGbWeight": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_letterOfAuth": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_make": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 30
-        },
-        "techRecord_manufactureYear": {
-            "anyOf": [
-                {
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 9999
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        },
-        "techRecord_manufacturerDetails": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_maxLoadOnCoupling": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "minimum": 0,
-            "maximum": 99999
-        },
-        "techRecord_microfilm": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_microfilm_microfilmDocumentType": {
-            "anyOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "$ref": "../../../enums/microfilmDocumentType.ignore.json"
-                }
-            ]
-        },
-        "techRecord_microfilm_microfilmRollNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 5
-        },
-        "techRecord_microfilm_microfilmSerialNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 4
-        },
-        "techRecord_model": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 30
-        },
-        "techRecord_noOfAxles": {
-            "anyOf": [
-                {
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 99
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        },
-        "plates": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "title": "TRL Plates",
-                "additionalProperties": false,
-                "properties": {
-                    "techRecord_plateSerialNumber": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "maxLength": 12
-                    },
-                    "techRecord_plateIssueDate": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
-                    "techRecord_reasonForIssue": {
-                        "anyOf": [
-                            {
-                                "type": "null"
-                            },
-                            {
-                                "$ref": "../../../enums/plateReasonForIssue.ignore.json"
-                            }
-                        ]
-                    },
-                    "techRecord_plateIssuer": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "maxLength": 150
-                    }
-                }
-            }
-        },
-        "techRecord_purchaserDetails_address1": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_purchaserDetails_address2": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_purchaserDetails_address3": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_purchaserDetails_emailAddress": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_purchaserDetails_faxNumber": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_purchaserDetails_name": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_purchaserDetails_postCode": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_purchaserDetails_postTown": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_purchaserDetails_purchaserNotes": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_purchaserDetails_telephoneNumber": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_lastUpdatedAt": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_lastUpdatedByName": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_lastUpdatedById": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_rearAxleToRearTrl": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_reasonForCreation": {
-            "type": "string"
-        },
-        "techRecord_regnDate": {
-            "anyOf": [
-                {
-                    "type": "string",
-                    "pattern": "^$"
-                },
-                {
-                    "type": "string",
-                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        },
-        "techRecord_roadFriendly": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_statusCode": {
-            "$ref": "../../../enums/statusCode.ignore.json"
-        },
-        "techRecord_suspensionType": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1
-        },
-        "techRecord_tyreUseCode": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 2
-        },
-        "techRecord_vehicleClass_code": {
-            "type": "string"
-        },
-        "techRecord_vehicleClass_description": {
-            "$ref": "../../../enums/vehicleClassDescription.ignore.json"
-        },
-        "techRecord_vehicleConfiguration": {
-            "anyOf": [
-                {
-                    "$ref": "../../../enums/vehicleConfiguration.ignore.json"
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        },
-        "techRecord_vehicleType": {
-            "const": "trl"
-        },
-        "trailerId": {
-            "type": "string"
-        },
-        "vin": {
-            "type": "string"
+  "title": "GET TRL Technical Record V3 Skeleton",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "partialVin",
+    "techRecord_reasonForCreation",
+    "techRecord_statusCode",
+    "techRecord_vehicleClass_code",
+    "techRecord_vehicleClass_description",
+    "techRecord_vehicleConfiguration",
+    "techRecord_vehicleType",
+    "trailerId",
+    "vin"
+  ],
+  "properties": {
+    "partialVin": {
+      "type": "string"
+    },
+    "techRecord_adrDetails_vehicleDetails_type": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_vehicleDetails_approvalDate": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_permittedDangerousGoods": {
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "techRecord_adrDetails_compatibilityGroupJ": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_additionalExaminerNotes": {
+      "type": ["string", "null"],
+      "maxLength": 1024
+    },
+    "techRecord_adrDetails_applicantDetails_name": {
+      "type": ["string", "null"],
+      "maxLength": 150
+    },
+    "techRecord_adrDetails_applicantDetails_street": {
+      "type": ["string", "null"],
+      "maxLength": 150
+    },
+    "techRecord_adrDetails_applicantDetails_town": {
+      "type": ["string", "null"],
+      "maxLength": 100
+    },
+    "techRecord_adrDetails_applicantDetails_city": {
+      "type": ["string", "null"],
+      "maxLength": 100
+    },
+    "techRecord_adrDetails_applicantDetails_postcode": {
+      "type": ["string", "null"],
+      "maxLength": 25
+    },
+    "techRecord_adrDetails_memosApply": {
+      "type": ["array", "null"],
+      "items": {
+        "type": ["string"]
+      }
+    },
+    "techRecord_adrDetails_documents": {
+      "type": ["array", "null"],
+      "items": {
+        "type": ["string"]
+      }
+    },
+    "techRecord_adrDetails_listStatementApplicable": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_batteryListNumber": {
+      "type": ["string", "null"],
+      "maxLength": 8
+    },
+    "techRecord_adrDetails_brakeDeclarationsSeen": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_brakeDeclarationIssuer": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_brakeEndurance": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_weight": {
+      "type": ["string", "null"],
+      "maxLength": 8
+    },
+    "techRecord_adrDetails_declarationsSeen": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_additionalNotes_guidanceNotes": {
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "techRecord_adrDetails_additionalNotes_number": {
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "techRecord_adrDetails_adrTypeApprovalNo": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_adrCertificateNotes": {
+      "type": ["string", "null"],
+      "maxLength": 1500
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
+      "type": ["string", "null"],
+      "maxLength": 70
+    },
+    "techRecord_adrDetails_tank_tankDetails_yearOfManufacture": {
+      "type": ["integer", "null"],
+      "maximum": 9999
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo": {
+      "type": ["string", "null"],
+      "maxLength": 50
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankTypeAppNo": {
+      "type": ["string", "null"],
+      "maxLength": 30
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankCode": {
+      "type": ["string", "null"],
+      "maxLength": 30
+    },
+    "techRecord_adrDetails_tank_tankDetails_specialProvisions": {
+      "type": ["string", "null"],
+      "maxLength": 1024
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2Type": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "../../../enums/tc2Types.ignore.json"
         }
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateApprovalNo": {
+      "type": ["string", "null"],
+      "maxLength": 70
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateExpiryDate": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc3Details_tc3Type": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "../../../enums/tc3Types.ignore.json"
+        }
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicNumber": {
+      "type": ["string", "null"],
+      "maxLength": 75
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicExpiryDate": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_substancesPermitted": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_statement": {
+      "type": ["string", "null"],
+      "maxLength": 1500
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo": {
+      "type": ["array", "null"],
+      "items": {
+        "type": ["string"]
+      }
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_productList": {
+      "type": ["string", "null"],
+      "maxLength": 1500
+    },
+    "techRecord_alterationMarker": {
+      "type": ["string", "null"]
+    },
+    "techRecord_applicantDetails_name": {
+      "type": ["string", "null"],
+      "maxLength": 150
+    },
+    "techRecord_applicantDetails_address1": {
+      "type": ["null", "string"],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_address2": {
+      "type": ["null", "string"],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_postTown": {
+      "type": ["null", "string"],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_address3": {
+      "type": ["null", "string"],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_postCode": {
+      "type": ["null", "string"],
+      "maxLength": 12
+    },
+    "techRecord_applicantDetails_telephoneNumber": {
+      "type": ["null", "string"],
+      "maxLength": 25
+    },
+    "techRecord_applicantDetails_emailAddress": {
+      "type": ["null", "string"],
+      "maxLength": 255
+    },
+    "techRecord_applicationId": {
+      "type": "string"
+    },
+    "techRecord_authIntoService": {
+      "type": ["string", "null"]
+    },
+    "techRecord_batchId": {
+      "type": ["string", "null"]
+    },
+    "techRecord_bodyType_code": {
+      "type": "string"
+    },
+    "techRecord_bodyType_description": {
+      "type": "string"
+    },
+    "techRecord_brakes_antilockBrakingSystem": {
+      "type": ["string", "null"]
+    },
+    "techRecord_brakes_dtpNumber": {
+      "type": ["string", "null"],
+      "maxLength": 6
+    },
+    "techRecord_brakes_loadSensingValve": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_centreOfRearmostAxleToRearOfTrl": {
+      "type": ["integer", "null"]
+    },
+    "techRecord_conversionRefNo": {
+      "type": ["string", "null"],
+      "maxLength": 10
+    },
+    "techRecord_couplingCenterToRearAxleMax": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_couplingCenterToRearAxleMin": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_couplingCenterToRearTrlMax": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_couplingCenterToRearTrlMin": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_couplingType": {
+      "type": ["string", "null"],
+      "maxLength": 1
+    },
+    "techRecord_departmentalVehicleMarker": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_dimensions_length": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_dimensions_width": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_euVehicleCategory": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/euVehicleCategory.ignore.json"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_firstUseDate": {
+      "type": ["string", "null"]
+    },
+    "techRecord_frameDescription": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/frameDescription.ignore.json"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_frontAxleToRearAxle": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_functionCode": {
+      "type": ["string", "null"],
+      "maxLength": 1
+    },
+    "techRecord_grossDesignWeight": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_grossEecWeight": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_grossGbWeight": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_letterOfAuth": {
+      "type": ["string", "null"]
+    },
+    "techRecord_make": {
+      "type": ["string", "null"],
+      "maxLength": 30
+    },
+    "techRecord_manufactureYear": {
+      "anyOf": [
+        {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9999
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_manufacturerDetails": {
+      "type": ["string", "null"]
+    },
+    "techRecord_maxLoadOnCoupling": {
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "maximum": 99999
+    },
+    "techRecord_microfilm": {
+      "type": ["string", "null"]
+    },
+    "techRecord_microfilm_microfilmDocumentType": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "../../../enums/microfilmDocumentType.ignore.json"
+        }
+      ]
+    },
+    "techRecord_microfilm_microfilmRollNumber": {
+      "type": ["string", "null"],
+      "maxLength": 5
+    },
+    "techRecord_microfilm_microfilmSerialNumber": {
+      "type": ["string", "null"],
+      "maxLength": 4
+    },
+    "techRecord_model": {
+      "type": ["string", "null"],
+      "maxLength": 30
+    },
+    "techRecord_noOfAxles": {
+      "anyOf": [
+        {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 99
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "plates": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "title": "TRL Plates",
+        "additionalProperties": false,
+        "properties": {
+          "techRecord_plateSerialNumber": {
+            "type": ["string", "null"],
+            "maxLength": 12
+          },
+          "techRecord_plateIssueDate": {
+            "type": ["string", "null"]
+          },
+          "techRecord_reasonForIssue": {
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "../../../enums/plateReasonForIssue.ignore.json"
+              }
+            ]
+          },
+          "techRecord_plateIssuer": {
+            "type": ["string", "null"],
+            "maxLength": 150
+          }
+        }
+      }
+    },
+    "techRecord_purchaserDetails_address1": {
+      "type": ["string", "null"]
+    },
+    "techRecord_purchaserDetails_address2": {
+      "type": ["string", "null"]
+    },
+    "techRecord_purchaserDetails_address3": {
+      "type": ["string", "null"]
+    },
+    "techRecord_purchaserDetails_emailAddress": {
+      "type": ["string", "null"]
+    },
+    "techRecord_purchaserDetails_faxNumber": {
+      "type": ["string", "null"]
+    },
+    "techRecord_purchaserDetails_name": {
+      "type": ["string", "null"]
+    },
+    "techRecord_purchaserDetails_postCode": {
+      "type": ["string", "null"]
+    },
+    "techRecord_purchaserDetails_postTown": {
+      "type": ["string", "null"]
+    },
+    "techRecord_purchaserDetails_purchaserNotes": {
+      "type": ["string", "null"]
+    },
+    "techRecord_purchaserDetails_telephoneNumber": {
+      "type": ["string", "null"]
+    },
+    "techRecord_lastUpdatedAt": {
+      "type": ["string", "null"]
+    },
+    "techRecord_lastUpdatedByName": {
+      "type": ["string", "null"]
+    },
+    "techRecord_lastUpdatedById": {
+      "type": ["string", "null"]
+    },
+    "techRecord_rearAxleToRearTrl": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_reasonForCreation": {
+      "type": "string"
+    },
+    "techRecord_regnDate": {
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^$"
+        },
+        {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_roadFriendly": {
+      "type": ["string", "null"]
+    },
+    "techRecord_statusCode": {
+      "$ref": "../../../enums/statusCode.ignore.json"
+    },
+    "techRecord_suspensionType": {
+      "type": ["string", "null"],
+      "maxLength": 1
+    },
+    "techRecord_tyreUseCode": {
+      "type": ["string", "null"],
+      "maxLength": 2
+    },
+    "techRecord_vehicleClass_code": {
+      "type": "string"
+    },
+    "techRecord_vehicleClass_description": {
+      "$ref": "../../../enums/vehicleClassDescription.ignore.json"
+    },
+    "techRecord_vehicleConfiguration": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/vehicleConfiguration.ignore.json"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_vehicleType": {
+      "const": "trl"
+    },
+    "trailerId": {
+      "type": "string"
+    },
+    "vin": {
+      "type": "string"
+    },
+    "techRecord_hiddenInVta": {
+      "type": "boolean"
+    },
+    "techRecord_updateType": {
+      "type": "string"
     }
+  }
 }

--- a/json-definitions/v3/tech-record/put/trl/testable/index.json
+++ b/json-definitions/v3/tech-record/put/trl/testable/index.json
@@ -1,947 +1,635 @@
 {
-    "title": "GET TRL Technical Record V3 Testable",
-    "type": "object",
-    "additionalProperties": false,
-    "required": [
-        "partialVin",
-        "techRecord_noOfAxles",
-        "systemNumber",
-        "trailerId",
-        "techRecord_reasonForCreation",
-        "techRecord_recordCompleteness",
-        "techRecord_statusCode",
-        "techRecord_vehicleClass_code",
-        "techRecord_vehicleClass_description",
-        "techRecord_vehicleType",
-        "techRecord_bodyType_description",
-        "techRecord_bodyType_code",
-        "techRecord_vehicleConfiguration",
-        "vin"
-    ],
-    "properties": {
-        "partialVin": {
-            "type": "string"
+  "title": "GET TRL Technical Record V3 Testable",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "partialVin",
+    "techRecord_noOfAxles",
+    "systemNumber",
+    "trailerId",
+    "techRecord_reasonForCreation",
+    "techRecord_recordCompleteness",
+    "techRecord_statusCode",
+    "techRecord_vehicleClass_code",
+    "techRecord_vehicleClass_description",
+    "techRecord_vehicleType",
+    "techRecord_bodyType_description",
+    "techRecord_bodyType_code",
+    "techRecord_vehicleConfiguration",
+    "vin"
+  ],
+  "properties": {
+    "partialVin": {
+      "type": "string"
+    },
+    "techRecord_adrDetails_vehicleDetails_type": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_vehicleDetails_approvalDate": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_permittedDangerousGoods": {
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "techRecord_adrDetails_compatibilityGroupJ": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_additionalExaminerNotes": {
+      "type": ["string", "null"],
+      "maxLength": 1024
+    },
+    "techRecord_adrDetails_applicantDetails_name": {
+      "type": ["string", "null"],
+      "maxLength": 150
+    },
+    "techRecord_adrDetails_applicantDetails_street": {
+      "type": ["string", "null"],
+      "maxLength": 150
+    },
+    "techRecord_adrDetails_applicantDetails_town": {
+      "type": ["string", "null"],
+      "maxLength": 100
+    },
+    "techRecord_adrDetails_applicantDetails_city": {
+      "type": ["string", "null"],
+      "maxLength": 100
+    },
+    "techRecord_adrDetails_applicantDetails_postcode": {
+      "type": ["string", "null"],
+      "maxLength": 25
+    },
+    "techRecord_adrDetails_memosApply": {
+      "type": ["array", "null"],
+      "items": {
+        "type": ["string"]
+      }
+    },
+    "techRecord_adrDetails_documents": {
+      "type": ["array", "null"],
+      "items": {
+        "type": ["string"]
+      }
+    },
+    "techRecord_adrDetails_listStatementApplicable": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_batteryListNumber": {
+      "type": ["string", "null"],
+      "maxLength": 8
+    },
+    "techRecord_adrDetails_brakeDeclarationsSeen": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_brakeDeclarationIssuer": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_brakeEndurance": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_weight": {
+      "type": ["string", "null"],
+      "maxLength": 8
+    },
+    "techRecord_adrDetails_declarationsSeen": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_adrDetails_additionalNotes_guidanceNotes": {
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "techRecord_adrDetails_additionalNotes_number": {
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "techRecord_adrDetails_adrTypeApprovalNo": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_adrCertificateNotes": {
+      "type": ["string", "null"],
+      "maxLength": 1500
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
+      "type": ["string", "null"],
+      "maxLength": 70
+    },
+    "techRecord_adrDetails_tank_tankDetails_yearOfManufacture": {
+      "type": ["integer", "null"],
+      "maximum": 9999
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo": {
+      "type": ["string", "null"],
+      "maxLength": 50
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankTypeAppNo": {
+      "type": ["string", "null"],
+      "maxLength": 30
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankCode": {
+      "type": ["string", "null"],
+      "maxLength": 30
+    },
+    "techRecord_adrDetails_tank_tankDetails_specialProvisions": {
+      "type": ["string", "null"],
+      "maxLength": 1024
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2Type": {
+      "anyOf": [
+        {
+          "type": "null"
         },
-        "techRecord_adrDetails_vehicleDetails_type": {
-            "type": [
-                "string",
-                "null"
-            ]
+        {
+          "$ref": "../../../enums/tc2Types.ignore.json"
+        }
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateApprovalNo": {
+      "type": ["string", "null"],
+      "maxLength": 70
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateExpiryDate": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc3Details_tc3Type": {
+      "anyOf": [
+        {
+          "type": "null"
         },
-        "techRecord_adrDetails_vehicleDetails_approvalDate": {
-            "type": [
-                "string",
-                "null"
-            ]
+        {
+          "$ref": "../../../enums/tc3Types.ignore.json"
+        }
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicNumber": {
+      "type": ["string", "null"],
+      "maxLength": 75
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicExpiryDate": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_substancesPermitted": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_statement": {
+      "type": ["string", "null"],
+      "maxLength": 1500
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo": {
+      "type": ["string", "null"]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo": {
+      "type": ["array", "null"],
+      "items": {
+        "type": ["string"]
+      }
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_productList": {
+      "type": ["string", "null"],
+      "maxLength": 1500
+    },
+    "techRecord_alterationMarker": {
+      "type": ["string", "null"]
+    },
+    "techRecord_applicantDetails_name": {
+      "type": ["string", "null"],
+      "maxLength": 150
+    },
+    "techRecord_applicantDetails_address1": {
+      "type": ["null", "string"],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_address2": {
+      "type": ["null", "string"],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_postTown": {
+      "type": ["null", "string"],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_address3": {
+      "type": ["null", "string"],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_postCode": {
+      "type": ["null", "string"],
+      "maxLength": 12
+    },
+    "techRecord_applicantDetails_telephoneNumber": {
+      "type": ["null", "string"],
+      "maxLength": 25
+    },
+    "techRecord_applicantDetails_emailAddress": {
+      "type": ["null", "string"],
+      "maxLength": 255
+    },
+    "techRecord_applicationId": {
+      "type": ["string", "null"]
+    },
+    "techRecord_authIntoService": {
+      "type": ["string", "null"]
+    },
+    "techRecord_batchId": {
+      "type": ["string", "null"]
+    },
+    "techRecord_bodyType_code": {
+      "type": "string"
+    },
+    "techRecord_bodyType_description": {
+      "type": "string"
+    },
+    "techRecord_brakes_antilockBrakingSystem": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_brakes_dtpNumber": {
+      "type": ["string", "null"],
+      "maxLength": 6
+    },
+    "techRecord_brakes_loadSensingValve": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_centreOfRearmostAxleToRearOfTrl": {
+      "type": ["integer", "null"]
+    },
+    "techRecord_conversionRefNo": {
+      "type": ["string", "null"],
+      "maxLength": 10
+    },
+    "techRecord_couplingCenterToRearAxleMax": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_couplingCenterToRearAxleMin": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_couplingCenterToRearTrlMax": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_couplingCenterToRearTrlMin": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_couplingType": {
+      "type": ["string", "null"],
+      "maxLength": 1
+    },
+    "techRecord_departmentalVehicleMarker": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_dimensions_length": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_dimensions_width": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_euVehicleCategory": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/euVehicleCategory.ignore.json"
         },
-        "techRecord_adrDetails_permittedDangerousGoods": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": "string"
-            }
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_firstUseDate": {
+      "type": ["string", "null"]
+    },
+    "techRecord_frameDescription": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/frameDescription.ignore.json"
         },
-        "techRecord_adrDetails_compatibilityGroupJ": {
-            "type": [
-                "boolean",
-                "null"
-            ]
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_frontAxleToRearAxle": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_functionCode": {
+      "type": ["string", "null"],
+      "maxLength": 1
+    },
+    "techRecord_grossDesignWeight": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_grossEecWeight": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_grossGbWeight": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_letterOfAuth": {
+      "type": ["string", "null"]
+    },
+    "techRecord_make": {
+      "type": ["string", "null"],
+      "maxLength": 30
+    },
+    "techRecord_manufactureYear": {
+      "anyOf": [
+        {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9999
         },
-        "techRecord_adrDetails_additionalExaminerNotes": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1024
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_manufacturerDetails": {
+      "type": ["string", "null"]
+    },
+    "techRecord_maxLoadOnCoupling": {
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "maximum": 99999
+    },
+    "techRecord_microfilm": {
+      "type": ["string", "null"]
+    },
+    "techRecord_microfilm_microfilmDocumentType": {
+      "anyOf": [
+        {
+          "type": "null"
         },
-        "techRecord_adrDetails_applicantDetails_name": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 150
+        {
+          "$ref": "../../../enums/microfilmDocumentType.ignore.json"
+        }
+      ]
+    },
+    "techRecord_microfilm_microfilmRollNumber": {
+      "type": ["string", "null"],
+      "maxLength": 5
+    },
+    "techRecord_microfilm_microfilmSerialNumber": {
+      "type": ["string", "null"],
+      "maxLength": 4
+    },
+    "techRecord_model": {
+      "type": ["string", "null"],
+      "maxLength": 30
+    },
+    "techRecord_noOfAxles": {
+      "anyOf": [
+        {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 99
         },
-        "techRecord_adrDetails_applicantDetails_street": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 150
-        },
-        "techRecord_adrDetails_applicantDetails_town": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 100
-        },
-        "techRecord_adrDetails_applicantDetails_city": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 100
-        },
-        "techRecord_adrDetails_applicantDetails_postcode": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 25
-        },
-        "techRecord_adrDetails_memosApply": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": [
-                    "string"
-                ]
-            }
-        },
-        "techRecord_adrDetails_documents": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": [
-                    "string"
-                ]
-            }
-        },
-        "techRecord_adrDetails_listStatementApplicable": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_batteryListNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 8
-        },
-        "techRecord_adrDetails_brakeDeclarationsSeen": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_brakeDeclarationIssuer": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_brakeEndurance": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_weight": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 8
-        },
-        "techRecord_adrDetails_declarationsSeen": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_additionalNotes_guidanceNotes": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": "string"
-            }
-        },
-        "techRecord_adrDetails_additionalNotes_number": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": "string"
-            }
-        },
-        "techRecord_adrDetails_adrTypeApprovalNo": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_adrCertificateNotes": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1500
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 70
-        },
-        "techRecord_adrDetails_tank_tankDetails_yearOfManufacture": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 9999
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 50
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankTypeAppNo": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 30
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankCode": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 30
-        },
-        "techRecord_adrDetails_tank_tankDetails_specialProvisions": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1024
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2Type": {
-            "anyOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "$ref": "../../../enums/tc2Types.ignore.json"
-                }
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateApprovalNo": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 70
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateExpiryDate": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc3Details_tc3Type": {
-            "anyOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "$ref": "../../../enums/tc3Types.ignore.json"
-                }
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 75
-        },
-        "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicExpiryDate": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_substancesPermitted": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_statement": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1500
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo": {
-            "type": [
-                "array",
-                "null"
-            ],
-            "items": {
-                "type": [
-                    "string"
-                ]
-            }
-        },
-        "techRecord_adrDetails_tank_tankDetails_tankStatement_productList": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1500
-        },
-        "techRecord_alterationMarker": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_applicantDetails_name": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 150
-        },
-        "techRecord_applicantDetails_address1": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 60
-        },
-        "techRecord_applicantDetails_address2": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 60
-        },
-        "techRecord_applicantDetails_postTown": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 60
-        },
-        "techRecord_applicantDetails_address3": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 60
-        },
-        "techRecord_applicantDetails_postCode": {
-            "type": [
-                "null",
-                "string"
-            ],
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "plates": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "title": "TRL Plates",
+        "additionalProperties": false,
+        "properties": {
+          "techRecord_plateSerialNumber": {
+            "type": ["string", "null"],
             "maxLength": 12
-        },
-        "techRecord_applicantDetails_telephoneNumber": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 25
-        },
-        "techRecord_applicantDetails_emailAddress": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "maxLength": 255
-        },
-        "techRecord_applicationId": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_authIntoService": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_batchId": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_bodyType_code": {
-            "type": "string"
-        },
-        "techRecord_bodyType_description": {
-            "type": "string"
-        },
-        "techRecord_brakes_antilockBrakingSystem": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_brakes_dtpNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 6
-        },
-        "techRecord_brakes_loadSensingValve": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_centreOfRearmostAxleToRearOfTrl": {
-            "type": [
-                "integer",
-                "null"
-            ]
-        },
-        "techRecord_conversionRefNo": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 10
-        },
-        "techRecord_couplingCenterToRearAxleMax": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_couplingCenterToRearAxleMin": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_couplingCenterToRearTrlMax": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_couplingCenterToRearTrlMin": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_couplingType": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1
-        },
-        "techRecord_departmentalVehicleMarker": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_dimensions_length": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_dimensions_width": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_euVehicleCategory": {
+          },
+          "techRecord_plateIssueDate": {
+            "type": ["string", "null"]
+          },
+          "techRecord_reasonForIssue": {
             "anyOf": [
-                {
-                    "$ref": "../../../enums/euVehicleCategory.ignore.json"
-                },
-                {
-                    "type": "null"
-                }
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "../../../enums/plateReasonForIssue.ignore.json"
+              }
             ]
+          },
+          "techRecord_plateIssuer": {
+            "type": ["string", "null"],
+            "maxLength": 150
+          }
+        }
+      }
+    },
+    "techRecord_purchaserDetails_address1": {
+      "type": ["string", "null"]
+    },
+    "techRecord_purchaserDetails_address2": {
+      "type": ["string", "null"]
+    },
+    "techRecord_purchaserDetails_address3": {
+      "type": ["string", "null"]
+    },
+    "techRecord_purchaserDetails_emailAddress": {
+      "type": ["string", "null"]
+    },
+    "techRecord_purchaserDetails_faxNumber": {
+      "type": ["string", "null"]
+    },
+    "techRecord_purchaserDetails_name": {
+      "type": ["string", "null"]
+    },
+    "techRecord_purchaserDetails_postCode": {
+      "type": ["string", "null"]
+    },
+    "techRecord_purchaserDetails_postTown": {
+      "type": ["string", "null"]
+    },
+    "techRecord_purchaserDetails_purchaserNotes": {
+      "type": ["string", "null"]
+    },
+    "techRecord_purchaserDetails_telephoneNumber": {
+      "type": ["string", "null"]
+    },
+    "techRecord_rearAxleToRearTrl": {
+      "type": ["integer", "null"],
+      "maximum": 99999,
+      "minimum": 0
+    },
+    "techRecord_reasonForCreation": {
+      "type": "string"
+    },
+    "techRecord_regnDate": {
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^$"
         },
-        "techRecord_firstUseDate": {
-            "type": [
-                "string",
-                "null"
-            ]
+        {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
         },
-        "techRecord_frameDescription": {
-            "anyOf": [
-                {
-                    "$ref": "../../../enums/frameDescription.ignore.json"
-                },
-                {
-                    "type": "null"
-                }
-            ]
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_roadFriendly": {
+      "type": ["boolean", "null"]
+    },
+    "techRecord_statusCode": {
+      "$ref": "../../../enums/statusCode.ignore.json"
+    },
+    "techRecord_suspensionType": {
+      "type": ["string", "null"],
+      "maxLength": 1
+    },
+    "techRecord_tyreUseCode": {
+      "type": ["string", "null"],
+      "maxLength": 2
+    },
+    "techRecord_vehicleClass_code": {
+      "type": "string"
+    },
+    "techRecord_vehicleClass_description": {
+      "$ref": "../../../enums/vehicleClassDescription.ignore.json"
+    },
+    "techRecord_vehicleConfiguration": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/vehicleConfiguration.ignore.json"
         },
-        "techRecord_frontAxleToRearAxle": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_functionCode": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1
-        },
-        "techRecord_grossDesignWeight": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_grossEecWeight": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_grossGbWeight": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_letterOfAuth": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_make": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 30
-        },
-        "techRecord_manufactureYear": {
-            "anyOf": [
-                {
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 9999
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        },
-        "techRecord_manufacturerDetails": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_maxLoadOnCoupling": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "minimum": 0,
-            "maximum": 99999
-        },
-        "techRecord_microfilm": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_microfilm_microfilmDocumentType": {
-            "anyOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "$ref": "../../../enums/microfilmDocumentType.ignore.json"
-                }
-            ]
-        },
-        "techRecord_microfilm_microfilmRollNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 5
-        },
-        "techRecord_microfilm_microfilmSerialNumber": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 4
-        },
-        "techRecord_model": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 30
-        },
-        "techRecord_noOfAxles": {
-            "anyOf": [
-                {
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 99
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        },
-        "plates": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "title": "TRL Plates",
-                "additionalProperties": false,
-                "properties": {
-                    "techRecord_plateSerialNumber": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "maxLength": 12
-                    },
-                    "techRecord_plateIssueDate": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
-                    "techRecord_reasonForIssue": {
-                        "anyOf": [
-                            {
-                                "type": "null"
-                            },
-                            {
-                                "$ref": "../../../enums/plateReasonForIssue.ignore.json"
-                            }
-                        ]
-                    },
-                    "techRecord_plateIssuer": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "maxLength": 150
-                    }
-                }
-            }
-        },
-        "techRecord_purchaserDetails_address1": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_purchaserDetails_address2": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_purchaserDetails_address3": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_purchaserDetails_emailAddress": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_purchaserDetails_faxNumber": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_purchaserDetails_name": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_purchaserDetails_postCode": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_purchaserDetails_postTown": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_purchaserDetails_purchaserNotes": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_purchaserDetails_telephoneNumber": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_rearAxleToRearTrl": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "maximum": 99999,
-            "minimum": 0
-        },
-        "techRecord_reasonForCreation": {
-            "type": "string"
-        },
-        "techRecord_regnDate": {
-            "anyOf": [
-                {
-                    "type": "string",
-                    "pattern": "^$"
-                },
-                {
-                    "type": "string",
-                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        },
-        "techRecord_roadFriendly": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "techRecord_statusCode": {
-            "$ref": "../../../enums/statusCode.ignore.json"
-        },
-        "techRecord_suspensionType": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1
-        },
-        "techRecord_tyreUseCode": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 2
-        },
-        "techRecord_vehicleClass_code": {
-            "type": "string"
-        },
-        "techRecord_vehicleClass_description": {
-            "$ref": "../../../enums/vehicleClassDescription.ignore.json"
-        },
-        "techRecord_vehicleConfiguration": {
-            "anyOf": [
-                {
-                    "$ref": "../../../enums/vehicleConfiguration.ignore.json"
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        },
-        "techRecord_vehicleType": {
-            "const": "trl"
-        },
-        "trailerId": {
-            "type": "string"
-        },
-        "vin": {
-            "type": "string"
-        },
-        "axles": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "title": "PSV Axles",
-                "additionalProperties": false,
-                "properties": {
-                    "techRecord_parkingBrakeMrk": {
-                        "type": [
-                            "boolean",
-                            "null"
-                        ]
-                    },
-                    "techRecord_axleNumber": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ]
-                    }
-                }
-            }
-        },
-        "techRecord_brakes": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "brakeActuator": {
-                        "type": "integer",
-                        "minimum": 0,
-                        "maximum": 999
-                    },
-                    "leverLength": {
-                        "type": "integer",
-                        "minimum": 0,
-                        "maximum": 999
-                    },
-                    "springBrakeParking": {
-                        "type": "boolean"
-                    }
-                }
-            }
-        },
-        "techRecord_weights_gbWeight": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "minimum": 0,
-            "maximum": 99999
-        },
-        "techRecord_weights_designWeight": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "minimum": 0,
-            "maximum": 99999
-        },
-        "techRecord_weights_ladenWeight": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "minimum": 0,
-            "maximum": 99999
-        },
-        "techRecord_weights_kerbWeight": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "minimum": 0,
-            "maximum": 99999
-        },
-        "techRecord_tyres_tyreCode": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "minimum": 0,
-            "maximum": 99999
-        },
-        "techRecord_tyres_tyreSize": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 12
-        },
-        "techRecord_tyres_plyRating": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "techRecord_tyres_fitmentCode": {
-            "anyOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "$ref": "../../../enums/fitmentCode.ignore.json"
-                }
-            ]
-        },
-        "techRecord_tyres_dataTrAxles": {
-            "type": [
-                "null",
-                "integer"
-            ],
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_vehicleType": {
+      "const": "trl"
+    },
+    "trailerId": {
+      "type": "string"
+    },
+    "vin": {
+      "type": "string"
+    },
+    "axles": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "title": "PSV Axles",
+        "additionalProperties": false,
+        "properties": {
+          "techRecord_parkingBrakeMrk": {
+            "type": ["boolean", "null"]
+          },
+          "techRecord_axleNumber": {
+            "type": ["integer", "null"]
+          }
+        }
+      }
+    },
+    "techRecord_brakes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "brakeActuator": {
+            "type": "integer",
             "minimum": 0,
             "maximum": 999
-        },
-        "techRecord_tyres_speedCategorySymbol": {
-            "anyOf": [
-                {
-                    "$ref": "../../../enums/speedCategorySymbol.ignore.json"
-                },
-                {
-                    "type": "null"
-                }
-            ]
+          },
+          "leverLength": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 999
+          },
+          "springBrakeParking": {
+            "type": "boolean"
+          }
         }
+      }
+    },
+    "techRecord_weights_gbWeight": {
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "maximum": 99999
+    },
+    "techRecord_weights_designWeight": {
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "maximum": 99999
+    },
+    "techRecord_weights_ladenWeight": {
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "maximum": 99999
+    },
+    "techRecord_weights_kerbWeight": {
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "maximum": 99999
+    },
+    "techRecord_tyres_tyreCode": {
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "maximum": 99999
+    },
+    "techRecord_tyres_tyreSize": {
+      "type": ["string", "null"],
+      "maxLength": 12
+    },
+    "techRecord_tyres_plyRating": {
+      "type": ["string", "null"]
+    },
+    "techRecord_tyres_fitmentCode": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "../../../enums/fitmentCode.ignore.json"
+        }
+      ]
+    },
+    "techRecord_tyres_dataTrAxles": {
+      "type": ["null", "integer"],
+      "minimum": 0,
+      "maximum": 999
+    },
+    "techRecord_tyres_speedCategorySymbol": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/speedCategorySymbol.ignore.json"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_hiddenInVta": {
+      "type": "boolean"
+    },
+    "techRecord_updateType": {
+      "type": "string"
     }
+  }
 }

--- a/json-schemas/v3/tech-record/get/car/complete/index.json
+++ b/json-schemas/v3/tech-record/get/car/complete/index.json
@@ -212,6 +212,12 @@
 					"w"
 				]
 			}
+		},
+		"techRecord_hiddenInVta": {
+			"type": "boolean"
+		},
+		"techRecord_updateType": {
+			"type": "string"
 		}
 	}
 }

--- a/json-schemas/v3/tech-record/get/car/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/car/skeleton/index.json
@@ -191,6 +191,12 @@
 		},
 		"vin": {
 			"type": "string"
+		},
+		"techRecord_hiddenInVta": {
+			"type": "boolean"
+		},
+		"techRecord_updateType": {
+			"type": "string"
 		}
 	}
 }

--- a/json-schemas/v3/tech-record/get/hgv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/complete/index.json
@@ -1046,6 +1046,12 @@
 		},
 		"vin": {
 			"type": "string"
+		},
+		"techRecord_hiddenInVta": {
+			"type": "boolean"
+		},
+		"techRecord_updateType": {
+			"type": "string"
 		}
 	}
 }

--- a/json-schemas/v3/tech-record/get/hgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/skeleton/index.json
@@ -1119,6 +1119,12 @@
 		},
 		"vin": {
 			"type": "string"
+		},
+		"techRecord_hiddenInVta": {
+			"type": "boolean"
+		},
+		"techRecord_updateType": {
+			"type": "string"
 		}
 	}
 }

--- a/json-schemas/v3/tech-record/get/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/testable/index.json
@@ -1114,6 +1114,12 @@
 		},
 		"vin": {
 			"type": "string"
+		},
+		"techRecord_hiddenInVta": {
+			"type": "boolean"
+		},
+		"techRecord_updateType": {
+			"type": "string"
 		}
 	}
 }

--- a/json-schemas/v3/tech-record/get/lgv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/lgv/complete/index.json
@@ -220,6 +220,12 @@
 							"w"
 						]
 					}
+				},
+				"techRecord_hiddenInVta": {
+					"type": "boolean"
+				},
+				"techRecord_updateType": {
+					"type": "string"
 				}
 			}
 		}

--- a/json-schemas/v3/tech-record/get/lgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/lgv/skeleton/index.json
@@ -196,6 +196,12 @@
 				},
 				"vin": {
 					"type": "string"
+				},
+				"techRecord_hiddenInVta": {
+					"type": "boolean"
+				},
+				"techRecord_updateType": {
+					"type": "string"
 				}
 			}
 		}

--- a/json-schemas/v3/tech-record/get/motorcycle/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/motorcycle/skeleton/index.json
@@ -196,6 +196,12 @@
 				},
 				"vin": {
 					"type": "string"
+				},
+				"techRecord_hiddenInVta": {
+					"type": "boolean"
+				},
+				"techRecord_updateType": {
+					"type": "string"
 				}
 			}
 		}

--- a/json-schemas/v3/tech-record/get/psv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/psv/complete/index.json
@@ -1022,6 +1022,9 @@
 			"type": [
 				"string"
 			]
+		},
+		"techRecord_updateType": {
+			"type": "string"
 		}
 	}
 }

--- a/json-schemas/v3/tech-record/get/psv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/psv/skeleton/index.json
@@ -1115,6 +1115,9 @@
 			"items": {
 				"type": "string"
 			}
+		},
+		"techRecord_updateType": {
+			"type": "string"
 		}
 	}
 }

--- a/json-schemas/v3/tech-record/get/psv/testable/index.json
+++ b/json-schemas/v3/tech-record/get/psv/testable/index.json
@@ -1092,6 +1092,9 @@
 			"items": {
 				"type": "string"
 			}
+		},
+		"techRecord_updateType": {
+			"type": "string"
 		}
 	}
 }

--- a/json-schemas/v3/tech-record/get/trl/complete/index.json
+++ b/json-schemas/v3/tech-record/get/trl/complete/index.json
@@ -1299,6 +1299,12 @@
 								"type": "null"
 							}
 						]
+					},
+					"techRecord_hiddenInVta": {
+						"type": "boolean"
+					},
+					"techRecord_updateType": {
+						"type": "string"
 					}
 				}
 			}

--- a/json-schemas/v3/tech-record/get/trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/trl/skeleton/index.json
@@ -997,6 +997,12 @@
 		},
 		"vin": {
 			"type": "string"
+		},
+		"techRecord_hiddenInVta": {
+			"type": "boolean"
+		},
+		"techRecord_updateType": {
+			"type": "string"
 		}
 	}
 }

--- a/json-schemas/v3/tech-record/get/trl/testable/index.json
+++ b/json-schemas/v3/tech-record/get/trl/testable/index.json
@@ -1150,6 +1150,12 @@
 					"type": "null"
 				}
 			]
+		},
+		"techRecord_hiddenInVta": {
+			"type": "boolean"
+		},
+		"techRecord_updateType": {
+			"type": "string"
 		}
 	}
 }

--- a/json-schemas/v3/tech-record/put/car/complete/index.json
+++ b/json-schemas/v3/tech-record/put/car/complete/index.json
@@ -83,6 +83,12 @@
 					"w"
 				]
 			}
+		},
+		"techRecord_hiddenInVta": {
+			"type": "boolean"
+		},
+		"techRecord_updateType": {
+			"type": "string"
 		}
 	}
 }

--- a/json-schemas/v3/tech-record/put/car/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/car/skeleton/index.json
@@ -63,6 +63,12 @@
 				"integer",
 				"null"
 			]
+		},
+		"techRecord_hiddenInVta": {
+			"type": "boolean"
+		},
+		"techRecord_updateType": {
+			"type": "string"
 		}
 	}
 }

--- a/json-schemas/v3/tech-record/put/hgv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/complete/index.json
@@ -1004,6 +1004,12 @@
 		},
 		"vin": {
 			"type": "string"
+		},
+		"techRecord_hiddenInVta": {
+			"type": "boolean"
+		},
+		"techRecord_updateType": {
+			"type": "string"
 		}
 	}
 }

--- a/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
@@ -1077,6 +1077,12 @@
 		},
 		"vin": {
 			"type": "string"
+		},
+		"techRecord_hiddenInVta": {
+			"type": "boolean"
+		},
+		"techRecord_updateType": {
+			"type": "string"
 		}
 	}
 }

--- a/json-schemas/v3/tech-record/put/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/testable/index.json
@@ -1072,6 +1072,12 @@
 		},
 		"vin": {
 			"type": "string"
+		},
+		"techRecord_hiddenInVta": {
+			"type": "boolean"
+		},
+		"techRecord_updateType": {
+			"type": "string"
 		}
 	}
 }

--- a/json-schemas/v3/tech-record/put/lgv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/lgv/complete/index.json
@@ -91,6 +91,12 @@
 							"w"
 						]
 					}
+				},
+				"techRecord_hiddenInVta": {
+					"type": "boolean"
+				},
+				"techRecord_updateType": {
+					"type": "string"
 				}
 			}
 		}

--- a/json-schemas/v3/tech-record/put/lgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/lgv/skeleton/index.json
@@ -68,6 +68,12 @@
 						"integer",
 						"null"
 					]
+				},
+				"techRecord_hiddenInVta": {
+					"type": "boolean"
+				},
+				"techRecord_updateType": {
+					"type": "string"
 				}
 			}
 		}

--- a/json-schemas/v3/tech-record/put/psv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/psv/complete/index.json
@@ -1019,6 +1019,9 @@
 			"items": {
 				"type": "string"
 			}
+		},
+		"techRecord_updateType": {
+			"type": "string"
 		}
 	}
 }

--- a/json-schemas/v3/tech-record/put/psv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/psv/skeleton/index.json
@@ -1107,6 +1107,9 @@
 			"items": {
 				"type": "string"
 			}
+		},
+		"techRecord_updateType": {
+			"type": "string"
 		}
 	}
 }

--- a/json-schemas/v3/tech-record/put/psv/testable/index.json
+++ b/json-schemas/v3/tech-record/put/psv/testable/index.json
@@ -1087,6 +1087,9 @@
 			"items": {
 				"type": "string"
 			}
+		},
+		"techRecord_updateType": {
+			"type": "string"
 		}
 	}
 }

--- a/json-schemas/v3/tech-record/put/trl/complete/index.json
+++ b/json-schemas/v3/tech-record/put/trl/complete/index.json
@@ -1257,6 +1257,12 @@
 								"type": "null"
 							}
 						]
+					},
+					"techRecord_hiddenInVta": {
+						"type": "boolean"
+					},
+					"techRecord_updateType": {
+						"type": "string"
 					}
 				}
 			}

--- a/json-schemas/v3/tech-record/put/trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/trl/skeleton/index.json
@@ -973,6 +973,12 @@
 		},
 		"vin": {
 			"type": "string"
+		},
+		"techRecord_hiddenInVta": {
+			"type": "boolean"
+		},
+		"techRecord_updateType": {
+			"type": "string"
 		}
 	}
 }

--- a/json-schemas/v3/tech-record/put/trl/testable/index.json
+++ b/json-schemas/v3/tech-record/put/trl/testable/index.json
@@ -1110,6 +1110,12 @@
 					"type": "null"
 				}
 			]
+		},
+		"techRecord_hiddenInVta": {
+			"type": "boolean"
+		},
+		"techRecord_updateType": {
+			"type": "string"
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "2.0.19",
+  "version": "2.0.20",
   "description": "type definitions for cvs vta application",
   "main": "index.js",
   "repository": {

--- a/types/v3/tech-record/get/car/complete/index.d.ts
+++ b/types/v3/tech-record/get/car/complete/index.d.ts
@@ -71,4 +71,6 @@ export interface TechRecordCompleteCarSchema {
   techRecord_vehicleType?: VehicleType;
   vin: string;
   vehicleSubclass: VehicleSubclass;
+  techRecord_hiddenInVta?: boolean;
+  techRecord_updateType?: string;
 }

--- a/types/v3/tech-record/get/car/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/car/skeleton/index.d.ts
@@ -69,4 +69,6 @@ export interface TechRecordSkeletonCarSchema {
   techRecord_vehicleConfiguration?: VehicleConfiguration;
   techRecord_vehicleType?: VehicleType;
   vin: string;
+  techRecord_hiddenInVta?: boolean;
+  techRecord_updateType?: string;
 }

--- a/types/v3/tech-record/get/hgv/complete/index.d.ts
+++ b/types/v3/tech-record/get/hgv/complete/index.d.ts
@@ -264,6 +264,8 @@ export interface GETHGVTechnicalRecordV3Complete {
   techRecord_vehicleType: "hgv";
   primaryVrm: string;
   vin: string;
+  techRecord_hiddenInVta?: boolean;
+  techRecord_updateType?: string;
 }
 export interface HGVAxles {
   techRecord_parkingBrakeMrk?: boolean;

--- a/types/v3/tech-record/get/hgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/hgv/skeleton/index.d.ts
@@ -264,6 +264,8 @@ export interface GETHGVTechnicalRecordV3Skeleton {
   techRecord_vehicleType: "hgv";
   primaryVrm: string;
   vin: string;
+  techRecord_hiddenInVta?: boolean;
+  techRecord_updateType?: string;
 }
 export interface HGVAxles {
   techRecord_parkingBrakeMrk?: boolean | null;

--- a/types/v3/tech-record/get/hgv/testable/index.d.ts
+++ b/types/v3/tech-record/get/hgv/testable/index.d.ts
@@ -264,6 +264,8 @@ export interface GETHGVTechnicalRecordV3Testable {
   techRecord_vehicleType: "hgv";
   primaryVrm: string;
   vin: string;
+  techRecord_hiddenInVta?: boolean;
+  techRecord_updateType?: string;
 }
 export interface HGVAxles {
   techRecord_parkingBrakeMrk?: boolean | null;

--- a/types/v3/tech-record/get/lgv/complete/index.d.ts
+++ b/types/v3/tech-record/get/lgv/complete/index.d.ts
@@ -72,4 +72,6 @@ export interface TechRecordCompleteCarSchema1 {
   techRecord_vehicleType?: VehicleType;
   vin: string;
   vehicleSubclass: VehicleSubclass;
+  techRecord_hiddenInVta?: boolean;
+  techRecord_updateType?: string;
 }

--- a/types/v3/tech-record/get/lgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/lgv/skeleton/index.d.ts
@@ -70,4 +70,6 @@ export interface TechRecordSkeletonCarSchema1 {
   techRecord_vehicleConfiguration?: VehicleConfiguration;
   techRecord_vehicleType?: VehicleType;
   vin: string;
+  techRecord_hiddenInVta?: boolean;
+  techRecord_updateType?: string;
 }

--- a/types/v3/tech-record/get/motorcycle/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/motorcycle/skeleton/index.d.ts
@@ -70,4 +70,6 @@ export interface TechRecordSkeletonCarSchema1 {
   techRecord_vehicleConfiguration?: VehicleConfiguration;
   techRecord_vehicleType?: VehicleType;
   vin: string;
+  techRecord_hiddenInVta?: boolean;
+  techRecord_updateType?: string;
 }

--- a/types/v3/tech-record/get/psv/complete/index.d.ts
+++ b/types/v3/tech-record/get/psv/complete/index.d.ts
@@ -298,6 +298,7 @@ export interface GETPSVTechnicalRecordV3Complete {
   techRecord_microfilmSerialNumber?: string | null;
   techRecord_brakeCode?: string | null;
   createdTimestamp?: string;
+  techRecord_updateType?: string;
 }
 export interface PSVAxlesComplete {
   techRecord_parkingBrakeMrk: boolean;

--- a/types/v3/tech-record/get/psv/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/psv/skeleton/index.d.ts
@@ -296,6 +296,7 @@ export interface GETPSVTechnicalRecordV3Skeleton {
   createdTimestamp: string;
   techRecord_applicationId?: string;
   secondaryVrms?: string[];
+  techRecord_updateType?: string;
 }
 export interface PSVAxles {
   techRecord_parkingBrakeMrk?: boolean | null;

--- a/types/v3/tech-record/get/psv/testable/index.d.ts
+++ b/types/v3/tech-record/get/psv/testable/index.d.ts
@@ -296,6 +296,7 @@ export interface GETPSVTechnicalRecordV3Testable {
   createdTimestamp?: string;
   techRecord_applicationId?: string;
   secondaryVrms?: string[];
+  techRecord_updateType?: string;
 }
 export interface PSVAxles {
   techRecord_parkingBrakeMrk?: boolean | null;

--- a/types/v3/tech-record/get/trl/complete/index.d.ts
+++ b/types/v3/tech-record/get/trl/complete/index.d.ts
@@ -347,4 +347,6 @@ export interface PSVAxles {
   techRecord_tyres_fitmentCode?: null | FitmentCode;
   techRecord_tyres_dataTrAxles?: null | number;
   techRecord_tyres_speedCategorySymbol?: SpeedCategorySymbol | null;
+  techRecord_hiddenInVta?: boolean;
+  techRecord_updateType?: string;
 }

--- a/types/v3/tech-record/get/trl/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/trl/skeleton/index.d.ts
@@ -247,6 +247,8 @@ export interface GETTRLTechnicalRecordV3Skeleton {
   techRecord_vehicleType: "trl";
   trailerId: string;
   vin: string;
+  techRecord_hiddenInVta?: boolean;
+  techRecord_updateType?: string;
 }
 export interface TRLPlates {
   techRecord_plateSerialNumber?: string | null;

--- a/types/v3/tech-record/get/trl/testable/index.d.ts
+++ b/types/v3/tech-record/get/trl/testable/index.d.ts
@@ -281,6 +281,8 @@ export interface GETTRLTechnicalRecordV3Testable {
   techRecord_tyres_fitmentCode?: null | FitmentCode;
   techRecord_tyres_dataTrAxles?: null | number;
   techRecord_tyres_speedCategorySymbol?: SpeedCategorySymbol | null;
+  techRecord_hiddenInVta?: boolean;
+  techRecord_updateType?: string;
 }
 export interface TRLPlates {
   techRecord_plateSerialNumber?: string | null;

--- a/types/v3/tech-record/put/car/complete/index.d.ts
+++ b/types/v3/tech-record/put/car/complete/index.d.ts
@@ -20,5 +20,7 @@ export interface TechRecordPUTRequestCompleteCarSchema {
   techRecord_manufactureYear?: string | null;
   techRecord_noOfAxles?: number | null;
   vehicleSubclass: VehicleSubclass;
+  techRecord_hiddenInVta?: boolean;
+  techRecord_updateType?: string;
   [k: string]: unknown;
 }

--- a/types/v3/tech-record/put/car/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/car/skeleton/index.d.ts
@@ -18,5 +18,7 @@ export interface TechRecordPUTRequestSkeletonCarSchema {
   techRecord_regnDate?: string | null;
   techRecord_manufactureYear?: string | null;
   techRecord_noOfAxles?: number | null;
+  techRecord_hiddenInVta?: boolean;
+  techRecord_updateType?: string;
   [k: string]: unknown;
 }

--- a/types/v3/tech-record/put/hgv/complete/index.d.ts
+++ b/types/v3/tech-record/put/hgv/complete/index.d.ts
@@ -255,6 +255,8 @@ export interface PUTHGVTechnicalRecordV3Complete {
   techRecord_vehicleType: "hgv";
   primaryVrm: string;
   vin: string;
+  techRecord_hiddenInVta?: boolean;
+  techRecord_updateType?: string;
 }
 export interface HGVAxles {
   techRecord_parkingBrakeMrk?: boolean;

--- a/types/v3/tech-record/put/hgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/hgv/skeleton/index.d.ts
@@ -255,6 +255,8 @@ export interface PUTHGVTechnicalRecordV3Skeleton {
   techRecord_vehicleType: "hgv";
   primaryVrm: string;
   vin: string;
+  techRecord_hiddenInVta?: boolean;
+  techRecord_updateType?: string;
 }
 export interface HGVAxles {
   techRecord_parkingBrakeMrk?: boolean | null;

--- a/types/v3/tech-record/put/hgv/testable/index.d.ts
+++ b/types/v3/tech-record/put/hgv/testable/index.d.ts
@@ -255,6 +255,8 @@ export interface PUTHGVTechnicalRecordV3Testable {
   techRecord_vehicleType: "hgv";
   primaryVrm: string;
   vin: string;
+  techRecord_hiddenInVta?: boolean;
+  techRecord_updateType?: string;
 }
 export interface HGVAxles {
   techRecord_parkingBrakeMrk?: boolean | null;

--- a/types/v3/tech-record/put/lgv/complete/index.d.ts
+++ b/types/v3/tech-record/put/lgv/complete/index.d.ts
@@ -21,5 +21,7 @@ export interface TechRecordPUTRequestCompleteCarSchema {
   techRecord_manufactureYear?: string | null;
   techRecord_noOfAxles?: number | null;
   vehicleSubclass: VehicleSubclass;
+  techRecord_hiddenInVta?: boolean;
+  techRecord_updateType?: string;
   [k: string]: unknown;
 }

--- a/types/v3/tech-record/put/lgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/lgv/skeleton/index.d.ts
@@ -19,5 +19,7 @@ export interface TechRecordPUTRequestSkeletonCarSchema {
   techRecord_regnDate?: string | null;
   techRecord_manufactureYear?: string | null;
   techRecord_noOfAxles?: number | null;
+  techRecord_hiddenInVta?: boolean;
+  techRecord_updateType?: string;
   [k: string]: unknown;
 }

--- a/types/v3/tech-record/put/psv/complete/index.d.ts
+++ b/types/v3/tech-record/put/psv/complete/index.d.ts
@@ -298,6 +298,7 @@ export interface POSTPSVTechnicalRecordV3Complete {
   techRecord_brakeCode?: string | null;
   createdTimestamp?: string;
   secondaryVrms?: string[];
+  techRecord_updateType?: string;
 }
 export interface PSVAxlesComplete {
   techRecord_parkingBrakeMrk: boolean;

--- a/types/v3/tech-record/put/psv/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/psv/skeleton/index.d.ts
@@ -296,6 +296,7 @@ export interface POSTPSVTechnicalRecordV3Skeleton {
   createdTimestamp?: string;
   techRecord_applicationId?: string;
   secondaryVrms?: string[];
+  techRecord_updateType?: string;
 }
 export interface PSVAxles {
   techRecord_parkingBrakeMrk?: boolean | null;

--- a/types/v3/tech-record/put/psv/testable/index.d.ts
+++ b/types/v3/tech-record/put/psv/testable/index.d.ts
@@ -296,6 +296,7 @@ export interface POSTPSVTechnicalRecordV3Testable {
   createdTimestamp?: string;
   techRecord_applicationId?: string;
   secondaryVrms?: string[];
+  techRecord_updateType?: string;
 }
 export interface PSVAxles {
   techRecord_parkingBrakeMrk?: boolean | null;

--- a/types/v3/tech-record/put/trl/complete/index.d.ts
+++ b/types/v3/tech-record/put/trl/complete/index.d.ts
@@ -338,4 +338,6 @@ export interface PSVAxles {
   techRecord_tyres_fitmentCode?: null | FitmentCode;
   techRecord_tyres_dataTrAxles?: null | number;
   techRecord_tyres_speedCategorySymbol?: SpeedCategorySymbol | null;
+  techRecord_hiddenInVta?: boolean;
+  techRecord_updateType?: string;
 }

--- a/types/v3/tech-record/put/trl/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/trl/skeleton/index.d.ts
@@ -241,6 +241,8 @@ export interface GETTRLTechnicalRecordV3Skeleton {
   techRecord_vehicleType: "trl";
   trailerId: string;
   vin: string;
+  techRecord_hiddenInVta?: boolean;
+  techRecord_updateType?: string;
 }
 export interface TRLPlates {
   techRecord_plateSerialNumber?: string | null;

--- a/types/v3/tech-record/put/trl/testable/index.d.ts
+++ b/types/v3/tech-record/put/trl/testable/index.d.ts
@@ -272,6 +272,8 @@ export interface GETTRLTechnicalRecordV3Testable {
   techRecord_tyres_fitmentCode?: null | FitmentCode;
   techRecord_tyres_dataTrAxles?: null | number;
   techRecord_tyres_speedCategorySymbol?: SpeedCategorySymbol | null;
+  techRecord_hiddenInVta?: boolean;
+  techRecord_updateType?: string;
 }
 export interface TRLPlates {
   techRecord_plateSerialNumber?: string | null;


### PR DESCRIPTION
## Ticket title

Adds missing hidden in vta and update type fields.

Resolves https://github.com/dvsa/cvs-type-definitions/issues/21 
Resolves https://github.com/dvsa/cvs-type-definitions/issues/18

Include summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`.

## Changelog

- Add `updateType` field
- Add `hiddenInVta` field

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
