### PR TITLE
patch(*): add notes to light vehicles

### DIFF
--- a/json-definitions/v3/tech-record/get/car/complete/index.json
+++ b/json-definitions/v3/tech-record/get/car/complete/index.json
@@ -2,42 +2,73 @@
   "title": "Tech Record Complete Car Schema",
   "type": "object",
   "additionalProperties": false,
-  "required": ["vehicleSubclass", "createdTimestamp", "systemNumber", "vin"],
+  "required": [
+    "vehicleSubclass",
+    "createdTimestamp",
+    "systemNumber",
+    "vin"
+  ],
   "properties": {
     "techRecord_applicantDetails_name": {
-      "type": ["string", "null"],
+      "type": [
+        "string",
+        "null"
+      ],
       "maxLength": 150
     },
     "techRecord_applicantDetails_address1": {
-      "type": ["null", "string"],
+      "type": [
+        "null",
+        "string"
+      ],
       "maxLength": 60
     },
     "techRecord_applicantDetails_address2": {
-      "type": ["null", "string"],
+      "type": [
+        "null",
+        "string"
+      ],
       "maxLength": 60
     },
     "techRecord_applicantDetails_postTown": {
-      "type": ["null", "string"],
+      "type": [
+        "null",
+        "string"
+      ],
       "maxLength": 60
     },
     "techRecord_applicantDetails_address3": {
-      "type": ["null", "string"],
+      "type": [
+        "null",
+        "string"
+      ],
       "maxLength": 60
     },
     "techRecord_applicantDetails_postCode": {
-      "type": ["null", "string"],
+      "type": [
+        "null",
+        "string"
+      ],
       "maxLength": 12
     },
     "techRecord_applicantDetails_telephoneNumber": {
-      "type": ["null", "string"],
+      "type": [
+        "null",
+        "string"
+      ],
       "maxLength": 25
     },
     "techRecord_applicantDetails_emailAddress": {
-      "type": ["null", "string"],
+      "type": [
+        "null",
+        "string"
+      ],
       "maxLength": 255
     },
     "createdTimestamp": {
-      "type": ["string"]
+      "type": [
+        "string"
+      ]
     },
     "partialVin": {
       "type": "string"
@@ -61,16 +92,28 @@
       "$ref": "../../../enums/euVehicleCategory.ignore.json"
     },
     "techRecord_lastUpdatedAt": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "techRecord_lastUpdatedById": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "techRecord_lastUpdatedByName": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "techRecord_manufactureYear": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "techRecord_recordCompleteness": {
       "type": "string"
@@ -78,11 +121,17 @@
     "techRecord_noOfAxles": {
       "type": "integer"
     },
+    "techRecord_notes": {
+      "type": "string"
+    },
     "techRecord_reasonForCreation": {
       "type": "string"
     },
     "techRecord_regnDate": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "techRecord_statusCode": {
       "$ref": "../../../enums/statusCode.ignore.json"

--- a/json-definitions/v3/tech-record/get/car/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/car/skeleton/index.json
@@ -2,42 +2,72 @@
   "title": "Tech Record Skeleton Car Schema",
   "type": "object",
   "additionalProperties": false,
-  "required": ["createdTimestamp", "systemNumber", "vin"],
+  "required": [
+    "createdTimestamp",
+    "systemNumber",
+    "vin"
+  ],
   "properties": {
     "techRecord_applicantDetails_name": {
-      "type": ["string", "null"],
+      "type": [
+        "string",
+        "null"
+      ],
       "maxLength": 150
     },
     "techRecord_applicantDetails_address1": {
-      "type": ["null", "string"],
+      "type": [
+        "null",
+        "string"
+      ],
       "maxLength": 60
     },
     "techRecord_applicantDetails_address2": {
-      "type": ["null", "string"],
+      "type": [
+        "null",
+        "string"
+      ],
       "maxLength": 60
     },
     "techRecord_applicantDetails_postTown": {
-      "type": ["null", "string"],
+      "type": [
+        "null",
+        "string"
+      ],
       "maxLength": 60
     },
     "techRecord_applicantDetails_address3": {
-      "type": ["null", "string"],
+      "type": [
+        "null",
+        "string"
+      ],
       "maxLength": 60
     },
     "techRecord_applicantDetails_postCode": {
-      "type": ["null", "string"],
+      "type": [
+        "null",
+        "string"
+      ],
       "maxLength": 12
     },
     "techRecord_applicantDetails_telephoneNumber": {
-      "type": ["null", "string"],
+      "type": [
+        "null",
+        "string"
+      ],
       "maxLength": 25
     },
     "techRecord_applicantDetails_emailAddress": {
-      "type": ["null", "string"],
+      "type": [
+        "null",
+        "string"
+      ],
       "maxLength": 255
     },
     "createdTimestamp": {
-      "type": ["string"]
+      "type": [
+        "string"
+      ]
     },
     "partialVin": {
       "type": "string"
@@ -61,16 +91,28 @@
       "$ref": "../../../enums/euVehicleCategory.ignore.json"
     },
     "techRecord_lastUpdatedAt": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "techRecord_lastUpdatedById": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "techRecord_lastUpdatedByName": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "techRecord_manufactureYear": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "techRecord_recordCompleteness": {
       "type": "string"
@@ -78,11 +120,17 @@
     "techRecord_noOfAxles": {
       "type": "integer"
     },
+    "techRecord_notes": {
+      "type": "string"
+    },
     "techRecord_reasonForCreation": {
       "type": "string"
     },
     "techRecord_regnDate": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "techRecord_statusCode": {
       "$ref": "../../../enums/statusCode.ignore.json"

--- a/json-definitions/v3/tech-record/get/motorcycle/complete/index.json
+++ b/json-definitions/v3/tech-record/get/motorcycle/complete/index.json
@@ -2,42 +2,73 @@
   "title": "Tech Record Complete Motorcycle Schema",
   "type": "object",
   "additionalProperties": false,
-  "required": ["vehicleSubclass", "createdTimestamp", "systemNumber", "vin"],
+  "required": [
+    "vehicleSubclass",
+    "createdTimestamp",
+    "systemNumber",
+    "vin"
+  ],
   "properties": {
     "techRecord_applicantDetails_name": {
-      "type": ["string", "null"],
+      "type": [
+        "string",
+        "null"
+      ],
       "maxLength": 150
     },
     "techRecord_applicantDetails_address1": {
-      "type": ["null", "string"],
+      "type": [
+        "null",
+        "string"
+      ],
       "maxLength": 60
     },
     "techRecord_applicantDetails_address2": {
-      "type": ["null", "string"],
+      "type": [
+        "null",
+        "string"
+      ],
       "maxLength": 60
     },
     "techRecord_applicantDetails_postTown": {
-      "type": ["null", "string"],
+      "type": [
+        "null",
+        "string"
+      ],
       "maxLength": 60
     },
     "techRecord_applicantDetails_address3": {
-      "type": ["null", "string"],
+      "type": [
+        "null",
+        "string"
+      ],
       "maxLength": 60
     },
     "techRecord_applicantDetails_postCode": {
-      "type": ["null", "string"],
+      "type": [
+        "null",
+        "string"
+      ],
       "maxLength": 12
     },
     "techRecord_applicantDetails_telephoneNumber": {
-      "type": ["null", "string"],
+      "type": [
+        "null",
+        "string"
+      ],
       "maxLength": 25
     },
     "techRecord_applicantDetails_emailAddress": {
-      "type": ["null", "string"],
+      "type": [
+        "null",
+        "string"
+      ],
       "maxLength": 255
     },
     "createdTimestamp": {
-      "type": ["string"]
+      "type": [
+        "string"
+      ]
     },
     "partialVin": {
       "type": "string"
@@ -61,16 +92,28 @@
       "$ref": "../../../enums/euVehicleCategory.ignore.json"
     },
     "techRecord_lastUpdatedAt": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "techRecord_lastUpdatedById": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "techRecord_lastUpdatedByName": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "techRecord_manufactureYear": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "techRecord_recordCompleteness": {
       "type": "string"
@@ -78,11 +121,17 @@
     "techRecord_noOfAxles": {
       "type": "integer"
     },
+    "techRecord_notes": {
+      "type": "string"
+    },
     "techRecord_reasonForCreation": {
       "type": "string"
     },
     "techRecord_regnDate": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "techRecord_statusCode": {
       "$ref": "../../../enums/statusCode.ignore.json"

--- a/json-definitions/v3/tech-record/put/car/complete/index.json
+++ b/json-definitions/v3/tech-record/put/car/complete/index.json
@@ -2,7 +2,10 @@
   "title": "Tech Record PUT Request Complete Car Schema",
   "type": "object",
   "additionalProperties": true,
-  "required": ["vehicleSubclass", "vin"],
+  "required": [
+    "vehicleSubclass",
+    "vin"
+  ],
   "properties": {
     "vin": {
       "type": "string"
@@ -11,10 +14,16 @@
       "type": "string"
     },
     "trailerId": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "techRecord_reasonForCreation": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "techRecord_vehicleType": {
       "$ref": "../../../enums/vehicleType.ignore.json"
@@ -23,13 +32,25 @@
       "$ref": "../../../enums/statusCode.ignore.json"
     },
     "techRecord_regnDate": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "techRecord_manufactureYear": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "techRecord_noOfAxles": {
-      "type": ["integer", "null"]
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "techRecord_notes": {
+      "type": "string"
     },
     "vehicleSubclass": {
       "$ref": "../../../enums/vehicleSubclass.ignore.json"

--- a/json-definitions/v3/tech-record/put/car/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/car/skeleton/index.json
@@ -2,7 +2,10 @@
   "title": "Tech Record PUT Request Skeleton Car Schema",
   "type": "object",
   "additionalProperties": true,
-  "required": ["vin", "vehicleType"],
+  "required": [
+    "vin",
+    "vehicleType"
+  ],
   "properties": {
     "vin": {
       "type": "string"
@@ -11,10 +14,16 @@
       "type": "string"
     },
     "trailerId": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "techRecord_reasonForCreation": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "techRecord_vehicleType": {
       "$ref": "../../../enums/vehicleType.ignore.json"
@@ -23,13 +32,25 @@
       "$ref": "../../../enums/statusCode.ignore.json"
     },
     "techRecord_regnDate": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "techRecord_manufactureYear": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "techRecord_noOfAxles": {
-      "type": ["integer", "null"]
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "techRecord_notes": {
+      "type": "string"
     },
     "techRecord_hiddenInVta": {
       "type": "boolean"

--- a/json-schemas/v3/tech-record/get/car/complete/index.json
+++ b/json-schemas/v3/tech-record/get/car/complete/index.json
@@ -142,6 +142,9 @@
 		"techRecord_noOfAxles": {
 			"type": "integer"
 		},
+		"techRecord_notes": {
+			"type": "string"
+		},
 		"techRecord_reasonForCreation": {
 			"type": "string"
 		},

--- a/json-schemas/v3/tech-record/get/car/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/car/skeleton/index.json
@@ -141,6 +141,9 @@
 		"techRecord_noOfAxles": {
 			"type": "integer"
 		},
+		"techRecord_notes": {
+			"type": "string"
+		},
 		"techRecord_reasonForCreation": {
 			"type": "string"
 		},

--- a/json-schemas/v3/tech-record/get/lgv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/lgv/complete/index.json
@@ -150,6 +150,9 @@
 				"techRecord_noOfAxles": {
 					"type": "integer"
 				},
+				"techRecord_notes": {
+					"type": "string"
+				},
 				"techRecord_reasonForCreation": {
 					"type": "string"
 				},

--- a/json-schemas/v3/tech-record/get/lgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/lgv/skeleton/index.json
@@ -146,6 +146,9 @@
 				"techRecord_noOfAxles": {
 					"type": "integer"
 				},
+				"techRecord_notes": {
+					"type": "string"
+				},
 				"techRecord_reasonForCreation": {
 					"type": "string"
 				},

--- a/json-schemas/v3/tech-record/get/motorcycle/complete/index.json
+++ b/json-schemas/v3/tech-record/get/motorcycle/complete/index.json
@@ -142,6 +142,9 @@
 		"techRecord_noOfAxles": {
 			"type": "integer"
 		},
+		"techRecord_notes": {
+			"type": "string"
+		},
 		"techRecord_reasonForCreation": {
 			"type": "string"
 		},

--- a/json-schemas/v3/tech-record/get/motorcycle/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/motorcycle/skeleton/index.json
@@ -146,6 +146,9 @@
 				"techRecord_noOfAxles": {
 					"type": "integer"
 				},
+				"techRecord_notes": {
+					"type": "string"
+				},
 				"techRecord_reasonForCreation": {
 					"type": "string"
 				},

--- a/json-schemas/v3/tech-record/put/car/complete/index.json
+++ b/json-schemas/v3/tech-record/put/car/complete/index.json
@@ -64,6 +64,9 @@
 				"null"
 			]
 		},
+		"techRecord_notes": {
+			"type": "string"
+		},
 		"vehicleSubclass": {
 			"title": "Vehicle Subclass",
 			"type": "array",

--- a/json-schemas/v3/tech-record/put/car/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/car/skeleton/index.json
@@ -64,6 +64,9 @@
 				"null"
 			]
 		},
+		"techRecord_notes": {
+			"type": "string"
+		},
 		"techRecord_hiddenInVta": {
 			"type": "boolean"
 		},

--- a/json-schemas/v3/tech-record/put/lgv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/lgv/complete/index.json
@@ -72,6 +72,9 @@
 						"null"
 					]
 				},
+				"techRecord_notes": {
+					"type": "string"
+				},
 				"vehicleSubclass": {
 					"title": "Vehicle Subclass",
 					"type": "array",

--- a/json-schemas/v3/tech-record/put/lgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/lgv/skeleton/index.json
@@ -69,6 +69,9 @@
 						"null"
 					]
 				},
+				"techRecord_notes": {
+					"type": "string"
+				},
 				"techRecord_hiddenInVta": {
 					"type": "boolean"
 				},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "type definitions for cvs vta application",
   "main": "index.js",
   "repository": {

--- a/types/v3/tech-record/get/car/complete/index.d.ts
+++ b/types/v3/tech-record/get/car/complete/index.d.ts
@@ -64,6 +64,7 @@ export interface TechRecordCompleteCarSchema {
   techRecord_manufactureYear?: string | null;
   techRecord_recordCompleteness?: string;
   techRecord_noOfAxles?: number;
+  techRecord_notes?: string;
   techRecord_reasonForCreation?: string;
   techRecord_regnDate?: string | null;
   techRecord_statusCode?: StatusCode;

--- a/types/v3/tech-record/get/car/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/car/skeleton/index.d.ts
@@ -63,6 +63,7 @@ export interface TechRecordSkeletonCarSchema {
   techRecord_manufactureYear?: string | null;
   techRecord_recordCompleteness?: string;
   techRecord_noOfAxles?: number;
+  techRecord_notes?: string;
   techRecord_reasonForCreation?: string;
   techRecord_regnDate?: string | null;
   techRecord_statusCode?: StatusCode;

--- a/types/v3/tech-record/get/lgv/complete/index.d.ts
+++ b/types/v3/tech-record/get/lgv/complete/index.d.ts
@@ -65,6 +65,7 @@ export interface TechRecordCompleteCarSchema1 {
   techRecord_manufactureYear?: string | null;
   techRecord_recordCompleteness?: string;
   techRecord_noOfAxles?: number;
+  techRecord_notes?: string;
   techRecord_reasonForCreation?: string;
   techRecord_regnDate?: string | null;
   techRecord_statusCode?: StatusCode;

--- a/types/v3/tech-record/get/lgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/lgv/skeleton/index.d.ts
@@ -64,6 +64,7 @@ export interface TechRecordSkeletonCarSchema1 {
   techRecord_manufactureYear?: string | null;
   techRecord_recordCompleteness?: string;
   techRecord_noOfAxles?: number;
+  techRecord_notes?: string;
   techRecord_reasonForCreation?: string;
   techRecord_regnDate?: string | null;
   techRecord_statusCode?: StatusCode;

--- a/types/v3/tech-record/get/motorcycle/complete/index.d.ts
+++ b/types/v3/tech-record/get/motorcycle/complete/index.d.ts
@@ -64,6 +64,7 @@ export interface TechRecordCompleteMotorcycleSchema {
   techRecord_manufactureYear?: string | null;
   techRecord_recordCompleteness?: string;
   techRecord_noOfAxles?: number;
+  techRecord_notes?: string;
   techRecord_reasonForCreation?: string;
   techRecord_regnDate?: string | null;
   techRecord_statusCode?: StatusCode;

--- a/types/v3/tech-record/get/motorcycle/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/motorcycle/skeleton/index.d.ts
@@ -64,6 +64,7 @@ export interface TechRecordSkeletonCarSchema1 {
   techRecord_manufactureYear?: string | null;
   techRecord_recordCompleteness?: string;
   techRecord_noOfAxles?: number;
+  techRecord_notes?: string;
   techRecord_reasonForCreation?: string;
   techRecord_regnDate?: string | null;
   techRecord_statusCode?: StatusCode;

--- a/types/v3/tech-record/put/car/complete/index.d.ts
+++ b/types/v3/tech-record/put/car/complete/index.d.ts
@@ -19,6 +19,7 @@ export interface TechRecordPUTRequestCompleteCarSchema {
   techRecord_regnDate?: string | null;
   techRecord_manufactureYear?: string | null;
   techRecord_noOfAxles?: number | null;
+  techRecord_notes?: string;
   vehicleSubclass: VehicleSubclass;
   techRecord_hiddenInVta?: boolean;
   techRecord_updateType?: string;

--- a/types/v3/tech-record/put/car/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/car/skeleton/index.d.ts
@@ -18,6 +18,7 @@ export interface TechRecordPUTRequestSkeletonCarSchema {
   techRecord_regnDate?: string | null;
   techRecord_manufactureYear?: string | null;
   techRecord_noOfAxles?: number | null;
+  techRecord_notes?: string;
   techRecord_hiddenInVta?: boolean;
   techRecord_updateType?: string;
   [k: string]: unknown;

--- a/types/v3/tech-record/put/lgv/complete/index.d.ts
+++ b/types/v3/tech-record/put/lgv/complete/index.d.ts
@@ -20,6 +20,7 @@ export interface TechRecordPUTRequestCompleteCarSchema {
   techRecord_regnDate?: string | null;
   techRecord_manufactureYear?: string | null;
   techRecord_noOfAxles?: number | null;
+  techRecord_notes?: string;
   vehicleSubclass: VehicleSubclass;
   techRecord_hiddenInVta?: boolean;
   techRecord_updateType?: string;

--- a/types/v3/tech-record/put/lgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/lgv/skeleton/index.d.ts
@@ -19,6 +19,7 @@ export interface TechRecordPUTRequestSkeletonCarSchema {
   techRecord_regnDate?: string | null;
   techRecord_manufactureYear?: string | null;
   techRecord_noOfAxles?: number | null;
+  techRecord_notes?: string;
   techRecord_hiddenInVta?: boolean;
   techRecord_updateType?: string;
   [k: string]: unknown;


### PR DESCRIPTION
## Ticket title

The light vehicles need to have notes attached to them as well.

Closes #25 

Include summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`.

## Changelog

- Add notes to all light vehicles

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
