### PR TITLE
minor(*): improve typing on isValidObject

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "2.0.30",
+  "version": "2.0.31",
   "description": "type definitions for cvs vta application",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "2.0.31",
+  "version": "2.1.0",
   "description": "type definitions for cvs vta application",
   "main": "index.js",
   "repository": {

--- a/schema-validator.ts
+++ b/schema-validator.ts
@@ -1,15 +1,17 @@
 import Ajv, { ErrorObject } from "ajv";
-import { schemas } from "./schemas";
 import { readFileSync } from "fs";
+import { schemas } from "./schemas";
 
 export type Schema = typeof schemas[number];
 
-export const isValidObject = (
+export function isValidObject<B extends boolean | undefined>(schemaName: Schema, objectToValidate: object): boolean
+export function isValidObject<B extends boolean | undefined>(schemaName: Schema, objectToValidate: object, returnErrors: B): B extends false ? boolean : ErrorObject[]
+export function isValidObject<B extends boolean | undefined>(
   schemaName: Schema,
   objectToValidate: object,
-  returnErrors = false,
+  returnErrors?: B,
   logErrors = false,
-): (boolean | ErrorObject[]) => {
+): (boolean | ErrorObject[]) {
   const ajv = new Ajv({ removeAdditional: true, allErrors: true });
   const schema = JSON.parse(
     readFileSync(`${__dirname}/json-schemas/${schemaName}`, "utf8")
@@ -21,8 +23,8 @@ export const isValidObject = (
     console.error(validateFunction.errors);
   }
 
-  if (returnErrors && validateFunction.errors) {
-    return validateFunction.errors;
+  if (returnErrors) {
+    return validateFunction.errors ?? [];
   }
 
   return isValid;

--- a/tests/hgv/complete.test.ts
+++ b/tests/hgv/complete.test.ts
@@ -18,7 +18,7 @@ describe("validate complete hgv schema", () => {
   it("should pass validation when given just required fields", () => {
     const data = hgvData[2];
     const res = isValidObject(schemaName, data, true);
-    expect(res).toEqual(true);
+    expect(res).toEqual([]);
   });
   it("should fail when missing a required field, systemNumber", () => {
     const data = hgvData[3];

--- a/tests/hgv/skeleton.test.ts
+++ b/tests/hgv/skeleton.test.ts
@@ -18,7 +18,7 @@ describe("validate skeleton hgv schema", () => {
   it("should pass validation when given just required fields", () => {
     const data = hgvData[2];
     const res = isValidObject(schemaName, data, true);
-    expect(res).toEqual(true);
+    expect(res).toEqual([]);
   });
   it("should fail when missing a required field, systemNumber", () => {
     const data = hgvData[3];

--- a/tests/hgv/testable.test.ts
+++ b/tests/hgv/testable.test.ts
@@ -18,7 +18,7 @@ describe("validate testable hgv schema", () => {
   it("should pass validation when given just required fields", () => {
     const data = hgvData[2];
     const res = isValidObject(schemaName, data, true);
-    expect(res).toEqual(true);
+    expect(res).toEqual([]);
   });
   it("should fail when missing a required field, systemNumber", () => {
     const data = hgvData[3];

--- a/tests/psv/skeleton.test.ts
+++ b/tests/psv/skeleton.test.ts
@@ -18,7 +18,7 @@ describe("validate skeleton psv schema", () => {
   it("should pass validation when given just required fields", () => {
     const data = psvData[2];
     const res = isValidObject(schemaName, data, true);
-    expect(res).toEqual(true);
+    expect(res).toEqual([]);
   });
   it("should fail when missing a required field, systemNumber", () => {
     const data = psvData[3];

--- a/tests/trl/complete.test.ts
+++ b/tests/trl/complete.test.ts
@@ -18,7 +18,7 @@ describe("validate complete trl schema", () => {
   it("should pass validation when given just required fields", () => {
     const data: object = trlData[2];
     const res = isValidObject(schemaName, data, true);
-    expect(res).toEqual(true);
+    expect(res).toEqual([]);
   });
   it("should fail when missing a required field, systemNumber", () => {
     const data: object = trlData[3];

--- a/tests/trl/skeleton.test.ts
+++ b/tests/trl/skeleton.test.ts
@@ -18,7 +18,7 @@ describe("validate skeleton trl schema", () => {
   it("should pass validation when given just required fields", () => {
     const data: object = trlData[2];
     const res = isValidObject(schemaName, data, true);
-    expect(res).toEqual(true);
+    expect(res).toEqual([]);
   });
   it("should fail when missing a required field, systemNumber", () => {
     const data: object = trlData[3];

--- a/tests/trl/testable.test.ts
+++ b/tests/trl/testable.test.ts
@@ -18,7 +18,7 @@ describe("validate testable trl schema", () => {
   it("should pass validation when given just required fields", () => {
     const data: object = trlData[2];
     const res = isValidObject(schemaName, data, true);
-    expect(res).toEqual(true);
+    expect(res).toEqual([]);
   });
   it("should fail when missing a required field, systemNumber", () => {
     const data: object = trlData[3];


### PR DESCRIPTION
## Ticket title

Use function overloading to determine which time is going to be returned from the function `isValidObject`.

#### Typing:
- If `returnErrors` is not passed in, or is false, the typescript compiler will know that the return type is boolean
- If `returnErrors` is true, the typescript compiler will know that the return type is `ErrorOject[]`

This removes the need to explicitly cast the return type of the function to `boolean` or `ErrorObject`, such as [here](https://github.com/dvsa/cvs-svc-technical-records-v3/pull/22/files#diff-33895ffddbe22a2e94a79ac80497419a89c5486b5a3e68af0789bceed7ba10eaL31).

#### Functionality:
- Consistent return on the `isValidObject` function. Returns `[]` if there are no errors instead of `true`.



## Changelog

- Improve typing on `isValidObject` function.
- Consistent return on the `isValidObject` function.

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
