### PR TITLE
patch(*): remove issue with allOf not playing nice with remove additional

### DIFF
--- a/json-definitions/v3/tech-record/get/car/complete/index.json
+++ b/json-definitions/v3/tech-record/get/car/complete/index.json
@@ -153,6 +153,12 @@
     },
     "techRecord_updateType": {
       "type": "string"
+    },
+    "secondaryVrms": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   }
 }

--- a/json-definitions/v3/tech-record/get/car/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/car/skeleton/index.json
@@ -149,6 +149,12 @@
     },
     "techRecord_updateType": {
       "type": "string"
+    },
+    "secondaryVrms": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   }
 }

--- a/json-definitions/v3/tech-record/get/lgv/complete/index.json
+++ b/json-definitions/v3/tech-record/get/lgv/complete/index.json
@@ -5,9 +5,157 @@
   "required": [
     "techRecord_vehicleSubclass"
   ],
-  "allOf": [
-    {
-      "$ref": "../../car/complete/index.json"
+  "properties": {
+    "techRecord_applicantDetails_name": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 150
+    },
+    "techRecord_applicantDetails_address1": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_address2": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_postTown": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_address3": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_postCode": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "maxLength": 12
+    },
+    "techRecord_applicantDetails_telephoneNumber": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "maxLength": 25
+    },
+    "techRecord_applicantDetails_emailAddress": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "maxLength": 255
+    },
+    "createdTimestamp": {
+      "type": [
+        "string"
+      ]
+    },
+    "partialVin": {
+      "type": "string"
+    },
+    "primaryVrm": {
+      "type": "string"
+    },
+    "systemNumber": {
+      "type": "string"
+    },
+    "techRecord_createdAt": {
+      "type": "string"
+    },
+    "techRecord_createdById": {
+      "type": "string"
+    },
+    "techRecord_createdByName": {
+      "type": "string"
+    },
+    "techRecord_euVehicleCategory": {
+      "$ref": "../../../enums/euVehicleCategory.ignore.json"
+    },
+    "techRecord_lastUpdatedAt": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_lastUpdatedById": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_lastUpdatedByName": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_manufactureYear": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_recordCompleteness": {
+      "type": "string"
+    },
+    "techRecord_noOfAxles": {
+      "type": "integer"
+    },
+    "techRecord_notes": {
+      "type": "string"
+    },
+    "techRecord_reasonForCreation": {
+      "type": "string"
+    },
+    "techRecord_regnDate": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_statusCode": {
+      "$ref": "../../../enums/statusCode.ignore.json"
+    },
+    "techRecord_vehicleConfiguration": {
+      "$ref": "../../../enums/vehicleConfiguration.ignore.json"
+    },
+    "techRecord_vehicleType": {
+      "$ref": "../../../enums/vehicleType.ignore.json"
+    },
+    "vin": {
+      "type": "string"
+    },
+    "techRecord_vehicleSubclass": {
+      "$ref": "../../../enums/vehicleSubclass.ignore.json"
+    },
+    "techRecord_hiddenInVta": {
+      "type": "boolean"
+    },
+    "techRecord_updateType": {
+      "type": "string"
+    },
+    "secondaryVrms": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
-  ]
+  }
 }

--- a/json-definitions/v3/tech-record/get/lgv/complete/index.json
+++ b/json-definitions/v3/tech-record/get/lgv/complete/index.json
@@ -3,7 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "techRecord_vehicleSubclass"
+    "techRecord_vehicleSubclass",
+    "createdTimestamp",
+    "systemNumber",
+    "vin"
   ],
   "properties": {
     "techRecord_applicantDetails_name": {

--- a/json-definitions/v3/tech-record/get/lgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/lgv/skeleton/index.json
@@ -2,6 +2,11 @@
   "title": "Tech Record Skeleton Car Schema",
   "type": "object",
   "additionalProperties": false,
+  "required": [
+    "createdTimestamp",
+    "systemNumber",
+    "vin"
+  ],
   "properties": {
     "techRecord_applicantDetails_name": {
       "type": [

--- a/json-definitions/v3/tech-record/get/lgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/lgv/skeleton/index.json
@@ -2,9 +2,154 @@
   "title": "Tech Record Skeleton Car Schema",
   "type": "object",
   "additionalProperties": false,
-  "allOf": [
-    {
-      "$ref": "../../car/skeleton/index.json"
+  "properties": {
+    "techRecord_applicantDetails_name": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 150
+    },
+    "techRecord_applicantDetails_address1": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_address2": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_postTown": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_address3": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_postCode": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "maxLength": 12
+    },
+    "techRecord_applicantDetails_telephoneNumber": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "maxLength": 25
+    },
+    "techRecord_applicantDetails_emailAddress": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "maxLength": 255
+    },
+    "createdTimestamp": {
+      "type": [
+        "string"
+      ]
+    },
+    "partialVin": {
+      "type": "string"
+    },
+    "primaryVrm": {
+      "type": "string"
+    },
+    "systemNumber": {
+      "type": "string"
+    },
+    "techRecord_createdAt": {
+      "type": "string"
+    },
+    "techRecord_createdById": {
+      "type": "string"
+    },
+    "techRecord_createdByName": {
+      "type": "string"
+    },
+    "techRecord_euVehicleCategory": {
+      "$ref": "../../../enums/euVehicleCategory.ignore.json"
+    },
+    "techRecord_lastUpdatedAt": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_lastUpdatedById": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_lastUpdatedByName": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_manufactureYear": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_recordCompleteness": {
+      "type": "string"
+    },
+    "techRecord_noOfAxles": {
+      "type": "integer"
+    },
+    "techRecord_notes": {
+      "type": "string"
+    },
+    "techRecord_reasonForCreation": {
+      "type": "string"
+    },
+    "techRecord_regnDate": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_statusCode": {
+      "$ref": "../../../enums/statusCode.ignore.json"
+    },
+    "techRecord_vehicleConfiguration": {
+      "$ref": "../../../enums/vehicleConfiguration.ignore.json"
+    },
+    "techRecord_vehicleType": {
+      "$ref": "../../../enums/vehicleType.ignore.json"
+    },
+    "vin": {
+      "type": "string"
+    },
+    "techRecord_hiddenInVta": {
+      "type": "boolean"
+    },
+    "techRecord_updateType": {
+      "type": "string"
+    },
+    "secondaryVrms": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
-  ]
+  }
 }

--- a/json-definitions/v3/tech-record/get/motorcycle/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/motorcycle/skeleton/index.json
@@ -2,9 +2,154 @@
   "title": "Tech Record Skeleton Car Schema",
   "type": "object",
   "additionalProperties": false,
-  "allOf": [
-    {
-      "$ref": "../../car/skeleton/index.json"
+  "properties": {
+    "techRecord_applicantDetails_name": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 150
+    },
+    "techRecord_applicantDetails_address1": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_address2": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_postTown": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_address3": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "maxLength": 60
+    },
+    "techRecord_applicantDetails_postCode": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "maxLength": 12
+    },
+    "techRecord_applicantDetails_telephoneNumber": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "maxLength": 25
+    },
+    "techRecord_applicantDetails_emailAddress": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "maxLength": 255
+    },
+    "createdTimestamp": {
+      "type": [
+        "string"
+      ]
+    },
+    "partialVin": {
+      "type": "string"
+    },
+    "primaryVrm": {
+      "type": "string"
+    },
+    "systemNumber": {
+      "type": "string"
+    },
+    "techRecord_createdAt": {
+      "type": "string"
+    },
+    "techRecord_createdById": {
+      "type": "string"
+    },
+    "techRecord_createdByName": {
+      "type": "string"
+    },
+    "techRecord_euVehicleCategory": {
+      "$ref": "../../../enums/euVehicleCategory.ignore.json"
+    },
+    "techRecord_lastUpdatedAt": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_lastUpdatedById": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_lastUpdatedByName": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_manufactureYear": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_recordCompleteness": {
+      "type": "string"
+    },
+    "techRecord_noOfAxles": {
+      "type": "integer"
+    },
+    "techRecord_notes": {
+      "type": "string"
+    },
+    "techRecord_reasonForCreation": {
+      "type": "string"
+    },
+    "techRecord_regnDate": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_statusCode": {
+      "$ref": "../../../enums/statusCode.ignore.json"
+    },
+    "techRecord_vehicleConfiguration": {
+      "$ref": "../../../enums/vehicleConfiguration.ignore.json"
+    },
+    "techRecord_vehicleType": {
+      "$ref": "../../../enums/vehicleType.ignore.json"
+    },
+    "vin": {
+      "type": "string"
+    },
+    "techRecord_hiddenInVta": {
+      "type": "boolean"
+    },
+    "techRecord_updateType": {
+      "type": "string"
+    },
+    "secondaryVrms": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
-  ]
+  }
 }

--- a/json-definitions/v3/tech-record/put/car/complete/index.json
+++ b/json-definitions/v3/tech-record/put/car/complete/index.json
@@ -2,7 +2,10 @@
   "title": "Tech Record PUT Request Complete Car Schema",
   "type": "object",
   "additionalProperties": false,
-  "required": ["techRecord_vehicleSubclass", "vin"],
+  "required": [
+    "techRecord_vehicleSubclass",
+    "vin"
+  ],
   "properties": {
     "vin": {
       "type": "string"
@@ -11,10 +14,16 @@
       "type": "string"
     },
     "trailerId": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "techRecord_reasonForCreation": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "techRecord_vehicleType": {
       "$ref": "../../../enums/vehicleType.ignore.json"
@@ -23,13 +32,22 @@
       "$ref": "../../../enums/statusCode.ignore.json"
     },
     "techRecord_regnDate": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "techRecord_manufactureYear": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "techRecord_noOfAxles": {
-      "type": ["integer", "null"]
+      "type": [
+        "integer",
+        "null"
+      ]
     },
     "techRecord_notes": {
       "type": "string"
@@ -51,6 +69,12 @@
     },
     "techRecord_createdByName": {
       "type": "string"
+    },
+    "secondaryVrms": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   }
 }

--- a/json-definitions/v3/tech-record/put/car/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/car/skeleton/index.json
@@ -2,7 +2,10 @@
   "title": "Tech Record PUT Request Skeleton Car Schema",
   "type": "object",
   "additionalProperties": false,
-  "required": ["vin", "techRecord_vehicleType"],
+  "required": [
+    "vin",
+    "techRecord_vehicleType"
+  ],
   "properties": {
     "vin": {
       "type": "string"
@@ -11,10 +14,16 @@
       "type": "string"
     },
     "trailerId": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "techRecord_reasonForCreation": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "techRecord_vehicleType": {
       "$ref": "../../../enums/vehicleType.ignore.json"
@@ -23,13 +32,22 @@
       "$ref": "../../../enums/statusCode.ignore.json"
     },
     "techRecord_regnDate": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "techRecord_manufactureYear": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "techRecord_noOfAxles": {
-      "type": ["integer", "null"]
+      "type": [
+        "integer",
+        "null"
+      ]
     },
     "techRecord_notes": {
       "type": "string"
@@ -48,6 +66,12 @@
     },
     "techRecord_createdByName": {
       "type": "string"
+    },
+    "secondaryVrms": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   }
 }

--- a/json-definitions/v3/tech-record/put/lgv/complete/index.json
+++ b/json-definitions/v3/tech-record/put/lgv/complete/index.json
@@ -3,7 +3,8 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "techRecord_vehicleSubclass"
+    "techRecord_vehicleSubclass",
+    "vin"
   ],
   "properties": {
     "vin": {

--- a/json-definitions/v3/tech-record/put/lgv/complete/index.json
+++ b/json-definitions/v3/tech-record/put/lgv/complete/index.json
@@ -2,10 +2,78 @@
   "title": "Tech Record Complete LGV Schema",
   "type": "object",
   "additionalProperties": false,
-  "required": ["techRecord_vehicleSubclass"],
-  "allOf": [
-    {
-      "$ref": "../../car/complete/index.json"
+  "required": [
+    "techRecord_vehicleSubclass"
+  ],
+  "properties": {
+    "vin": {
+      "type": "string"
+    },
+    "primaryVrm": {
+      "type": "string"
+    },
+    "trailerId": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_reasonForCreation": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_vehicleType": {
+      "$ref": "../../../enums/vehicleType.ignore.json"
+    },
+    "techRecord_statusCode": {
+      "$ref": "../../../enums/statusCode.ignore.json"
+    },
+    "techRecord_regnDate": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_manufactureYear": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_noOfAxles": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "techRecord_notes": {
+      "type": "string"
+    },
+    "techRecord_vehicleSubclass": {
+      "$ref": "../../../enums/vehicleSubclass.ignore.json"
+    },
+    "techRecord_hiddenInVta": {
+      "type": "boolean"
+    },
+    "techRecord_updateType": {
+      "type": "string"
+    },
+    "techRecord_createdAt": {
+      "type": "string"
+    },
+    "techRecord_createdById": {
+      "type": "string"
+    },
+    "techRecord_createdByName": {
+      "type": "string"
+    },
+    "secondaryVrms": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
-  ]
+  }
 }

--- a/json-definitions/v3/tech-record/put/lgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/lgv/skeleton/index.json
@@ -2,9 +2,72 @@
   "title": "Tech Record Complete Car Schema",
   "type": "object",
   "additionalProperties": false,
-  "allOf": [
-    {
-      "$ref": "../../car/skeleton/index.json"
+  "properties": {
+    "vin": {
+      "type": "string"
+    },
+    "primaryVrm": {
+      "type": "string"
+    },
+    "trailerId": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_reasonForCreation": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_vehicleType": {
+      "$ref": "../../../enums/vehicleType.ignore.json"
+    },
+    "techRecord_statusCode": {
+      "$ref": "../../../enums/statusCode.ignore.json"
+    },
+    "techRecord_regnDate": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_manufactureYear": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_noOfAxles": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "techRecord_notes": {
+      "type": "string"
+    },
+    "techRecord_hiddenInVta": {
+      "type": "boolean"
+    },
+    "techRecord_updateType": {
+      "type": "string"
+    },
+    "techRecord_createdAt": {
+      "type": "string"
+    },
+    "techRecord_createdById": {
+      "type": "string"
+    },
+    "techRecord_createdByName": {
+      "type": "string"
+    },
+    "secondaryVrms": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
-  ]
+  }
 }

--- a/json-definitions/v3/tech-record/put/lgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/lgv/skeleton/index.json
@@ -2,6 +2,10 @@
   "title": "Tech Record Complete Car Schema",
   "type": "object",
   "additionalProperties": false,
+  "required": [
+    "vin",
+    "techRecord_vehicleType"
+  ],
   "properties": {
     "vin": {
       "type": "string"

--- a/json-schemas/v3/tech-record/get/car/complete/index.json
+++ b/json-schemas/v3/tech-record/get/car/complete/index.json
@@ -221,6 +221,12 @@
 		},
 		"techRecord_updateType": {
 			"type": "string"
+		},
+		"secondaryVrms": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
 		}
 	}
 }

--- a/json-schemas/v3/tech-record/get/car/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/car/skeleton/index.json
@@ -200,6 +200,12 @@
 		},
 		"techRecord_updateType": {
 			"type": "string"
+		},
+		"secondaryVrms": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
 		}
 	}
 }

--- a/json-schemas/v3/tech-record/get/lgv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/lgv/complete/index.json
@@ -5,232 +5,225 @@
 	"required": [
 		"techRecord_vehicleSubclass"
 	],
-	"allOf": [
-		{
-			"title": "Tech Record Complete Car Schema",
-			"type": "object",
-			"additionalProperties": false,
-			"required": [
-				"techRecord_vehicleSubclass",
-				"createdTimestamp",
-				"systemNumber",
-				"vin"
+	"properties": {
+		"techRecord_applicantDetails_name": {
+			"type": [
+				"string",
+				"null"
 			],
-			"properties": {
-				"techRecord_applicantDetails_name": {
-					"type": [
-						"string",
-						"null"
-					],
-					"maxLength": 150
-				},
-				"techRecord_applicantDetails_address1": {
-					"type": [
-						"null",
-						"string"
-					],
-					"maxLength": 60
-				},
-				"techRecord_applicantDetails_address2": {
-					"type": [
-						"null",
-						"string"
-					],
-					"maxLength": 60
-				},
-				"techRecord_applicantDetails_postTown": {
-					"type": [
-						"null",
-						"string"
-					],
-					"maxLength": 60
-				},
-				"techRecord_applicantDetails_address3": {
-					"type": [
-						"null",
-						"string"
-					],
-					"maxLength": 60
-				},
-				"techRecord_applicantDetails_postCode": {
-					"type": [
-						"null",
-						"string"
-					],
-					"maxLength": 12
-				},
-				"techRecord_applicantDetails_telephoneNumber": {
-					"type": [
-						"null",
-						"string"
-					],
-					"maxLength": 25
-				},
-				"techRecord_applicantDetails_emailAddress": {
-					"type": [
-						"null",
-						"string"
-					],
-					"maxLength": 255
-				},
-				"createdTimestamp": {
-					"type": [
-						"string"
-					]
-				},
-				"partialVin": {
-					"type": "string"
-				},
-				"primaryVrm": {
-					"type": "string"
-				},
-				"systemNumber": {
-					"type": "string"
-				},
-				"techRecord_createdAt": {
-					"type": "string"
-				},
-				"techRecord_createdById": {
-					"type": "string"
-				},
-				"techRecord_createdByName": {
-					"type": "string"
-				},
-				"techRecord_euVehicleCategory": {
-					"title": "EU vehicle category",
-					"type": "string",
-					"enum": [
-						"m1",
-						"m2",
-						"m3",
-						"n1",
-						"n2",
-						"n3",
-						"o1",
-						"o2",
-						"o3",
-						"o4",
-						"l1e-a",
-						"l1e",
-						"l2e",
-						"l3e",
-						"l4e",
-						"l5e",
-						"l6e",
-						"l7e"
-					]
-				},
-				"techRecord_lastUpdatedAt": {
-					"type": [
-						"string",
-						"null"
-					]
-				},
-				"techRecord_lastUpdatedById": {
-					"type": [
-						"string",
-						"null"
-					]
-				},
-				"techRecord_lastUpdatedByName": {
-					"type": [
-						"string",
-						"null"
-					]
-				},
-				"techRecord_manufactureYear": {
-					"type": [
-						"string",
-						"null"
-					]
-				},
-				"techRecord_recordCompleteness": {
-					"type": "string"
-				},
-				"techRecord_noOfAxles": {
-					"type": "integer"
-				},
-				"techRecord_notes": {
-					"type": "string"
-				},
-				"techRecord_reasonForCreation": {
-					"type": "string"
-				},
-				"techRecord_regnDate": {
-					"type": [
-						"string",
-						"null"
-					]
-				},
-				"techRecord_statusCode": {
-					"title": "Status Code",
-					"type": "string",
-					"enum": [
-						"provisional",
-						"current",
-						"archived"
-					]
-				},
-				"techRecord_vehicleConfiguration": {
-					"title": "Vehicle Configuration",
-					"type": "string",
-					"enum": [
-						"rigid",
-						"articulated",
-						"centre axle drawbar",
-						"semi-car transporter",
-						"semi-trailer",
-						"long semi-trailer",
-						"low loader",
-						"other",
-						"drawbar",
-						"four-in-line",
-						"dolly",
-						"full drawbar"
-					]
-				},
-				"techRecord_vehicleType": {
-					"title": "Vehicle Type",
-					"type": "string",
-					"enum": [
-						"psv",
-						"trl",
-						"hgv",
-						"car",
-						"lgv",
-						"motorcycle"
-					]
-				},
-				"vin": {
-					"type": "string"
-				},
-				"techRecord_vehicleSubclass": {
-					"title": "Vehicle Subclass",
-					"type": "array",
-					"items": {
-						"type": "string",
-						"enum": [
-							"n",
-							"p",
-							"a",
-							"s",
-							"c",
-							"l",
-							"t",
-							"e",
-							"m",
-							"r",
-							"w"
-						]
-					}
-				},
-				"techRecord_hiddenInVta": {
-					"type": "boolean"
-				},
-				"techRecord_updateType": {
-					"type": "string"
-				}
+			"maxLength": 150
+		},
+		"techRecord_applicantDetails_address1": {
+			"type": [
+				"null",
+				"string"
+			],
+			"maxLength": 60
+		},
+		"techRecord_applicantDetails_address2": {
+			"type": [
+				"null",
+				"string"
+			],
+			"maxLength": 60
+		},
+		"techRecord_applicantDetails_postTown": {
+			"type": [
+				"null",
+				"string"
+			],
+			"maxLength": 60
+		},
+		"techRecord_applicantDetails_address3": {
+			"type": [
+				"null",
+				"string"
+			],
+			"maxLength": 60
+		},
+		"techRecord_applicantDetails_postCode": {
+			"type": [
+				"null",
+				"string"
+			],
+			"maxLength": 12
+		},
+		"techRecord_applicantDetails_telephoneNumber": {
+			"type": [
+				"null",
+				"string"
+			],
+			"maxLength": 25
+		},
+		"techRecord_applicantDetails_emailAddress": {
+			"type": [
+				"null",
+				"string"
+			],
+			"maxLength": 255
+		},
+		"createdTimestamp": {
+			"type": [
+				"string"
+			]
+		},
+		"partialVin": {
+			"type": "string"
+		},
+		"primaryVrm": {
+			"type": "string"
+		},
+		"systemNumber": {
+			"type": "string"
+		},
+		"techRecord_createdAt": {
+			"type": "string"
+		},
+		"techRecord_createdById": {
+			"type": "string"
+		},
+		"techRecord_createdByName": {
+			"type": "string"
+		},
+		"techRecord_euVehicleCategory": {
+			"title": "EU vehicle category",
+			"type": "string",
+			"enum": [
+				"m1",
+				"m2",
+				"m3",
+				"n1",
+				"n2",
+				"n3",
+				"o1",
+				"o2",
+				"o3",
+				"o4",
+				"l1e-a",
+				"l1e",
+				"l2e",
+				"l3e",
+				"l4e",
+				"l5e",
+				"l6e",
+				"l7e"
+			]
+		},
+		"techRecord_lastUpdatedAt": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_lastUpdatedById": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_lastUpdatedByName": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_manufactureYear": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_recordCompleteness": {
+			"type": "string"
+		},
+		"techRecord_noOfAxles": {
+			"type": "integer"
+		},
+		"techRecord_notes": {
+			"type": "string"
+		},
+		"techRecord_reasonForCreation": {
+			"type": "string"
+		},
+		"techRecord_regnDate": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_statusCode": {
+			"title": "Status Code",
+			"type": "string",
+			"enum": [
+				"provisional",
+				"current",
+				"archived"
+			]
+		},
+		"techRecord_vehicleConfiguration": {
+			"title": "Vehicle Configuration",
+			"type": "string",
+			"enum": [
+				"rigid",
+				"articulated",
+				"centre axle drawbar",
+				"semi-car transporter",
+				"semi-trailer",
+				"long semi-trailer",
+				"low loader",
+				"other",
+				"drawbar",
+				"four-in-line",
+				"dolly",
+				"full drawbar"
+			]
+		},
+		"techRecord_vehicleType": {
+			"title": "Vehicle Type",
+			"type": "string",
+			"enum": [
+				"psv",
+				"trl",
+				"hgv",
+				"car",
+				"lgv",
+				"motorcycle"
+			]
+		},
+		"vin": {
+			"type": "string"
+		},
+		"techRecord_vehicleSubclass": {
+			"title": "Vehicle Subclass",
+			"type": "array",
+			"items": {
+				"type": "string",
+				"enum": [
+					"n",
+					"p",
+					"a",
+					"s",
+					"c",
+					"l",
+					"t",
+					"e",
+					"m",
+					"r",
+					"w"
+				]
+			}
+		},
+		"techRecord_hiddenInVta": {
+			"type": "boolean"
+		},
+		"techRecord_updateType": {
+			"type": "string"
+		},
+		"secondaryVrms": {
+			"type": "array",
+			"items": {
+				"type": "string"
 			}
 		}
-	]
+	}
 }

--- a/json-schemas/v3/tech-record/get/lgv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/lgv/complete/index.json
@@ -3,7 +3,10 @@
 	"type": "object",
 	"additionalProperties": false,
 	"required": [
-		"techRecord_vehicleSubclass"
+		"techRecord_vehicleSubclass",
+		"createdTimestamp",
+		"systemNumber",
+		"vin"
 	],
 	"properties": {
 		"techRecord_applicantDetails_name": {

--- a/json-schemas/v3/tech-record/get/lgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/lgv/skeleton/index.json
@@ -2,6 +2,11 @@
 	"title": "Tech Record Skeleton Car Schema",
 	"type": "object",
 	"additionalProperties": false,
+	"required": [
+		"createdTimestamp",
+		"systemNumber",
+		"vin"
+	],
 	"properties": {
 		"techRecord_applicantDetails_name": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/lgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/lgv/skeleton/index.json
@@ -2,211 +2,205 @@
 	"title": "Tech Record Skeleton Car Schema",
 	"type": "object",
 	"additionalProperties": false,
-	"allOf": [
-		{
-			"title": "Tech Record Skeleton Car Schema",
-			"type": "object",
-			"additionalProperties": false,
-			"required": [
-				"createdTimestamp",
-				"systemNumber",
-				"vin"
+	"properties": {
+		"techRecord_applicantDetails_name": {
+			"type": [
+				"string",
+				"null"
 			],
-			"properties": {
-				"techRecord_applicantDetails_name": {
-					"type": [
-						"string",
-						"null"
-					],
-					"maxLength": 150
-				},
-				"techRecord_applicantDetails_address1": {
-					"type": [
-						"null",
-						"string"
-					],
-					"maxLength": 60
-				},
-				"techRecord_applicantDetails_address2": {
-					"type": [
-						"null",
-						"string"
-					],
-					"maxLength": 60
-				},
-				"techRecord_applicantDetails_postTown": {
-					"type": [
-						"null",
-						"string"
-					],
-					"maxLength": 60
-				},
-				"techRecord_applicantDetails_address3": {
-					"type": [
-						"null",
-						"string"
-					],
-					"maxLength": 60
-				},
-				"techRecord_applicantDetails_postCode": {
-					"type": [
-						"null",
-						"string"
-					],
-					"maxLength": 12
-				},
-				"techRecord_applicantDetails_telephoneNumber": {
-					"type": [
-						"null",
-						"string"
-					],
-					"maxLength": 25
-				},
-				"techRecord_applicantDetails_emailAddress": {
-					"type": [
-						"null",
-						"string"
-					],
-					"maxLength": 255
-				},
-				"createdTimestamp": {
-					"type": [
-						"string"
-					]
-				},
-				"partialVin": {
-					"type": "string"
-				},
-				"primaryVrm": {
-					"type": "string"
-				},
-				"systemNumber": {
-					"type": "string"
-				},
-				"techRecord_createdAt": {
-					"type": "string"
-				},
-				"techRecord_createdById": {
-					"type": "string"
-				},
-				"techRecord_createdByName": {
-					"type": "string"
-				},
-				"techRecord_euVehicleCategory": {
-					"title": "EU vehicle category",
-					"type": "string",
-					"enum": [
-						"m1",
-						"m2",
-						"m3",
-						"n1",
-						"n2",
-						"n3",
-						"o1",
-						"o2",
-						"o3",
-						"o4",
-						"l1e-a",
-						"l1e",
-						"l2e",
-						"l3e",
-						"l4e",
-						"l5e",
-						"l6e",
-						"l7e"
-					]
-				},
-				"techRecord_lastUpdatedAt": {
-					"type": [
-						"string",
-						"null"
-					]
-				},
-				"techRecord_lastUpdatedById": {
-					"type": [
-						"string",
-						"null"
-					]
-				},
-				"techRecord_lastUpdatedByName": {
-					"type": [
-						"string",
-						"null"
-					]
-				},
-				"techRecord_manufactureYear": {
-					"type": [
-						"string",
-						"null"
-					]
-				},
-				"techRecord_recordCompleteness": {
-					"type": "string"
-				},
-				"techRecord_noOfAxles": {
-					"type": "integer"
-				},
-				"techRecord_notes": {
-					"type": "string"
-				},
-				"techRecord_reasonForCreation": {
-					"type": "string"
-				},
-				"techRecord_regnDate": {
-					"type": [
-						"string",
-						"null"
-					]
-				},
-				"techRecord_statusCode": {
-					"title": "Status Code",
-					"type": "string",
-					"enum": [
-						"provisional",
-						"current",
-						"archived"
-					]
-				},
-				"techRecord_vehicleConfiguration": {
-					"title": "Vehicle Configuration",
-					"type": "string",
-					"enum": [
-						"rigid",
-						"articulated",
-						"centre axle drawbar",
-						"semi-car transporter",
-						"semi-trailer",
-						"long semi-trailer",
-						"low loader",
-						"other",
-						"drawbar",
-						"four-in-line",
-						"dolly",
-						"full drawbar"
-					]
-				},
-				"techRecord_vehicleType": {
-					"title": "Vehicle Type",
-					"type": "string",
-					"enum": [
-						"psv",
-						"trl",
-						"hgv",
-						"car",
-						"lgv",
-						"motorcycle"
-					]
-				},
-				"vin": {
-					"type": "string"
-				},
-				"techRecord_hiddenInVta": {
-					"type": "boolean"
-				},
-				"techRecord_updateType": {
-					"type": "string"
-				}
+			"maxLength": 150
+		},
+		"techRecord_applicantDetails_address1": {
+			"type": [
+				"null",
+				"string"
+			],
+			"maxLength": 60
+		},
+		"techRecord_applicantDetails_address2": {
+			"type": [
+				"null",
+				"string"
+			],
+			"maxLength": 60
+		},
+		"techRecord_applicantDetails_postTown": {
+			"type": [
+				"null",
+				"string"
+			],
+			"maxLength": 60
+		},
+		"techRecord_applicantDetails_address3": {
+			"type": [
+				"null",
+				"string"
+			],
+			"maxLength": 60
+		},
+		"techRecord_applicantDetails_postCode": {
+			"type": [
+				"null",
+				"string"
+			],
+			"maxLength": 12
+		},
+		"techRecord_applicantDetails_telephoneNumber": {
+			"type": [
+				"null",
+				"string"
+			],
+			"maxLength": 25
+		},
+		"techRecord_applicantDetails_emailAddress": {
+			"type": [
+				"null",
+				"string"
+			],
+			"maxLength": 255
+		},
+		"createdTimestamp": {
+			"type": [
+				"string"
+			]
+		},
+		"partialVin": {
+			"type": "string"
+		},
+		"primaryVrm": {
+			"type": "string"
+		},
+		"systemNumber": {
+			"type": "string"
+		},
+		"techRecord_createdAt": {
+			"type": "string"
+		},
+		"techRecord_createdById": {
+			"type": "string"
+		},
+		"techRecord_createdByName": {
+			"type": "string"
+		},
+		"techRecord_euVehicleCategory": {
+			"title": "EU vehicle category",
+			"type": "string",
+			"enum": [
+				"m1",
+				"m2",
+				"m3",
+				"n1",
+				"n2",
+				"n3",
+				"o1",
+				"o2",
+				"o3",
+				"o4",
+				"l1e-a",
+				"l1e",
+				"l2e",
+				"l3e",
+				"l4e",
+				"l5e",
+				"l6e",
+				"l7e"
+			]
+		},
+		"techRecord_lastUpdatedAt": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_lastUpdatedById": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_lastUpdatedByName": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_manufactureYear": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_recordCompleteness": {
+			"type": "string"
+		},
+		"techRecord_noOfAxles": {
+			"type": "integer"
+		},
+		"techRecord_notes": {
+			"type": "string"
+		},
+		"techRecord_reasonForCreation": {
+			"type": "string"
+		},
+		"techRecord_regnDate": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_statusCode": {
+			"title": "Status Code",
+			"type": "string",
+			"enum": [
+				"provisional",
+				"current",
+				"archived"
+			]
+		},
+		"techRecord_vehicleConfiguration": {
+			"title": "Vehicle Configuration",
+			"type": "string",
+			"enum": [
+				"rigid",
+				"articulated",
+				"centre axle drawbar",
+				"semi-car transporter",
+				"semi-trailer",
+				"long semi-trailer",
+				"low loader",
+				"other",
+				"drawbar",
+				"four-in-line",
+				"dolly",
+				"full drawbar"
+			]
+		},
+		"techRecord_vehicleType": {
+			"title": "Vehicle Type",
+			"type": "string",
+			"enum": [
+				"psv",
+				"trl",
+				"hgv",
+				"car",
+				"lgv",
+				"motorcycle"
+			]
+		},
+		"vin": {
+			"type": "string"
+		},
+		"techRecord_hiddenInVta": {
+			"type": "boolean"
+		},
+		"techRecord_updateType": {
+			"type": "string"
+		},
+		"secondaryVrms": {
+			"type": "array",
+			"items": {
+				"type": "string"
 			}
 		}
-	]
+	}
 }

--- a/json-schemas/v3/tech-record/get/motorcycle/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/motorcycle/skeleton/index.json
@@ -2,217 +2,205 @@
 	"title": "Tech Record Skeleton Car Schema",
 	"type": "object",
 	"additionalProperties": false,
-	"allOf": [
-		{
-			"title": "Tech Record Skeleton Car Schema",
-			"type": "object",
-			"additionalProperties": false,
-			"required": [
-				"createdTimestamp",
-				"systemNumber",
-				"vin"
+	"properties": {
+		"techRecord_applicantDetails_name": {
+			"type": [
+				"string",
+				"null"
 			],
-			"properties": {
-				"techRecord_applicantDetails_name": {
-					"type": [
-						"string",
-						"null"
-					],
-					"maxLength": 150
-				},
-				"techRecord_applicantDetails_address1": {
-					"type": [
-						"null",
-						"string"
-					],
-					"maxLength": 60
-				},
-				"techRecord_applicantDetails_address2": {
-					"type": [
-						"null",
-						"string"
-					],
-					"maxLength": 60
-				},
-				"techRecord_applicantDetails_postTown": {
-					"type": [
-						"null",
-						"string"
-					],
-					"maxLength": 60
-				},
-				"techRecord_applicantDetails_address3": {
-					"type": [
-						"null",
-						"string"
-					],
-					"maxLength": 60
-				},
-				"techRecord_applicantDetails_postCode": {
-					"type": [
-						"null",
-						"string"
-					],
-					"maxLength": 12
-				},
-				"techRecord_applicantDetails_telephoneNumber": {
-					"type": [
-						"null",
-						"string"
-					],
-					"maxLength": 25
-				},
-				"techRecord_applicantDetails_emailAddress": {
-					"type": [
-						"null",
-						"string"
-					],
-					"maxLength": 255
-				},
-				"createdTimestamp": {
-					"type": [
-						"string"
-					]
-				},
-				"partialVin": {
-					"type": "string"
-				},
-				"primaryVrm": {
-					"type": "string"
-				},
-				"systemNumber": {
-					"type": "string"
-				},
-				"techRecord_createdAt": {
-					"type": "string"
-				},
-				"techRecord_createdById": {
-					"type": "string"
-				},
-				"techRecord_createdByName": {
-					"type": "string"
-				},
-				"techRecord_euVehicleCategory": {
-					"title": "EU vehicle category",
-					"type": "string",
-					"enum": [
-						"m1",
-						"m2",
-						"m3",
-						"n1",
-						"n2",
-						"n3",
-						"o1",
-						"o2",
-						"o3",
-						"o4",
-						"l1e-a",
-						"l1e",
-						"l2e",
-						"l3e",
-						"l4e",
-						"l5e",
-						"l6e",
-						"l7e"
-					]
-				},
-				"techRecord_lastUpdatedAt": {
-					"type": [
-						"string",
-						"null"
-					]
-				},
-				"techRecord_lastUpdatedById": {
-					"type": [
-						"string",
-						"null"
-					]
-				},
-				"techRecord_lastUpdatedByName": {
-					"type": [
-						"string",
-						"null"
-					]
-				},
-				"techRecord_manufactureYear": {
-					"type": [
-						"string",
-						"null"
-					]
-				},
-				"techRecord_recordCompleteness": {
-					"type": "string"
-				},
-				"techRecord_noOfAxles": {
-					"type": "integer"
-				},
-				"techRecord_notes": {
-					"type": "string"
-				},
-				"techRecord_reasonForCreation": {
-					"type": "string"
-				},
-				"techRecord_regnDate": {
-					"type": [
-						"string",
-						"null"
-					]
-				},
-				"techRecord_statusCode": {
-					"title": "Status Code",
-					"type": "string",
-					"enum": [
-						"provisional",
-						"current",
-						"archived"
-					]
-				},
-				"techRecord_vehicleConfiguration": {
-					"title": "Vehicle Configuration",
-					"type": "string",
-					"enum": [
-						"rigid",
-						"articulated",
-						"centre axle drawbar",
-						"semi-car transporter",
-						"semi-trailer",
-						"long semi-trailer",
-						"low loader",
-						"other",
-						"drawbar",
-						"four-in-line",
-						"dolly",
-						"full drawbar"
-					]
-				},
-				"techRecord_vehicleType": {
-					"title": "Vehicle Type",
-					"type": "string",
-					"enum": [
-						"psv",
-						"trl",
-						"hgv",
-						"car",
-						"lgv",
-						"motorcycle"
-					]
-				},
-				"vin": {
-					"type": "string"
-				},
-				"techRecord_hiddenInVta": {
-					"type": "boolean"
-				},
-				"techRecord_updateType": {
-					"type": "string"
-				},
-				"secondaryVrms": {
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				}
+			"maxLength": 150
+		},
+		"techRecord_applicantDetails_address1": {
+			"type": [
+				"null",
+				"string"
+			],
+			"maxLength": 60
+		},
+		"techRecord_applicantDetails_address2": {
+			"type": [
+				"null",
+				"string"
+			],
+			"maxLength": 60
+		},
+		"techRecord_applicantDetails_postTown": {
+			"type": [
+				"null",
+				"string"
+			],
+			"maxLength": 60
+		},
+		"techRecord_applicantDetails_address3": {
+			"type": [
+				"null",
+				"string"
+			],
+			"maxLength": 60
+		},
+		"techRecord_applicantDetails_postCode": {
+			"type": [
+				"null",
+				"string"
+			],
+			"maxLength": 12
+		},
+		"techRecord_applicantDetails_telephoneNumber": {
+			"type": [
+				"null",
+				"string"
+			],
+			"maxLength": 25
+		},
+		"techRecord_applicantDetails_emailAddress": {
+			"type": [
+				"null",
+				"string"
+			],
+			"maxLength": 255
+		},
+		"createdTimestamp": {
+			"type": [
+				"string"
+			]
+		},
+		"partialVin": {
+			"type": "string"
+		},
+		"primaryVrm": {
+			"type": "string"
+		},
+		"systemNumber": {
+			"type": "string"
+		},
+		"techRecord_createdAt": {
+			"type": "string"
+		},
+		"techRecord_createdById": {
+			"type": "string"
+		},
+		"techRecord_createdByName": {
+			"type": "string"
+		},
+		"techRecord_euVehicleCategory": {
+			"title": "EU vehicle category",
+			"type": "string",
+			"enum": [
+				"m1",
+				"m2",
+				"m3",
+				"n1",
+				"n2",
+				"n3",
+				"o1",
+				"o2",
+				"o3",
+				"o4",
+				"l1e-a",
+				"l1e",
+				"l2e",
+				"l3e",
+				"l4e",
+				"l5e",
+				"l6e",
+				"l7e"
+			]
+		},
+		"techRecord_lastUpdatedAt": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_lastUpdatedById": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_lastUpdatedByName": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_manufactureYear": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_recordCompleteness": {
+			"type": "string"
+		},
+		"techRecord_noOfAxles": {
+			"type": "integer"
+		},
+		"techRecord_notes": {
+			"type": "string"
+		},
+		"techRecord_reasonForCreation": {
+			"type": "string"
+		},
+		"techRecord_regnDate": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_statusCode": {
+			"title": "Status Code",
+			"type": "string",
+			"enum": [
+				"provisional",
+				"current",
+				"archived"
+			]
+		},
+		"techRecord_vehicleConfiguration": {
+			"title": "Vehicle Configuration",
+			"type": "string",
+			"enum": [
+				"rigid",
+				"articulated",
+				"centre axle drawbar",
+				"semi-car transporter",
+				"semi-trailer",
+				"long semi-trailer",
+				"low loader",
+				"other",
+				"drawbar",
+				"four-in-line",
+				"dolly",
+				"full drawbar"
+			]
+		},
+		"techRecord_vehicleType": {
+			"title": "Vehicle Type",
+			"type": "string",
+			"enum": [
+				"psv",
+				"trl",
+				"hgv",
+				"car",
+				"lgv",
+				"motorcycle"
+			]
+		},
+		"vin": {
+			"type": "string"
+		},
+		"techRecord_hiddenInVta": {
+			"type": "boolean"
+		},
+		"techRecord_updateType": {
+			"type": "string"
+		},
+		"secondaryVrms": {
+			"type": "array",
+			"items": {
+				"type": "string"
 			}
 		}
-	]
+	}
 }

--- a/json-schemas/v3/tech-record/get/motorcycle/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/motorcycle/skeleton/index.json
@@ -205,6 +205,12 @@
 				},
 				"techRecord_updateType": {
 					"type": "string"
+				},
+				"secondaryVrms": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
 				}
 			}
 		}

--- a/json-schemas/v3/tech-record/put/car/complete/index.json
+++ b/json-schemas/v3/tech-record/put/car/complete/index.json
@@ -101,6 +101,12 @@
 		},
 		"techRecord_createdByName": {
 			"type": "string"
+		},
+		"secondaryVrms": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
 		}
 	}
 }

--- a/json-schemas/v3/tech-record/put/car/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/car/skeleton/index.json
@@ -81,6 +81,12 @@
 		},
 		"techRecord_createdByName": {
 			"type": "string"
+		},
+		"secondaryVrms": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
 		}
 	}
 }

--- a/json-schemas/v3/tech-record/put/lgv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/lgv/complete/index.json
@@ -3,7 +3,8 @@
 	"type": "object",
 	"additionalProperties": false,
 	"required": [
-		"techRecord_vehicleSubclass"
+		"techRecord_vehicleSubclass",
+		"vin"
 	],
 	"properties": {
 		"vin": {

--- a/json-schemas/v3/tech-record/put/lgv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/lgv/complete/index.json
@@ -5,112 +5,107 @@
 	"required": [
 		"techRecord_vehicleSubclass"
 	],
-	"allOf": [
-		{
-			"title": "Tech Record PUT Request Complete Car Schema",
-			"type": "object",
-			"additionalProperties": false,
-			"required": [
-				"techRecord_vehicleSubclass",
-				"vin"
-			],
-			"properties": {
-				"vin": {
-					"type": "string"
-				},
-				"primaryVrm": {
-					"type": "string"
-				},
-				"trailerId": {
-					"type": [
-						"string",
-						"null"
-					]
-				},
-				"techRecord_reasonForCreation": {
-					"type": [
-						"string",
-						"null"
-					]
-				},
-				"techRecord_vehicleType": {
-					"title": "Vehicle Type",
-					"type": "string",
-					"enum": [
-						"psv",
-						"trl",
-						"hgv",
-						"car",
-						"lgv",
-						"motorcycle"
-					]
-				},
-				"techRecord_statusCode": {
-					"title": "Status Code",
-					"type": "string",
-					"enum": [
-						"provisional",
-						"current",
-						"archived"
-					]
-				},
-				"techRecord_regnDate": {
-					"type": [
-						"string",
-						"null"
-					]
-				},
-				"techRecord_manufactureYear": {
-					"type": [
-						"string",
-						"null"
-					]
-				},
-				"techRecord_noOfAxles": {
-					"type": [
-						"integer",
-						"null"
-					]
-				},
-				"techRecord_notes": {
-					"type": "string"
-				},
-				"techRecord_vehicleSubclass": {
-					"title": "Vehicle Subclass",
-					"type": "array",
-					"items": {
-						"type": "string",
-						"enum": [
-							"n",
-							"p",
-							"a",
-							"s",
-							"c",
-							"l",
-							"t",
-							"e",
-							"m",
-							"r",
-							"w"
-						]
-					}
-				},
-				"techRecord_hiddenInVta": {
-					"type": "boolean"
-				},
-				"techRecord_updateType": {
-					"type": "string"
-				},
-				"techRecord_createdAt": {
-					"type": "string"
-				},
-				"techRecord_createdById": {
-					"type": "string"
-				},
-				"techRecord_createdByName": {
-					"type": "string"
-				}
+	"properties": {
+		"vin": {
+			"type": "string"
+		},
+		"primaryVrm": {
+			"type": "string"
+		},
+		"trailerId": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_reasonForCreation": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_vehicleType": {
+			"title": "Vehicle Type",
+			"type": "string",
+			"enum": [
+				"psv",
+				"trl",
+				"hgv",
+				"car",
+				"lgv",
+				"motorcycle"
+			]
+		},
+		"techRecord_statusCode": {
+			"title": "Status Code",
+			"type": "string",
+			"enum": [
+				"provisional",
+				"current",
+				"archived"
+			]
+		},
+		"techRecord_regnDate": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_manufactureYear": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_noOfAxles": {
+			"type": [
+				"integer",
+				"null"
+			]
+		},
+		"techRecord_notes": {
+			"type": "string"
+		},
+		"techRecord_vehicleSubclass": {
+			"title": "Vehicle Subclass",
+			"type": "array",
+			"items": {
+				"type": "string",
+				"enum": [
+					"n",
+					"p",
+					"a",
+					"s",
+					"c",
+					"l",
+					"t",
+					"e",
+					"m",
+					"r",
+					"w"
+				]
+			}
+		},
+		"techRecord_hiddenInVta": {
+			"type": "boolean"
+		},
+		"techRecord_updateType": {
+			"type": "string"
+		},
+		"techRecord_createdAt": {
+			"type": "string"
+		},
+		"techRecord_createdById": {
+			"type": "string"
+		},
+		"techRecord_createdByName": {
+			"type": "string"
+		},
+		"secondaryVrms": {
+			"type": "array",
+			"items": {
+				"type": "string"
 			}
 		}
-	]
+	}
 }

--- a/json-schemas/v3/tech-record/put/lgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/lgv/skeleton/index.json
@@ -2,92 +2,87 @@
 	"title": "Tech Record Complete Car Schema",
 	"type": "object",
 	"additionalProperties": false,
-	"allOf": [
-		{
-			"title": "Tech Record PUT Request Skeleton Car Schema",
-			"type": "object",
-			"additionalProperties": false,
-			"required": [
-				"vin",
-				"techRecord_vehicleType"
-			],
-			"properties": {
-				"vin": {
-					"type": "string"
-				},
-				"primaryVrm": {
-					"type": "string"
-				},
-				"trailerId": {
-					"type": [
-						"string",
-						"null"
-					]
-				},
-				"techRecord_reasonForCreation": {
-					"type": [
-						"string",
-						"null"
-					]
-				},
-				"techRecord_vehicleType": {
-					"title": "Vehicle Type",
-					"type": "string",
-					"enum": [
-						"psv",
-						"trl",
-						"hgv",
-						"car",
-						"lgv",
-						"motorcycle"
-					]
-				},
-				"techRecord_statusCode": {
-					"title": "Status Code",
-					"type": "string",
-					"enum": [
-						"provisional",
-						"current",
-						"archived"
-					]
-				},
-				"techRecord_regnDate": {
-					"type": [
-						"string",
-						"null"
-					]
-				},
-				"techRecord_manufactureYear": {
-					"type": [
-						"string",
-						"null"
-					]
-				},
-				"techRecord_noOfAxles": {
-					"type": [
-						"integer",
-						"null"
-					]
-				},
-				"techRecord_notes": {
-					"type": "string"
-				},
-				"techRecord_hiddenInVta": {
-					"type": "boolean"
-				},
-				"techRecord_updateType": {
-					"type": "string"
-				},
-				"techRecord_createdAt": {
-					"type": "string"
-				},
-				"techRecord_createdById": {
-					"type": "string"
-				},
-				"techRecord_createdByName": {
-					"type": "string"
-				}
+	"properties": {
+		"vin": {
+			"type": "string"
+		},
+		"primaryVrm": {
+			"type": "string"
+		},
+		"trailerId": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_reasonForCreation": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_vehicleType": {
+			"title": "Vehicle Type",
+			"type": "string",
+			"enum": [
+				"psv",
+				"trl",
+				"hgv",
+				"car",
+				"lgv",
+				"motorcycle"
+			]
+		},
+		"techRecord_statusCode": {
+			"title": "Status Code",
+			"type": "string",
+			"enum": [
+				"provisional",
+				"current",
+				"archived"
+			]
+		},
+		"techRecord_regnDate": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_manufactureYear": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_noOfAxles": {
+			"type": [
+				"integer",
+				"null"
+			]
+		},
+		"techRecord_notes": {
+			"type": "string"
+		},
+		"techRecord_hiddenInVta": {
+			"type": "boolean"
+		},
+		"techRecord_updateType": {
+			"type": "string"
+		},
+		"techRecord_createdAt": {
+			"type": "string"
+		},
+		"techRecord_createdById": {
+			"type": "string"
+		},
+		"techRecord_createdByName": {
+			"type": "string"
+		},
+		"secondaryVrms": {
+			"type": "array",
+			"items": {
+				"type": "string"
 			}
 		}
-	]
+	}
 }

--- a/json-schemas/v3/tech-record/put/lgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/lgv/skeleton/index.json
@@ -2,6 +2,10 @@
 	"title": "Tech Record Complete Car Schema",
 	"type": "object",
 	"additionalProperties": false,
+	"required": [
+		"vin",
+		"techRecord_vehicleType"
+	],
 	"properties": {
 		"vin": {
 			"type": "string"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "2.1.1",
+  "version": "2.1.11",
   "description": "type definitions for cvs vta application",
   "main": "index.js",
   "repository": {

--- a/schema-validator.ts
+++ b/schema-validator.ts
@@ -4,14 +4,21 @@ import { schemas } from "./schemas";
 
 export type Schema = typeof schemas[number];
 
-export function isValidObject<B extends boolean | undefined>(schemaName: Schema, objectToValidate: object): boolean
-export function isValidObject<B extends boolean | undefined>(schemaName: Schema, objectToValidate: object, returnErrors: B): B extends false ? boolean : ErrorObject[]
+export function isValidObject<B extends boolean | undefined>(
+  schemaName: Schema,
+  objectToValidate: object
+): boolean;
+export function isValidObject<B extends boolean | undefined>(
+  schemaName: Schema,
+  objectToValidate: object,
+  returnErrors: B
+): B extends false ? boolean : ErrorObject[];
 export function isValidObject<B extends boolean | undefined>(
   schemaName: Schema,
   objectToValidate: object,
   returnErrors?: B,
-  logErrors = false,
-): (boolean | ErrorObject[]) {
+  logErrors = false
+): boolean | ErrorObject[] {
   const ajv = new Ajv({ removeAdditional: true, allErrors: true });
   const schema = JSON.parse(
     readFileSync(`${__dirname}/json-schemas/${schemaName}`, "utf8")
@@ -28,4 +35,4 @@ export function isValidObject<B extends boolean | undefined>(
   }
 
   return isValid;
-};
+}

--- a/types/v3/tech-record/get/car/complete/index.d.ts
+++ b/types/v3/tech-record/get/car/complete/index.d.ts
@@ -74,4 +74,5 @@ export interface TechRecordCompleteCarSchema {
   techRecord_vehicleSubclass: VehicleSubclass;
   techRecord_hiddenInVta?: boolean;
   techRecord_updateType?: string;
+  secondaryVrms?: string[];
 }

--- a/types/v3/tech-record/get/car/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/car/skeleton/index.d.ts
@@ -72,4 +72,5 @@ export interface TechRecordSkeletonCarSchema {
   vin: string;
   techRecord_hiddenInVta?: boolean;
   techRecord_updateType?: string;
+  secondaryVrms?: string[];
 }

--- a/types/v3/tech-record/get/lgv/complete/index.d.ts
+++ b/types/v3/tech-record/get/lgv/complete/index.d.ts
@@ -50,10 +50,10 @@ export interface TechRecordCompleteLGVSchema {
   techRecord_applicantDetails_postCode?: null | string;
   techRecord_applicantDetails_telephoneNumber?: null | string;
   techRecord_applicantDetails_emailAddress?: null | string;
-  createdTimestamp?: string;
+  createdTimestamp: string;
   partialVin?: string;
   primaryVrm?: string;
-  systemNumber?: string;
+  systemNumber: string;
   techRecord_createdAt?: string;
   techRecord_createdById?: string;
   techRecord_createdByName?: string;
@@ -70,7 +70,7 @@ export interface TechRecordCompleteLGVSchema {
   techRecord_statusCode?: StatusCode;
   techRecord_vehicleConfiguration?: VehicleConfiguration;
   techRecord_vehicleType?: VehicleType;
-  vin?: string;
+  vin: string;
   techRecord_vehicleSubclass: VehicleSubclass;
   techRecord_hiddenInVta?: boolean;
   techRecord_updateType?: string;

--- a/types/v3/tech-record/get/lgv/complete/index.d.ts
+++ b/types/v3/tech-record/get/lgv/complete/index.d.ts
@@ -5,7 +5,6 @@
  * and run json-schema-to-typescript to regenerate this file.
  */
 
-export type TechRecordCompleteLGVSchema = TechRecordCompleteCarSchema;
 export type EUVehicleCategory =
   | "m1"
   | "m2"
@@ -42,7 +41,7 @@ export type VehicleConfiguration =
 export type VehicleType = "psv" | "trl" | "hgv" | "car" | "lgv" | "motorcycle";
 export type VehicleSubclass = ("n" | "p" | "a" | "s" | "c" | "l" | "t" | "e" | "m" | "r" | "w")[];
 
-export interface TechRecordCompleteCarSchema {
+export interface TechRecordCompleteLGVSchema {
   techRecord_applicantDetails_name?: string | null;
   techRecord_applicantDetails_address1?: null | string;
   techRecord_applicantDetails_address2?: null | string;
@@ -51,10 +50,10 @@ export interface TechRecordCompleteCarSchema {
   techRecord_applicantDetails_postCode?: null | string;
   techRecord_applicantDetails_telephoneNumber?: null | string;
   techRecord_applicantDetails_emailAddress?: null | string;
-  createdTimestamp: string;
+  createdTimestamp?: string;
   partialVin?: string;
   primaryVrm?: string;
-  systemNumber: string;
+  systemNumber?: string;
   techRecord_createdAt?: string;
   techRecord_createdById?: string;
   techRecord_createdByName?: string;
@@ -71,8 +70,9 @@ export interface TechRecordCompleteCarSchema {
   techRecord_statusCode?: StatusCode;
   techRecord_vehicleConfiguration?: VehicleConfiguration;
   techRecord_vehicleType?: VehicleType;
-  vin: string;
+  vin?: string;
   techRecord_vehicleSubclass: VehicleSubclass;
   techRecord_hiddenInVta?: boolean;
   techRecord_updateType?: string;
+  secondaryVrms?: string[];
 }

--- a/types/v3/tech-record/get/lgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/lgv/skeleton/index.d.ts
@@ -5,7 +5,6 @@
  * and run json-schema-to-typescript to regenerate this file.
  */
 
-export type TechRecordSkeletonCarSchema = TechRecordSkeletonCarSchema1;
 export type EUVehicleCategory =
   | "m1"
   | "m2"
@@ -41,7 +40,7 @@ export type VehicleConfiguration =
   | "full drawbar";
 export type VehicleType = "psv" | "trl" | "hgv" | "car" | "lgv" | "motorcycle";
 
-export interface TechRecordSkeletonCarSchema1 {
+export interface TechRecordSkeletonCarSchema {
   techRecord_applicantDetails_name?: string | null;
   techRecord_applicantDetails_address1?: null | string;
   techRecord_applicantDetails_address2?: null | string;
@@ -50,10 +49,10 @@ export interface TechRecordSkeletonCarSchema1 {
   techRecord_applicantDetails_postCode?: null | string;
   techRecord_applicantDetails_telephoneNumber?: null | string;
   techRecord_applicantDetails_emailAddress?: null | string;
-  createdTimestamp: string;
+  createdTimestamp?: string;
   partialVin?: string;
   primaryVrm?: string;
-  systemNumber: string;
+  systemNumber?: string;
   techRecord_createdAt?: string;
   techRecord_createdById?: string;
   techRecord_createdByName?: string;
@@ -70,7 +69,8 @@ export interface TechRecordSkeletonCarSchema1 {
   techRecord_statusCode?: StatusCode;
   techRecord_vehicleConfiguration?: VehicleConfiguration;
   techRecord_vehicleType?: VehicleType;
-  vin: string;
+  vin?: string;
   techRecord_hiddenInVta?: boolean;
   techRecord_updateType?: string;
+  secondaryVrms?: string[];
 }

--- a/types/v3/tech-record/get/lgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/lgv/skeleton/index.d.ts
@@ -49,10 +49,10 @@ export interface TechRecordSkeletonCarSchema {
   techRecord_applicantDetails_postCode?: null | string;
   techRecord_applicantDetails_telephoneNumber?: null | string;
   techRecord_applicantDetails_emailAddress?: null | string;
-  createdTimestamp?: string;
+  createdTimestamp: string;
   partialVin?: string;
   primaryVrm?: string;
-  systemNumber?: string;
+  systemNumber: string;
   techRecord_createdAt?: string;
   techRecord_createdById?: string;
   techRecord_createdByName?: string;
@@ -69,7 +69,7 @@ export interface TechRecordSkeletonCarSchema {
   techRecord_statusCode?: StatusCode;
   techRecord_vehicleConfiguration?: VehicleConfiguration;
   techRecord_vehicleType?: VehicleType;
-  vin?: string;
+  vin: string;
   techRecord_hiddenInVta?: boolean;
   techRecord_updateType?: string;
   secondaryVrms?: string[];

--- a/types/v3/tech-record/get/motorcycle/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/motorcycle/skeleton/index.d.ts
@@ -73,4 +73,5 @@ export interface TechRecordSkeletonCarSchema1 {
   vin: string;
   techRecord_hiddenInVta?: boolean;
   techRecord_updateType?: string;
+  secondaryVrms?: string[];
 }

--- a/types/v3/tech-record/get/motorcycle/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/motorcycle/skeleton/index.d.ts
@@ -5,7 +5,6 @@
  * and run json-schema-to-typescript to regenerate this file.
  */
 
-export type TechRecordSkeletonCarSchema = TechRecordSkeletonCarSchema1;
 export type EUVehicleCategory =
   | "m1"
   | "m2"
@@ -41,7 +40,7 @@ export type VehicleConfiguration =
   | "full drawbar";
 export type VehicleType = "psv" | "trl" | "hgv" | "car" | "lgv" | "motorcycle";
 
-export interface TechRecordSkeletonCarSchema1 {
+export interface TechRecordSkeletonCarSchema {
   techRecord_applicantDetails_name?: string | null;
   techRecord_applicantDetails_address1?: null | string;
   techRecord_applicantDetails_address2?: null | string;
@@ -50,10 +49,10 @@ export interface TechRecordSkeletonCarSchema1 {
   techRecord_applicantDetails_postCode?: null | string;
   techRecord_applicantDetails_telephoneNumber?: null | string;
   techRecord_applicantDetails_emailAddress?: null | string;
-  createdTimestamp: string;
+  createdTimestamp?: string;
   partialVin?: string;
   primaryVrm?: string;
-  systemNumber: string;
+  systemNumber?: string;
   techRecord_createdAt?: string;
   techRecord_createdById?: string;
   techRecord_createdByName?: string;
@@ -70,7 +69,7 @@ export interface TechRecordSkeletonCarSchema1 {
   techRecord_statusCode?: StatusCode;
   techRecord_vehicleConfiguration?: VehicleConfiguration;
   techRecord_vehicleType?: VehicleType;
-  vin: string;
+  vin?: string;
   techRecord_hiddenInVta?: boolean;
   techRecord_updateType?: string;
   secondaryVrms?: string[];

--- a/types/v3/tech-record/put/car/complete/index.d.ts
+++ b/types/v3/tech-record/put/car/complete/index.d.ts
@@ -26,4 +26,5 @@ export interface TechRecordPUTRequestCompleteCarSchema {
   techRecord_createdAt?: string;
   techRecord_createdById?: string;
   techRecord_createdByName?: string;
+  secondaryVrms?: string[];
 }

--- a/types/v3/tech-record/put/car/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/car/skeleton/index.d.ts
@@ -24,4 +24,5 @@ export interface TechRecordPUTRequestSkeletonCarSchema {
   techRecord_createdAt?: string;
   techRecord_createdById?: string;
   techRecord_createdByName?: string;
+  secondaryVrms?: string[];
 }

--- a/types/v3/tech-record/put/lgv/complete/index.d.ts
+++ b/types/v3/tech-record/put/lgv/complete/index.d.ts
@@ -10,7 +10,7 @@ export type StatusCode = "provisional" | "current" | "archived";
 export type VehicleSubclass = ("n" | "p" | "a" | "s" | "c" | "l" | "t" | "e" | "m" | "r" | "w")[];
 
 export interface TechRecordCompleteLGVSchema {
-  vin?: string;
+  vin: string;
   primaryVrm?: string;
   trailerId?: string | null;
   techRecord_reasonForCreation?: string | null;

--- a/types/v3/tech-record/put/lgv/complete/index.d.ts
+++ b/types/v3/tech-record/put/lgv/complete/index.d.ts
@@ -5,13 +5,12 @@
  * and run json-schema-to-typescript to regenerate this file.
  */
 
-export type TechRecordCompleteLGVSchema = TechRecordPUTRequestCompleteCarSchema;
 export type VehicleType = "psv" | "trl" | "hgv" | "car" | "lgv" | "motorcycle";
 export type StatusCode = "provisional" | "current" | "archived";
 export type VehicleSubclass = ("n" | "p" | "a" | "s" | "c" | "l" | "t" | "e" | "m" | "r" | "w")[];
 
-export interface TechRecordPUTRequestCompleteCarSchema {
-  vin: string;
+export interface TechRecordCompleteLGVSchema {
+  vin?: string;
   primaryVrm?: string;
   trailerId?: string | null;
   techRecord_reasonForCreation?: string | null;
@@ -27,4 +26,5 @@ export interface TechRecordPUTRequestCompleteCarSchema {
   techRecord_createdAt?: string;
   techRecord_createdById?: string;
   techRecord_createdByName?: string;
+  secondaryVrms?: string[];
 }

--- a/types/v3/tech-record/put/lgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/lgv/skeleton/index.d.ts
@@ -5,16 +5,15 @@
  * and run json-schema-to-typescript to regenerate this file.
  */
 
-export type TechRecordCompleteCarSchema = TechRecordPUTRequestSkeletonCarSchema;
 export type VehicleType = "psv" | "trl" | "hgv" | "car" | "lgv" | "motorcycle";
 export type StatusCode = "provisional" | "current" | "archived";
 
-export interface TechRecordPUTRequestSkeletonCarSchema {
-  vin: string;
+export interface TechRecordCompleteCarSchema {
+  vin?: string;
   primaryVrm?: string;
   trailerId?: string | null;
   techRecord_reasonForCreation?: string | null;
-  techRecord_vehicleType: VehicleType;
+  techRecord_vehicleType?: VehicleType;
   techRecord_statusCode?: StatusCode;
   techRecord_regnDate?: string | null;
   techRecord_manufactureYear?: string | null;
@@ -25,4 +24,5 @@ export interface TechRecordPUTRequestSkeletonCarSchema {
   techRecord_createdAt?: string;
   techRecord_createdById?: string;
   techRecord_createdByName?: string;
+  secondaryVrms?: string[];
 }

--- a/types/v3/tech-record/put/lgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/lgv/skeleton/index.d.ts
@@ -9,11 +9,11 @@ export type VehicleType = "psv" | "trl" | "hgv" | "car" | "lgv" | "motorcycle";
 export type StatusCode = "provisional" | "current" | "archived";
 
 export interface TechRecordCompleteCarSchema {
-  vin?: string;
+  vin: string;
   primaryVrm?: string;
   trailerId?: string | null;
   techRecord_reasonForCreation?: string | null;
-  techRecord_vehicleType?: VehicleType;
+  techRecord_vehicleType: VehicleType;
   techRecord_statusCode?: StatusCode;
   techRecord_regnDate?: string | null;
   techRecord_manufactureYear?: string | null;


### PR DESCRIPTION
## Ticket title

LGV was stripping everything due to a known limitation with AJV.

Include summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`.

## Changelog

- Add secondary vrms to car and lgv
- Rewrite LGV to not use allOf due to bad behavior with removeAdditional

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
