### PR TITLE
patch(60): correct techRecord_tyres_dataTrAxles to tyres_dataTrAxles

### DIFF
--- a/json-definitions/v3/tech-record/get/hgv/complete/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/complete/index.json
@@ -471,7 +471,7 @@
               }
             ]
           },
-          "techRecord_tyres_dataTrAxles": {
+          "tyres_dataTrAxles": {
             "type": [
               "null",
               "integer"

--- a/json-schemas/v3/tech-record/get/hgv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/complete/index.json
@@ -486,7 +486,7 @@
 							}
 						]
 					},
-					"techRecord_tyres_dataTrAxles": {
+					"tyres_dataTrAxles": {
 						"type": [
 							"null",
 							"integer"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "2.1.19",
+  "version": "2.1.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "2.1.19",
+      "version": "2.1.20",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "2.1.19",
+  "version": "2.1.20",
   "description": "type definitions for cvs vta application",
   "main": "index.js",
   "repository": {

--- a/types/v3/tech-record/get/hgv/complete/index.d.ts
+++ b/types/v3/tech-record/get/hgv/complete/index.d.ts
@@ -278,7 +278,7 @@ export interface HGVAxles {
   tyres_tyreSize?: string;
   tyres_plyRating?: string | null;
   tyres_fitmentCode?: FitmentCode;
-  techRecord_tyres_dataTrAxles?: null | number;
+  tyres_dataTrAxles?: null | number;
 }
 export interface HGVPlates {
   plateSerialNumber?: string | null;


### PR DESCRIPTION
## correct techRecord_tyres_dataTrAxles to tyres_dataTrAxles

Closes [60](https://github.com/dvsa/cvs-type-definitions/issues/60)


<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

- techRecord_tyres_dataTrAxles changed to tyres_dataTrAxles in HGV schema

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
