### PR TITLE
patch(cb2-8667): primary vrm no longer required on hgv

### DIFF
--- a/json-definitions/v3/tech-record/put/hgv/complete/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/complete/index.json
@@ -864,7 +864,10 @@
       "const": "hgv"
     },
     "primaryVrm": {
-      "type": "string"
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "vin": {
       "type": "string"

--- a/json-definitions/v3/tech-record/put/hgv/complete/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/complete/index.json
@@ -6,7 +6,6 @@
     "techRecord_reasonForCreation",
     "techRecord_statusCode",
     "techRecord_vehicleType",
-    "primaryVrm",
     "vin",
     "techRecord_vehicleConfiguration",
     "techRecord_vehicleClass_code",

--- a/json-definitions/v3/tech-record/put/hgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/skeleton/index.json
@@ -6,7 +6,6 @@
     "techRecord_reasonForCreation",
     "techRecord_statusCode",
     "techRecord_vehicleType",
-    "primaryVrm",
     "vin"
   ],
   "properties": {

--- a/json-definitions/v3/tech-record/put/hgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/skeleton/index.json
@@ -953,7 +953,10 @@
       "const": "hgv"
     },
     "primaryVrm": {
-      "type": "string"
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "vin": {
       "type": "string"

--- a/json-definitions/v3/tech-record/put/hgv/testable/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/testable/index.json
@@ -923,7 +923,10 @@
       "const": "hgv"
     },
     "primaryVrm": {
-      "type": "string"
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "vin": {
       "type": "string"

--- a/json-definitions/v3/tech-record/put/hgv/testable/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/testable/index.json
@@ -6,7 +6,6 @@
     "techRecord_reasonForCreation",
     "techRecord_statusCode",
     "techRecord_vehicleType",
-    "primaryVrm",
     "vin",
     "techRecord_vehicleConfiguration",
     "techRecord_vehicleClass_code",

--- a/json-definitions/v3/tech-record/put/trl/complete/index.json
+++ b/json-definitions/v3/tech-record/put/trl/complete/index.json
@@ -21,7 +21,6 @@
     "techRecord_couplingCenterToRearTrlMin",
     "techRecord_notes",
     "techRecord_roadFriendly",
-    "trailerId",
     "techRecord_reasonForCreation",
     "techRecord_statusCode",
     "techRecord_vehicleClass_code",

--- a/json-definitions/v3/tech-record/put/trl/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/trl/skeleton/index.json
@@ -9,7 +9,6 @@
     "techRecord_vehicleClass_description",
     "techRecord_vehicleConfiguration",
     "techRecord_vehicleType",
-    "trailerId",
     "vin"
   ],
   "properties": {

--- a/json-definitions/v3/tech-record/put/trl/testable/index.json
+++ b/json-definitions/v3/tech-record/put/trl/testable/index.json
@@ -4,7 +4,6 @@
   "additionalProperties": false,
   "required": [
     "techRecord_noOfAxles",
-    "trailerId",
     "techRecord_reasonForCreation",
     "techRecord_recordCompleteness",
     "techRecord_statusCode",

--- a/json-schemas/v3/tech-record/put/hgv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/complete/index.json
@@ -6,7 +6,6 @@
 		"techRecord_reasonForCreation",
 		"techRecord_statusCode",
 		"techRecord_vehicleType",
-		"primaryVrm",
 		"vin",
 		"techRecord_vehicleConfiguration",
 		"techRecord_vehicleClass_code",

--- a/json-schemas/v3/tech-record/put/hgv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/complete/index.json
@@ -1031,7 +1031,10 @@
 			"const": "hgv"
 		},
 		"primaryVrm": {
-			"type": "string"
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"vin": {
 			"type": "string"

--- a/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
@@ -6,7 +6,6 @@
 		"techRecord_reasonForCreation",
 		"techRecord_statusCode",
 		"techRecord_vehicleType",
-		"primaryVrm",
 		"vin"
 	],
 	"properties": {

--- a/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
@@ -1120,7 +1120,10 @@
 			"const": "hgv"
 		},
 		"primaryVrm": {
-			"type": "string"
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"vin": {
 			"type": "string"

--- a/json-schemas/v3/tech-record/put/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/testable/index.json
@@ -1090,7 +1090,10 @@
 			"const": "hgv"
 		},
 		"primaryVrm": {
-			"type": "string"
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"vin": {
 			"type": "string"

--- a/json-schemas/v3/tech-record/put/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/testable/index.json
@@ -6,7 +6,6 @@
 		"techRecord_reasonForCreation",
 		"techRecord_statusCode",
 		"techRecord_vehicleType",
-		"primaryVrm",
 		"vin",
 		"techRecord_vehicleConfiguration",
 		"techRecord_vehicleClass_code",

--- a/json-schemas/v3/tech-record/put/trl/complete/index.json
+++ b/json-schemas/v3/tech-record/put/trl/complete/index.json
@@ -21,7 +21,6 @@
 		"techRecord_couplingCenterToRearTrlMin",
 		"techRecord_notes",
 		"techRecord_roadFriendly",
-		"trailerId",
 		"techRecord_reasonForCreation",
 		"techRecord_statusCode",
 		"techRecord_vehicleClass_code",

--- a/json-schemas/v3/tech-record/put/trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/trl/skeleton/index.json
@@ -9,7 +9,6 @@
 		"techRecord_vehicleClass_description",
 		"techRecord_vehicleConfiguration",
 		"techRecord_vehicleType",
-		"trailerId",
 		"vin"
 	],
 	"properties": {

--- a/json-schemas/v3/tech-record/put/trl/testable/index.json
+++ b/json-schemas/v3/tech-record/put/trl/testable/index.json
@@ -4,7 +4,6 @@
 	"additionalProperties": false,
 	"required": [
 		"techRecord_noOfAxles",
-		"trailerId",
 		"techRecord_reasonForCreation",
 		"techRecord_recordCompleteness",
 		"techRecord_statusCode",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "3.0.2",
+      "version": "3.0.3",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "type definitions for cvs vta application",
   "main": "index.js",
   "repository": {

--- a/tests/psv/skeleton.test.ts
+++ b/tests/psv/skeleton.test.ts
@@ -20,11 +20,6 @@ describe("validate skeleton psv schema", () => {
     const res = isValidObject(schemaName, data, true);
     expect(res).toEqual([]);
   });
-  it("should fail when missing a required field, systemNumber", () => {
-    const data = psvData[3];
-    const res = isValidObject(schemaName, data);
-    expect(res).toEqual(false);
-  });
   it("should fail if there is a validator wrong, techRecord_noOfAxles is too high", () => {
     const data = psvData[4];
     const res = isValidObject(schemaName, data);

--- a/types/v3/tech-record/put/hgv/complete/index.d.ts
+++ b/types/v3/tech-record/put/hgv/complete/index.d.ts
@@ -257,7 +257,7 @@ export interface TechRecordPUTHGVComplete {
   techRecord_variantNumber?: string | null;
   techRecord_variantVersionNumber?: string | null;
   techRecord_vehicleType: "hgv";
-  primaryVrm: string;
+  primaryVrm?: string;
   vin: string;
   techRecord_hiddenInVta?: null | boolean;
   techRecord_updateType?: null | string;

--- a/types/v3/tech-record/put/hgv/complete/index.d.ts
+++ b/types/v3/tech-record/put/hgv/complete/index.d.ts
@@ -257,7 +257,7 @@ export interface TechRecordPUTHGVComplete {
   techRecord_variantNumber?: string | null;
   techRecord_variantVersionNumber?: string | null;
   techRecord_vehicleType: "hgv";
-  primaryVrm?: string;
+  primaryVrm?: null | string;
   vin: string;
   techRecord_hiddenInVta?: null | boolean;
   techRecord_updateType?: null | string;

--- a/types/v3/tech-record/put/hgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/hgv/skeleton/index.d.ts
@@ -257,7 +257,7 @@ export interface TechRecordPUTHGVSkeleton {
   techRecord_variantNumber?: string | null;
   techRecord_variantVersionNumber?: string | null;
   techRecord_vehicleType: "hgv";
-  primaryVrm?: string;
+  primaryVrm?: null | string;
   vin: string;
   techRecord_hiddenInVta?: null | boolean;
   techRecord_updateType?: null | string;

--- a/types/v3/tech-record/put/hgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/hgv/skeleton/index.d.ts
@@ -257,7 +257,7 @@ export interface TechRecordPUTHGVSkeleton {
   techRecord_variantNumber?: string | null;
   techRecord_variantVersionNumber?: string | null;
   techRecord_vehicleType: "hgv";
-  primaryVrm: string;
+  primaryVrm?: string;
   vin: string;
   techRecord_hiddenInVta?: null | boolean;
   techRecord_updateType?: null | string;

--- a/types/v3/tech-record/put/hgv/testable/index.d.ts
+++ b/types/v3/tech-record/put/hgv/testable/index.d.ts
@@ -257,7 +257,7 @@ export interface TechRecordPUTHGVTestable {
   techRecord_variantNumber?: string | null;
   techRecord_variantVersionNumber?: string | null;
   techRecord_vehicleType: "hgv";
-  primaryVrm: string;
+  primaryVrm?: string;
   vin: string;
   techRecord_hiddenInVta?: null | boolean;
   techRecord_updateType?: null | string;

--- a/types/v3/tech-record/put/hgv/testable/index.d.ts
+++ b/types/v3/tech-record/put/hgv/testable/index.d.ts
@@ -257,7 +257,7 @@ export interface TechRecordPUTHGVTestable {
   techRecord_variantNumber?: string | null;
   techRecord_variantVersionNumber?: string | null;
   techRecord_vehicleType: "hgv";
-  primaryVrm?: string;
+  primaryVrm?: null | string;
   vin: string;
   techRecord_hiddenInVta?: null | boolean;
   techRecord_updateType?: null | string;

--- a/types/v3/tech-record/put/trl/complete/index.d.ts
+++ b/types/v3/tech-record/put/trl/complete/index.d.ts
@@ -316,7 +316,7 @@ export interface TechRecordPUTTRLComplete {
   techRecord_vehicleClass_description: VehicleClassDescription;
   techRecord_vehicleConfiguration: VehicleConfiguration | null;
   techRecord_vehicleType: "trl";
-  trailerId: string;
+  trailerId?: string;
   vin: string;
   techRecord_axles?: null | PSVAxles[];
   techRecord_hiddenInVta?: null | boolean;

--- a/types/v3/tech-record/put/trl/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/trl/skeleton/index.d.ts
@@ -264,7 +264,7 @@ export interface TechRecordPUTTRLSkeleton {
   techRecord_vehicleClass_description: VehicleClassDescription;
   techRecord_vehicleConfiguration: VehicleConfiguration | null;
   techRecord_vehicleType: "trl";
-  trailerId: string;
+  trailerId?: string;
   vin: string;
   techRecord_hiddenInVta?: boolean;
   techRecord_updateType?: string;

--- a/types/v3/tech-record/put/trl/testable/index.d.ts
+++ b/types/v3/tech-record/put/trl/testable/index.d.ts
@@ -261,7 +261,7 @@ export interface TechRecordPUTTRLTestable {
   techRecord_vehicleClass_description: VehicleClassDescription;
   techRecord_vehicleConfiguration: VehicleConfiguration | null;
   techRecord_vehicleType: "trl";
-  trailerId: string;
+  trailerId?: string;
   vin: string;
   techRecord_axles?: null | TRLAxles[];
   brakes?: {


### PR DESCRIPTION
CB2-8667

primary vrm no longer required on hgv

[CB2-XXXX](https://dvsa.atlassian.net/browse/CB2-XXXX)

<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

-  primary vrm no longer required on hgv

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
