### PR TITLE
patch(*): consistent typing on manufactureYear

### DIFF
--- a/json-definitions/v3/tech-record/get/car/complete/index.json
+++ b/json-definitions/v3/tech-record/get/car/complete/index.json
@@ -134,7 +134,7 @@
     },
     "techRecord_manufactureYear": {
       "type": [
-        "string",
+        "integer",
         "null"
       ]
     },

--- a/json-definitions/v3/tech-record/get/car/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/car/skeleton/index.json
@@ -133,7 +133,7 @@
     },
     "techRecord_manufactureYear": {
       "type": [
-        "string",
+        "integer",
         "null"
       ]
     },

--- a/json-definitions/v3/tech-record/get/lgv/complete/index.json
+++ b/json-definitions/v3/tech-record/get/lgv/complete/index.json
@@ -134,7 +134,7 @@
     },
     "techRecord_manufactureYear": {
       "type": [
-        "string",
+        "integer",
         "null"
       ]
     },

--- a/json-definitions/v3/tech-record/get/lgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/lgv/skeleton/index.json
@@ -133,7 +133,7 @@
     },
     "techRecord_manufactureYear": {
       "type": [
-        "string",
+        "integer",
         "null"
       ]
     },

--- a/json-definitions/v3/tech-record/get/motorcycle/complete/index.json
+++ b/json-definitions/v3/tech-record/get/motorcycle/complete/index.json
@@ -139,7 +139,7 @@
     },
     "techRecord_manufactureYear": {
       "type": [
-        "string",
+        "integer",
         "null"
       ]
     },

--- a/json-definitions/v3/tech-record/get/motorcycle/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/motorcycle/skeleton/index.json
@@ -132,7 +132,7 @@
     },
     "techRecord_manufactureYear": {
       "type": [
-        "string",
+        "integer",
         "null"
       ]
     },

--- a/json-definitions/v3/tech-record/put/car/complete/index.json
+++ b/json-definitions/v3/tech-record/put/car/complete/index.json
@@ -50,7 +50,7 @@
     },
     "techRecord_manufactureYear": {
       "type": [
-        "string",
+        "integer",
         "null"
       ]
     },

--- a/json-definitions/v3/tech-record/put/car/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/car/skeleton/index.json
@@ -49,7 +49,7 @@
     },
     "techRecord_manufactureYear": {
       "type": [
-        "string",
+        "integer",
         "null"
       ]
     },

--- a/json-definitions/v3/tech-record/put/lgv/complete/index.json
+++ b/json-definitions/v3/tech-record/put/lgv/complete/index.json
@@ -103,7 +103,7 @@
     },
     "techRecord_manufactureYear": {
       "type": [
-        "string",
+        "integer",
         "null"
       ]
     },

--- a/json-definitions/v3/tech-record/put/lgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/lgv/skeleton/index.json
@@ -102,7 +102,7 @@
     },
     "techRecord_manufactureYear": {
       "type": [
-        "string",
+        "integer",
         "null"
       ]
     },

--- a/json-definitions/v3/tech-record/put/motorcycle/complete/index.json
+++ b/json-definitions/v3/tech-record/put/motorcycle/complete/index.json
@@ -146,7 +146,7 @@
     },
     "techRecord_manufactureYear": {
       "type": [
-        "string",
+        "integer",
         "null"
       ]
     },

--- a/json-definitions/v3/tech-record/put/motorcycle/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/motorcycle/skeleton/index.json
@@ -136,7 +136,7 @@
     },
     "techRecord_manufactureYear": {
       "type": [
-        "string",
+        "integer",
         "null"
       ]
     },

--- a/json-schemas/v3/tech-record/get/car/complete/index.json
+++ b/json-schemas/v3/tech-record/get/car/complete/index.json
@@ -155,7 +155,7 @@
 		},
 		"techRecord_manufactureYear": {
 			"type": [
-				"string",
+				"integer",
 				"null"
 			]
 		},

--- a/json-schemas/v3/tech-record/get/car/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/car/skeleton/index.json
@@ -154,7 +154,7 @@
 		},
 		"techRecord_manufactureYear": {
 			"type": [
-				"string",
+				"integer",
 				"null"
 			]
 		},

--- a/json-schemas/v3/tech-record/get/lgv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/lgv/complete/index.json
@@ -155,7 +155,7 @@
 		},
 		"techRecord_manufactureYear": {
 			"type": [
-				"string",
+				"integer",
 				"null"
 			]
 		},

--- a/json-schemas/v3/tech-record/get/lgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/lgv/skeleton/index.json
@@ -154,7 +154,7 @@
 		},
 		"techRecord_manufactureYear": {
 			"type": [
-				"string",
+				"integer",
 				"null"
 			]
 		},

--- a/json-schemas/v3/tech-record/get/motorcycle/complete/index.json
+++ b/json-schemas/v3/tech-record/get/motorcycle/complete/index.json
@@ -160,7 +160,7 @@
 		},
 		"techRecord_manufactureYear": {
 			"type": [
-				"string",
+				"integer",
 				"null"
 			]
 		},

--- a/json-schemas/v3/tech-record/get/motorcycle/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/motorcycle/skeleton/index.json
@@ -153,7 +153,7 @@
 		},
 		"techRecord_manufactureYear": {
 			"type": [
-				"string",
+				"integer",
 				"null"
 			]
 		},

--- a/json-schemas/v3/tech-record/put/car/complete/index.json
+++ b/json-schemas/v3/tech-record/put/car/complete/index.json
@@ -65,7 +65,7 @@
 		},
 		"techRecord_manufactureYear": {
 			"type": [
-				"string",
+				"integer",
 				"null"
 			]
 		},

--- a/json-schemas/v3/tech-record/put/car/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/car/skeleton/index.json
@@ -64,7 +64,7 @@
 		},
 		"techRecord_manufactureYear": {
 			"type": [
-				"string",
+				"integer",
 				"null"
 			]
 		},

--- a/json-schemas/v3/tech-record/put/lgv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/lgv/complete/index.json
@@ -139,7 +139,7 @@
 		},
 		"techRecord_manufactureYear": {
 			"type": [
-				"string",
+				"integer",
 				"null"
 			]
 		},

--- a/json-schemas/v3/tech-record/put/lgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/lgv/skeleton/index.json
@@ -138,7 +138,7 @@
 		},
 		"techRecord_manufactureYear": {
 			"type": [
-				"string",
+				"integer",
 				"null"
 			]
 		},

--- a/json-schemas/v3/tech-record/put/motorcycle/complete/index.json
+++ b/json-schemas/v3/tech-record/put/motorcycle/complete/index.json
@@ -167,7 +167,7 @@
 		},
 		"techRecord_manufactureYear": {
 			"type": [
-				"string",
+				"integer",
 				"null"
 			]
 		},

--- a/json-schemas/v3/tech-record/put/motorcycle/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/motorcycle/skeleton/index.json
@@ -157,7 +157,7 @@
 		},
 		"techRecord_manufactureYear": {
 			"type": [
-				"string",
+				"integer",
 				"null"
 			]
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "3.0.6",
+      "version": "3.0.7",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "type definitions for cvs vta application",
   "main": "index.js",
   "repository": {

--- a/types/v3/tech-record/get/car/complete/index.d.ts
+++ b/types/v3/tech-record/get/car/complete/index.d.ts
@@ -61,7 +61,7 @@ export interface TechRecordGETCarComplete {
   techRecord_lastUpdatedAt?: string | null;
   techRecord_lastUpdatedById?: string | null;
   techRecord_lastUpdatedByName?: string | null;
-  techRecord_manufactureYear?: string | null;
+  techRecord_manufactureYear?: number | null;
   techRecord_recordCompleteness?: null | string;
   techRecord_noOfAxles?: null | number;
   techRecord_notes?: null | string;

--- a/types/v3/tech-record/get/car/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/car/skeleton/index.d.ts
@@ -60,7 +60,7 @@ export interface TechRecordGETCarSkeleton {
   techRecord_lastUpdatedAt?: string | null;
   techRecord_lastUpdatedById?: string | null;
   techRecord_lastUpdatedByName?: string | null;
-  techRecord_manufactureYear?: string | null;
+  techRecord_manufactureYear?: number | null;
   techRecord_recordCompleteness?: null | string;
   techRecord_noOfAxles?: null | number;
   techRecord_notes?: null | string;

--- a/types/v3/tech-record/get/lgv/complete/index.d.ts
+++ b/types/v3/tech-record/get/lgv/complete/index.d.ts
@@ -61,7 +61,7 @@ export interface TechRecordGETLGVComplete {
   techRecord_lastUpdatedAt?: string | null;
   techRecord_lastUpdatedById?: string | null;
   techRecord_lastUpdatedByName?: string | null;
-  techRecord_manufactureYear?: string | null;
+  techRecord_manufactureYear?: number | null;
   techRecord_recordCompleteness?: null | string;
   techRecord_noOfAxles?: null | number;
   techRecord_notes?: null | string;

--- a/types/v3/tech-record/get/lgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/lgv/skeleton/index.d.ts
@@ -60,7 +60,7 @@ export interface TechRecordGETLGVSkeleton {
   techRecord_lastUpdatedAt?: string | null;
   techRecord_lastUpdatedById?: string | null;
   techRecord_lastUpdatedByName?: string | null;
-  techRecord_manufactureYear?: string | null;
+  techRecord_manufactureYear?: number | null;
   techRecord_recordCompleteness?: null | string;
   techRecord_noOfAxles?: null | number;
   techRecord_notes?: null | string;

--- a/types/v3/tech-record/get/motorcycle/complete/index.d.ts
+++ b/types/v3/tech-record/get/motorcycle/complete/index.d.ts
@@ -62,7 +62,7 @@ export interface TechRecordGETMotorcycleComplete {
   techRecord_lastUpdatedAt?: string | null;
   techRecord_lastUpdatedById?: string | null;
   techRecord_lastUpdatedByName?: string | null;
-  techRecord_manufactureYear?: string | null;
+  techRecord_manufactureYear?: number | null;
   techRecord_recordCompleteness?: null | string;
   techRecord_noOfAxles?: null | number;
   techRecord_notes?: null | string;

--- a/types/v3/tech-record/get/motorcycle/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/motorcycle/skeleton/index.d.ts
@@ -60,7 +60,7 @@ export interface TechRecordGETMotorcycleSkeleton {
   techRecord_lastUpdatedAt?: string | null;
   techRecord_lastUpdatedById?: string | null;
   techRecord_lastUpdatedByName?: string | null;
-  techRecord_manufactureYear?: string | null;
+  techRecord_manufactureYear?: number | null;
   techRecord_recordCompleteness?: null | string;
   techRecord_noOfAxles?: null | number;
   techRecord_notes?: null | string;

--- a/types/v3/tech-record/put/car/complete/index.d.ts
+++ b/types/v3/tech-record/put/car/complete/index.d.ts
@@ -17,7 +17,7 @@ export interface TechRecordPUTCarComplete {
   techRecord_vehicleType: VehicleType;
   techRecord_statusCode?: null | StatusCode;
   techRecord_regnDate?: string | null;
-  techRecord_manufactureYear?: string | null;
+  techRecord_manufactureYear?: number | null;
   techRecord_noOfAxles?: number | null;
   techRecord_notes?: string;
   techRecord_vehicleSubclass: VehicleSubclass;

--- a/types/v3/tech-record/put/car/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/car/skeleton/index.d.ts
@@ -16,7 +16,7 @@ export interface TechRecordPUTCarSkeleton {
   techRecord_vehicleType: VehicleType;
   techRecord_statusCode?: null | StatusCode;
   techRecord_regnDate?: string | null;
-  techRecord_manufactureYear?: string | null;
+  techRecord_manufactureYear?: number | null;
   techRecord_noOfAxles?: number | null;
   techRecord_notes?: null | string;
   techRecord_hiddenInVta?: null | boolean;

--- a/types/v3/tech-record/put/lgv/complete/index.d.ts
+++ b/types/v3/tech-record/put/lgv/complete/index.d.ts
@@ -45,7 +45,7 @@ export interface TechRecordPUTLGVComplete {
   techRecord_vehicleType: VehicleType;
   techRecord_statusCode?: StatusCode;
   techRecord_regnDate?: string | null;
-  techRecord_manufactureYear?: string | null;
+  techRecord_manufactureYear?: number | null;
   techRecord_noOfAxles?: number | null;
   techRecord_notes?: string;
   techRecord_vehicleSubclass: VehicleSubclass;

--- a/types/v3/tech-record/put/lgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/lgv/skeleton/index.d.ts
@@ -44,7 +44,7 @@ export interface TechRecordPUTLGVSkeleton {
   techRecord_vehicleType: VehicleType;
   techRecord_statusCode?: StatusCode;
   techRecord_regnDate?: string | null;
-  techRecord_manufactureYear?: string | null;
+  techRecord_manufactureYear?: number | null;
   techRecord_noOfAxles?: number | null;
   techRecord_notes?: string;
   techRecord_hiddenInVta?: boolean;

--- a/types/v3/tech-record/put/motorcycle/complete/index.d.ts
+++ b/types/v3/tech-record/put/motorcycle/complete/index.d.ts
@@ -62,7 +62,7 @@ export interface TechRecordPUTMotorcycleComplete {
   techRecord_lastUpdatedAt?: string | null;
   techRecord_lastUpdatedById?: string | null;
   techRecord_lastUpdatedByName?: string | null;
-  techRecord_manufactureYear?: string | null;
+  techRecord_manufactureYear?: number | null;
   techRecord_recordCompleteness?: null | string;
   techRecord_noOfAxles?: null | number;
   techRecord_notes?: null | string;

--- a/types/v3/tech-record/put/motorcycle/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/motorcycle/skeleton/index.d.ts
@@ -60,7 +60,7 @@ export interface TechRecordPUTMotorcycleSkeleton {
   techRecord_lastUpdatedAt?: string | null;
   techRecord_lastUpdatedById?: string | null;
   techRecord_lastUpdatedByName?: string | null;
-  techRecord_manufactureYear?: string | null;
+  techRecord_manufactureYear?: number | null;
   techRecord_recordCompleteness?: null | string;
   techRecord_noOfAxles?: null | number;
   techRecord_notes?: null | string;


### PR DESCRIPTION
## Ticket title

Apply a consistent type on cvs-type-definitions

Resolves https://github.com/dvsa/cvs-type-definitions/issues/73

## Changelog

- Consistent type on manufacture year

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
