### PR TITLE
patch(cb2-8667): adds the approval type to trailers some other changes

### DIFF
--- a/json-definitions/v3/tech-record/get/hgv/complete/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/complete/index.json
@@ -673,6 +673,9 @@
         }
       ]
     },
+    "techRecord_microfilm": {
+      "type": "null"
+    },
     "techRecord_microfilm_microfilmDocumentType": {
       "anyOf": [
         {

--- a/json-definitions/v3/tech-record/get/hgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/skeleton/index.json
@@ -719,6 +719,9 @@
         }
       ]
     },
+    "techRecord_microfilm": {
+      "type": "null"
+    },
     "techRecord_microfilm_microfilmDocumentType": {
       "anyOf": [
         {

--- a/json-definitions/v3/tech-record/get/hgv/testable/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/testable/index.json
@@ -717,6 +717,9 @@
         }
       ]
     },
+    "techRecord_microfilm": {
+      "type": "null"
+    },
     "techRecord_microfilm_microfilmDocumentType": {
       "anyOf": [
         {

--- a/json-definitions/v3/tech-record/get/psv/complete/index.json
+++ b/json-definitions/v3/tech-record/get/psv/complete/index.json
@@ -287,6 +287,9 @@
         "null"
       ]
     },
+    "techRecord_dda": {
+      "type": "null"
+    },
     "techRecord_dda_certificateIssued": {
       "type": "boolean"
     },
@@ -521,6 +524,9 @@
       ],
       "maximum": 99999,
       "minimum": 0
+    },
+    "techRecord_dimensions": {
+      "type": "null"
     },
     "techRecord_dimensions_length": {
       "type": [
@@ -800,7 +806,10 @@
       "maximum": 99999,
       "minimum": 0
     },
-    "techRecord_microfilmDocumentType": {
+    "techRecord_microfilm": {
+      "type": "null"
+    },
+    "techRecord_microfilm_microfilmDocumentType": {
       "anyOf": [
         {
           "$ref": "../../../enums/microfilmDocumentType.ignore.json"
@@ -810,14 +819,14 @@
         }
       ]
     },
-    "techRecord_microfilmRollNumber": {
+    "techRecord_microfilm_microfilmRollNumber": {
       "type": [
         "string",
         "null"
       ],
       "maxLength": 5
     },
-    "techRecord_microfilmSerialNumber": {
+    "techRecord_microfilm_microfilmSerialNumber": {
       "type": [
         "string",
         "null"

--- a/json-definitions/v3/tech-record/get/psv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/psv/skeleton/index.json
@@ -266,6 +266,9 @@
         "null"
       ]
     },
+    "techRecord_dda": {
+      "type": "null"
+    },
     "techRecord_dda_certificateIssued": {
       "type": [
         "boolean",
@@ -525,6 +528,9 @@
       ],
       "maximum": 99999,
       "minimum": 0
+    },
+    "techRecord_dimensions": {
+      "type": "null"
     },
     "techRecord_dimensions_length": {
       "type": [
@@ -844,7 +850,10 @@
       "maximum": 99999,
       "minimum": 0
     },
-    "techRecord_microfilmDocumentType": {
+    "techRecord_microfilm": {
+      "type": "null"
+    },
+    "techRecord_microfilm_microfilmDocumentType": {
       "anyOf": [
         {
           "$ref": "../../../enums/microfilmDocumentType.ignore.json"
@@ -854,14 +863,14 @@
         }
       ]
     },
-    "techRecord_microfilmRollNumber": {
+    "techRecord_microfilm_microfilmRollNumber": {
       "type": [
         "string",
         "null"
       ],
       "maxLength": 5
     },
-    "techRecord_microfilmSerialNumber": {
+    "techRecord_microfilm_microfilmSerialNumber": {
       "type": [
         "string",
         "null"

--- a/json-definitions/v3/tech-record/get/psv/testable/index.json
+++ b/json-definitions/v3/tech-record/get/psv/testable/index.json
@@ -252,6 +252,9 @@
         "null"
       ]
     },
+    "techRecord_dda": {
+      "type": "null"
+    },
     "techRecord_dda_certificateIssued": {
       "type": [
         "boolean",
@@ -511,6 +514,9 @@
       ],
       "maximum": 99999,
       "minimum": 0
+    },
+    "techRecord_dimensions": {
+      "type": "null"
     },
     "techRecord_dimensions_length": {
       "type": [
@@ -830,7 +836,10 @@
       "maximum": 99999,
       "minimum": 0
     },
-    "techRecord_microfilmDocumentType": {
+    "techRecord_microfilm": {
+      "type": "null"
+    },
+    "techRecord_microfilm_microfilmDocumentType": {
       "anyOf": [
         {
           "$ref": "../../../enums/microfilmDocumentType.ignore.json"
@@ -840,14 +849,14 @@
         }
       ]
     },
-    "techRecord_microfilmRollNumber": {
+    "techRecord_microfilm_microfilmRollNumber": {
       "type": [
         "string",
         "null"
       ],
       "maxLength": 5
     },
-    "techRecord_microfilmSerialNumber": {
+    "techRecord_microfilm_microfilmSerialNumber": {
       "type": [
         "string",
         "null"

--- a/json-definitions/v3/tech-record/get/trl/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/trl/skeleton/index.json
@@ -388,6 +388,41 @@
         "string"
       ]
     },
+    "techRecord_approvalType": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/approvalType.ignore.json"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_approvalTypeNumber": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 25
+    },
+    "techRecord_ntaNumber": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "techRecord_variantNumber": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "techRecord_variantVersionNumber": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "techRecord_authIntoService": {
       "type": [
         "string",

--- a/json-definitions/v3/tech-record/get/trl/testable/index.json
+++ b/json-definitions/v3/tech-record/get/trl/testable/index.json
@@ -391,6 +391,41 @@
         "null"
       ]
     },
+    "techRecord_approvalType": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/approvalType.ignore.json"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_approvalTypeNumber": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 25
+    },
+    "techRecord_ntaNumber": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "techRecord_variantNumber": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "techRecord_variantVersionNumber": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "techRecord_authIntoService": {
       "type": [
         "string",

--- a/json-definitions/v3/tech-record/put/psv/complete/index.json
+++ b/json-definitions/v3/tech-record/put/psv/complete/index.json
@@ -798,7 +798,7 @@
       "maximum": 99999,
       "minimum": 0
     },
-    "techRecord_microfilmDocumentType": {
+    "techRecord_microfilm_microfilmDocumentType": {
       "anyOf": [
         {
           "$ref": "../../../enums/microfilmDocumentType.ignore.json"
@@ -808,14 +808,14 @@
         }
       ]
     },
-    "techRecord_microfilmRollNumber": {
+    "techRecord_microfilm_microfilmRollNumber": {
       "type": [
         "string",
         "null"
       ],
       "maxLength": 5
     },
-    "techRecord_microfilmSerialNumber": {
+    "techRecord_microfilm_microfilmSerialNumber": {
       "type": [
         "string",
         "null"

--- a/json-definitions/v3/tech-record/put/psv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/psv/skeleton/index.json
@@ -856,7 +856,7 @@
       "maximum": 99999,
       "minimum": 0
     },
-    "techRecord_microfilmDocumentType": {
+    "techRecord_microfilm_microfilmDocumentType": {
       "anyOf": [
         {
           "$ref": "../../../enums/microfilmDocumentType.ignore.json"
@@ -866,14 +866,14 @@
         }
       ]
     },
-    "techRecord_microfilmRollNumber": {
+    "techRecord_microfilm_microfilmRollNumber": {
       "type": [
         "string",
         "null"
       ],
       "maxLength": 5
     },
-    "techRecord_microfilmSerialNumber": {
+    "techRecord_microfilm_microfilmSerialNumber": {
       "type": [
         "string",
         "null"

--- a/json-definitions/v3/tech-record/put/psv/testable/index.json
+++ b/json-definitions/v3/tech-record/put/psv/testable/index.json
@@ -834,7 +834,7 @@
       "maximum": 99999,
       "minimum": 0
     },
-    "techRecord_microfilmDocumentType": {
+    "techRecord_microfilm_microfilmDocumentType": {
       "anyOf": [
         {
           "$ref": "../../../enums/microfilmDocumentType.ignore.json"
@@ -844,14 +844,14 @@
         }
       ]
     },
-    "techRecord_microfilmRollNumber": {
+    "techRecord_microfilm_microfilmRollNumber": {
       "type": [
         "string",
         "null"
       ],
       "maxLength": 5
     },
-    "techRecord_microfilmSerialNumber": {
+    "techRecord_microfilm_microfilmSerialNumber": {
       "type": [
         "string",
         "null"

--- a/json-definitions/v3/tech-record/put/trl/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/trl/skeleton/index.json
@@ -18,6 +18,41 @@
         "null"
       ]
     },
+    "techRecord_approvalType": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/approvalType.ignore.json"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }, 
+    "techRecord_approvalTypeNumber": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 25
+    },
+    "techRecord_ntaNumber": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "techRecord_variantNumber": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "techRecord_variantVersionNumber": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "techRecord_createdAt": {
       "type": "string"
     },
@@ -623,12 +658,6 @@
       ],
       "minimum": 0,
       "maximum": 99999
-    },
-    "techRecord_microfilm": {
-      "type": [
-        "string",
-        "null"
-      ]
     },
     "techRecord_microfilm_microfilmDocumentType": {
       "anyOf": [

--- a/json-definitions/v3/tech-record/put/trl/testable/index.json
+++ b/json-definitions/v3/tech-record/put/trl/testable/index.json
@@ -22,6 +22,41 @@
         "null"
       ]
     },
+    "techRecord_approvalType": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/approvalType.ignore.json"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "techRecord_approvalTypeNumber": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 25
+    },
+    "techRecord_ntaNumber": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "techRecord_variantNumber": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "techRecord_variantVersionNumber": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "techRecord_createdAt": {
       "type": "string"
     },
@@ -630,12 +665,6 @@
       ],
       "minimum": 0,
       "maximum": 99999
-    },
-    "techRecord_microfilm": {
-      "type": [
-        "string",
-        "null"
-      ]
     },
     "techRecord_microfilm_microfilmDocumentType": {
       "anyOf": [

--- a/json-schemas/v3/tech-record/get/hgv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/complete/index.json
@@ -721,6 +721,9 @@
 				}
 			]
 		},
+		"techRecord_microfilm": {
+			"type": "null"
+		},
 		"techRecord_microfilm_microfilmDocumentType": {
 			"anyOf": [
 				{

--- a/json-schemas/v3/tech-record/get/hgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/skeleton/index.json
@@ -767,6 +767,9 @@
 				}
 			]
 		},
+		"techRecord_microfilm": {
+			"type": "null"
+		},
 		"techRecord_microfilm_microfilmDocumentType": {
 			"anyOf": [
 				{

--- a/json-schemas/v3/tech-record/get/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/testable/index.json
@@ -765,6 +765,9 @@
 				}
 			]
 		},
+		"techRecord_microfilm": {
+			"type": "null"
+		},
 		"techRecord_microfilm_microfilmDocumentType": {
 			"anyOf": [
 				{

--- a/json-schemas/v3/tech-record/get/psv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/psv/complete/index.json
@@ -389,6 +389,9 @@
 				"null"
 			]
 		},
+		"techRecord_dda": {
+			"type": "null"
+		},
 		"techRecord_dda_certificateIssued": {
 			"type": "boolean"
 		},
@@ -647,6 +650,9 @@
 			],
 			"maximum": 99999,
 			"minimum": 0
+		},
+		"techRecord_dimensions": {
+			"type": "null"
 		},
 		"techRecord_dimensions_length": {
 			"type": [
@@ -967,7 +973,10 @@
 			"maximum": 99999,
 			"minimum": 0
 		},
-		"techRecord_microfilmDocumentType": {
+		"techRecord_microfilm": {
+			"type": "null"
+		},
+		"techRecord_microfilm_microfilmDocumentType": {
 			"anyOf": [
 				{
 					"title": "Microfilm Document Type",
@@ -1035,14 +1044,14 @@
 				}
 			]
 		},
-		"techRecord_microfilmRollNumber": {
+		"techRecord_microfilm_microfilmRollNumber": {
 			"type": [
 				"string",
 				"null"
 			],
 			"maxLength": 5
 		},
-		"techRecord_microfilmSerialNumber": {
+		"techRecord_microfilm_microfilmSerialNumber": {
 			"type": [
 				"string",
 				"null"

--- a/json-schemas/v3/tech-record/get/psv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/psv/skeleton/index.json
@@ -368,6 +368,9 @@
 				"null"
 			]
 		},
+		"techRecord_dda": {
+			"type": "null"
+		},
 		"techRecord_dda_certificateIssued": {
 			"type": [
 				"boolean",
@@ -651,6 +654,9 @@
 			],
 			"maximum": 99999,
 			"minimum": 0
+		},
+		"techRecord_dimensions": {
+			"type": "null"
 		},
 		"techRecord_dimensions_length": {
 			"type": [
@@ -1011,7 +1017,10 @@
 			"maximum": 99999,
 			"minimum": 0
 		},
-		"techRecord_microfilmDocumentType": {
+		"techRecord_microfilm": {
+			"type": "null"
+		},
+		"techRecord_microfilm_microfilmDocumentType": {
 			"anyOf": [
 				{
 					"title": "Microfilm Document Type",
@@ -1079,14 +1088,14 @@
 				}
 			]
 		},
-		"techRecord_microfilmRollNumber": {
+		"techRecord_microfilm_microfilmRollNumber": {
 			"type": [
 				"string",
 				"null"
 			],
 			"maxLength": 5
 		},
-		"techRecord_microfilmSerialNumber": {
+		"techRecord_microfilm_microfilmSerialNumber": {
 			"type": [
 				"string",
 				"null"

--- a/json-schemas/v3/tech-record/get/psv/testable/index.json
+++ b/json-schemas/v3/tech-record/get/psv/testable/index.json
@@ -354,6 +354,9 @@
 				"null"
 			]
 		},
+		"techRecord_dda": {
+			"type": "null"
+		},
 		"techRecord_dda_certificateIssued": {
 			"type": [
 				"boolean",
@@ -637,6 +640,9 @@
 			],
 			"maximum": 99999,
 			"minimum": 0
+		},
+		"techRecord_dimensions": {
+			"type": "null"
 		},
 		"techRecord_dimensions_length": {
 			"type": [
@@ -997,7 +1003,10 @@
 			"maximum": 99999,
 			"minimum": 0
 		},
-		"techRecord_microfilmDocumentType": {
+		"techRecord_microfilm": {
+			"type": "null"
+		},
+		"techRecord_microfilm_microfilmDocumentType": {
 			"anyOf": [
 				{
 					"title": "Microfilm Document Type",
@@ -1065,14 +1074,14 @@
 				}
 			]
 		},
-		"techRecord_microfilmRollNumber": {
+		"techRecord_microfilm_microfilmRollNumber": {
 			"type": [
 				"string",
 				"null"
 			],
 			"maxLength": 5
 		},
-		"techRecord_microfilmSerialNumber": {
+		"techRecord_microfilm_microfilmSerialNumber": {
 			"type": [
 				"string",
 				"null"

--- a/json-schemas/v3/tech-record/get/trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/trl/skeleton/index.json
@@ -398,6 +398,58 @@
 				"string"
 			]
 		},
+		"techRecord_approvalType": {
+			"anyOf": [
+				{
+					"title": "Approval Type",
+					"type": "string",
+					"enum": [
+						"NTA",
+						"ECTA",
+						"IVA",
+						"NSSTA",
+						"ECSSTA",
+						"GB WVTA",
+						"UKNI WVTA",
+						"EU WVTA Pre 23",
+						"EU WVTA 23 on",
+						"QNIG",
+						"Prov.GB WVTA",
+						"Small series",
+						"IVA - VCA",
+						"IVA - DVSA/NI"
+					]
+				},
+				{
+					"type": "null"
+				}
+			]
+		},
+		"techRecord_approvalTypeNumber": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 25
+		},
+		"techRecord_ntaNumber": {
+			"type": [
+				"null",
+				"string"
+			]
+		},
+		"techRecord_variantNumber": {
+			"type": [
+				"null",
+				"string"
+			]
+		},
+		"techRecord_variantVersionNumber": {
+			"type": [
+				"null",
+				"string"
+			]
+		},
 		"techRecord_authIntoService": {
 			"type": [
 				"string",

--- a/json-schemas/v3/tech-record/get/trl/testable/index.json
+++ b/json-schemas/v3/tech-record/get/trl/testable/index.json
@@ -401,6 +401,58 @@
 				"null"
 			]
 		},
+		"techRecord_approvalType": {
+			"anyOf": [
+				{
+					"title": "Approval Type",
+					"type": "string",
+					"enum": [
+						"NTA",
+						"ECTA",
+						"IVA",
+						"NSSTA",
+						"ECSSTA",
+						"GB WVTA",
+						"UKNI WVTA",
+						"EU WVTA Pre 23",
+						"EU WVTA 23 on",
+						"QNIG",
+						"Prov.GB WVTA",
+						"Small series",
+						"IVA - VCA",
+						"IVA - DVSA/NI"
+					]
+				},
+				{
+					"type": "null"
+				}
+			]
+		},
+		"techRecord_approvalTypeNumber": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 25
+		},
+		"techRecord_ntaNumber": {
+			"type": [
+				"null",
+				"string"
+			]
+		},
+		"techRecord_variantNumber": {
+			"type": [
+				"null",
+				"string"
+			]
+		},
+		"techRecord_variantVersionNumber": {
+			"type": [
+				"null",
+				"string"
+			]
+		},
 		"techRecord_authIntoService": {
 			"type": [
 				"string",

--- a/json-schemas/v3/tech-record/put/psv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/psv/complete/index.json
@@ -965,7 +965,7 @@
 			"maximum": 99999,
 			"minimum": 0
 		},
-		"techRecord_microfilmDocumentType": {
+		"techRecord_microfilm_microfilmDocumentType": {
 			"anyOf": [
 				{
 					"title": "Microfilm Document Type",
@@ -1033,14 +1033,14 @@
 				}
 			]
 		},
-		"techRecord_microfilmRollNumber": {
+		"techRecord_microfilm_microfilmRollNumber": {
 			"type": [
 				"string",
 				"null"
 			],
 			"maxLength": 5
 		},
-		"techRecord_microfilmSerialNumber": {
+		"techRecord_microfilm_microfilmSerialNumber": {
 			"type": [
 				"string",
 				"null"

--- a/json-schemas/v3/tech-record/put/psv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/psv/skeleton/index.json
@@ -1023,7 +1023,7 @@
 			"maximum": 99999,
 			"minimum": 0
 		},
-		"techRecord_microfilmDocumentType": {
+		"techRecord_microfilm_microfilmDocumentType": {
 			"anyOf": [
 				{
 					"title": "Microfilm Document Type",
@@ -1091,14 +1091,14 @@
 				}
 			]
 		},
-		"techRecord_microfilmRollNumber": {
+		"techRecord_microfilm_microfilmRollNumber": {
 			"type": [
 				"string",
 				"null"
 			],
 			"maxLength": 5
 		},
-		"techRecord_microfilmSerialNumber": {
+		"techRecord_microfilm_microfilmSerialNumber": {
 			"type": [
 				"string",
 				"null"

--- a/json-schemas/v3/tech-record/put/psv/testable/index.json
+++ b/json-schemas/v3/tech-record/put/psv/testable/index.json
@@ -1001,7 +1001,7 @@
 			"maximum": 99999,
 			"minimum": 0
 		},
-		"techRecord_microfilmDocumentType": {
+		"techRecord_microfilm_microfilmDocumentType": {
 			"anyOf": [
 				{
 					"title": "Microfilm Document Type",
@@ -1069,14 +1069,14 @@
 				}
 			]
 		},
-		"techRecord_microfilmRollNumber": {
+		"techRecord_microfilm_microfilmRollNumber": {
 			"type": [
 				"string",
 				"null"
 			],
 			"maxLength": 5
 		},
-		"techRecord_microfilmSerialNumber": {
+		"techRecord_microfilm_microfilmSerialNumber": {
 			"type": [
 				"string",
 				"null"

--- a/json-schemas/v3/tech-record/put/trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/trl/skeleton/index.json
@@ -18,6 +18,58 @@
 				"null"
 			]
 		},
+		"techRecord_approvalType": {
+			"anyOf": [
+				{
+					"title": "Approval Type",
+					"type": "string",
+					"enum": [
+						"NTA",
+						"ECTA",
+						"IVA",
+						"NSSTA",
+						"ECSSTA",
+						"GB WVTA",
+						"UKNI WVTA",
+						"EU WVTA Pre 23",
+						"EU WVTA 23 on",
+						"QNIG",
+						"Prov.GB WVTA",
+						"Small series",
+						"IVA - VCA",
+						"IVA - DVSA/NI"
+					]
+				},
+				{
+					"type": "null"
+				}
+			]
+		},
+		"techRecord_approvalTypeNumber": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 25
+		},
+		"techRecord_ntaNumber": {
+			"type": [
+				"null",
+				"string"
+			]
+		},
+		"techRecord_variantNumber": {
+			"type": [
+				"null",
+				"string"
+			]
+		},
+		"techRecord_variantVersionNumber": {
+			"type": [
+				"null",
+				"string"
+			]
+		},
 		"techRecord_createdAt": {
 			"type": "string"
 		},
@@ -679,12 +731,6 @@
 			],
 			"minimum": 0,
 			"maximum": 99999
-		},
-		"techRecord_microfilm": {
-			"type": [
-				"string",
-				"null"
-			]
 		},
 		"techRecord_microfilm_microfilmDocumentType": {
 			"anyOf": [

--- a/json-schemas/v3/tech-record/put/trl/testable/index.json
+++ b/json-schemas/v3/tech-record/put/trl/testable/index.json
@@ -22,6 +22,58 @@
 				"null"
 			]
 		},
+		"techRecord_approvalType": {
+			"anyOf": [
+				{
+					"title": "Approval Type",
+					"type": "string",
+					"enum": [
+						"NTA",
+						"ECTA",
+						"IVA",
+						"NSSTA",
+						"ECSSTA",
+						"GB WVTA",
+						"UKNI WVTA",
+						"EU WVTA Pre 23",
+						"EU WVTA 23 on",
+						"QNIG",
+						"Prov.GB WVTA",
+						"Small series",
+						"IVA - VCA",
+						"IVA - DVSA/NI"
+					]
+				},
+				{
+					"type": "null"
+				}
+			]
+		},
+		"techRecord_approvalTypeNumber": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 25
+		},
+		"techRecord_ntaNumber": {
+			"type": [
+				"null",
+				"string"
+			]
+		},
+		"techRecord_variantNumber": {
+			"type": [
+				"null",
+				"string"
+			]
+		},
+		"techRecord_variantVersionNumber": {
+			"type": [
+				"null",
+				"string"
+			]
+		},
 		"techRecord_createdAt": {
 			"type": "string"
 		},
@@ -686,12 +738,6 @@
 			],
 			"minimum": 0,
 			"maximum": 99999
-		},
-		"techRecord_microfilm": {
-			"type": [
-				"string",
-				"null"
-			]
 		},
 		"techRecord_microfilm_microfilmDocumentType": {
 			"anyOf": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "3.0.8",
+      "version": "3.0.9",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "description": "type definitions for cvs vta application",
   "main": "index.js",
   "repository": {

--- a/types/v3/tech-record/get/hgv/complete/index.d.ts
+++ b/types/v3/tech-record/get/hgv/complete/index.d.ts
@@ -231,6 +231,7 @@ export interface TechRecordGETHGVComplete {
   techRecord_maxTrainEecWeight?: number | null;
   techRecord_maxTrainDesignWeight?: number | null;
   techRecord_manufactureYear: number;
+  techRecord_microfilm?: null;
   techRecord_microfilm_microfilmDocumentType?: null | MicrofilmDocumentType;
   techRecord_microfilm_microfilmRollNumber?: string | null;
   techRecord_microfilm_microfilmSerialNumber?: string | null;

--- a/types/v3/tech-record/get/hgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/hgv/skeleton/index.d.ts
@@ -231,6 +231,7 @@ export interface TechRecordGETHGVSkeleton {
   techRecord_maxTrainEecWeight?: number | null;
   techRecord_maxTrainDesignWeight?: number | null;
   techRecord_manufactureYear?: number | null;
+  techRecord_microfilm?: null;
   techRecord_microfilm_microfilmDocumentType?: null | MicrofilmDocumentType;
   techRecord_microfilm_microfilmRollNumber?: string | null;
   techRecord_microfilm_microfilmSerialNumber?: string | null;

--- a/types/v3/tech-record/get/hgv/testable/index.d.ts
+++ b/types/v3/tech-record/get/hgv/testable/index.d.ts
@@ -231,6 +231,7 @@ export interface TechRecordGETHGVTestable {
   techRecord_maxTrainEecWeight?: number | null;
   techRecord_maxTrainDesignWeight?: number | null;
   techRecord_manufactureYear?: number | null;
+  techRecord_microfilm?: null;
   techRecord_microfilm_microfilmDocumentType?: null | MicrofilmDocumentType;
   techRecord_microfilm_microfilmRollNumber?: string | null;
   techRecord_microfilm_microfilmSerialNumber?: string | null;

--- a/types/v3/tech-record/get/psv/complete/index.d.ts
+++ b/types/v3/tech-record/get/psv/complete/index.d.ts
@@ -224,6 +224,7 @@ export interface TechRecordGETPSVComplete {
   techRecord_lastUpdatedAt?: string | null;
   techRecord_lastUpdatedByName?: string | null;
   techRecord_lastUpdatedById?: string | null;
+  techRecord_dda?: null;
   techRecord_dda_certificateIssued: boolean;
   techRecord_dda_wheelchairCapacity?: number | null;
   techRecord_dda_wheelchairFittings?: string | null;
@@ -258,6 +259,7 @@ export interface TechRecordGETPSVComplete {
   techRecord_grossLadenWeight: number;
   techRecord_unladenWeight?: number | null;
   techRecord_maxTrainGbWeight?: number | null;
+  techRecord_dimensions?: null;
   techRecord_dimensions_length?: number | null;
   techRecord_dimensions_width?: number | null;
   techRecord_dimensions_height?: number | null;
@@ -290,9 +292,10 @@ export interface TechRecordGETPSVComplete {
   techRecord_brakes_brakeForceWheelsUpToHalfLocked_parkingBrakeForceB: number;
   techRecord_brakes_brakeForceWheelsUpToHalfLocked_secondaryBrakeForceB: number;
   techRecord_brakes_brakeForceWheelsUpToHalfLocked_serviceBrakeForceB: number;
-  techRecord_microfilmDocumentType?: MicrofilmDocumentType | null;
-  techRecord_microfilmRollNumber?: string | null;
-  techRecord_microfilmSerialNumber?: string | null;
+  techRecord_microfilm?: null;
+  techRecord_microfilm_microfilmDocumentType?: MicrofilmDocumentType | null;
+  techRecord_microfilm_microfilmRollNumber?: string | null;
+  techRecord_microfilm_microfilmSerialNumber?: string | null;
   techRecord_brakeCode?: string | null;
   createdTimestamp?: null | string;
   techRecord_updateType?: null | string;

--- a/types/v3/tech-record/get/psv/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/psv/skeleton/index.d.ts
@@ -223,6 +223,7 @@ export interface TechRecordGETPSVSkeleton {
   techRecord_lastUpdatedAt?: string | null;
   techRecord_lastUpdatedByName?: string | null;
   techRecord_lastUpdatedById?: string | null;
+  techRecord_dda?: null;
   techRecord_dda_certificateIssued?: boolean | null;
   techRecord_dda_wheelchairCapacity?: number | null;
   techRecord_dda_wheelchairFittings?: string | null;
@@ -257,6 +258,7 @@ export interface TechRecordGETPSVSkeleton {
   techRecord_grossLadenWeight?: number | null;
   techRecord_unladenWeight?: number | null;
   techRecord_maxTrainGbWeight?: number | null;
+  techRecord_dimensions?: null;
   techRecord_dimensions_length?: number | null;
   techRecord_dimensions_width?: number | null;
   techRecord_dimensions_height?: number | null;
@@ -286,9 +288,10 @@ export interface TechRecordGETPSVSkeleton {
   techRecord_brakes_brakeForceWheelsUpToHalfLocked_parkingBrakeForceB?: number | null;
   techRecord_brakes_brakeForceWheelsUpToHalfLocked_secondaryBrakeForceB?: number | null;
   techRecord_brakes_brakeForceWheelsUpToHalfLocked_serviceBrakeForceB?: number | null;
-  techRecord_microfilmDocumentType?: MicrofilmDocumentType | null;
-  techRecord_microfilmRollNumber?: string | null;
-  techRecord_microfilmSerialNumber?: string | null;
+  techRecord_microfilm?: null;
+  techRecord_microfilm_microfilmDocumentType?: MicrofilmDocumentType | null;
+  techRecord_microfilm_microfilmRollNumber?: string | null;
+  techRecord_microfilm_microfilmSerialNumber?: string | null;
   techRecord_brakeCode?: string | null;
   createdTimestamp: string;
   techRecord_applicationId?: string;

--- a/types/v3/tech-record/get/psv/testable/index.d.ts
+++ b/types/v3/tech-record/get/psv/testable/index.d.ts
@@ -223,6 +223,7 @@ export interface TechRecordGETPSVTestable {
   techRecord_lastUpdatedAt?: string | null;
   techRecord_lastUpdatedByName?: string | null;
   techRecord_lastUpdatedById?: string | null;
+  techRecord_dda?: null;
   techRecord_dda_certificateIssued?: boolean | null;
   techRecord_dda_wheelchairCapacity?: number | null;
   techRecord_dda_wheelchairFittings?: string | null;
@@ -257,6 +258,7 @@ export interface TechRecordGETPSVTestable {
   techRecord_grossLadenWeight?: number | null;
   techRecord_unladenWeight?: number | null;
   techRecord_maxTrainGbWeight?: number | null;
+  techRecord_dimensions?: null;
   techRecord_dimensions_length?: number | null;
   techRecord_dimensions_width?: number | null;
   techRecord_dimensions_height?: number | null;
@@ -286,9 +288,10 @@ export interface TechRecordGETPSVTestable {
   techRecord_brakes_brakeForceWheelsUpToHalfLocked_parkingBrakeForceB?: number | null;
   techRecord_brakes_brakeForceWheelsUpToHalfLocked_secondaryBrakeForceB?: number | null;
   techRecord_brakes_brakeForceWheelsUpToHalfLocked_serviceBrakeForceB?: number | null;
-  techRecord_microfilmDocumentType?: MicrofilmDocumentType | null;
-  techRecord_microfilmRollNumber?: string | null;
-  techRecord_microfilmSerialNumber?: string | null;
+  techRecord_microfilm?: null;
+  techRecord_microfilm_microfilmDocumentType?: MicrofilmDocumentType | null;
+  techRecord_microfilm_microfilmRollNumber?: string | null;
+  techRecord_microfilm_microfilmSerialNumber?: string | null;
   techRecord_brakeCode?: string | null;
   createdTimestamp?: null | string;
   techRecord_applicationId?: null | string;

--- a/types/v3/tech-record/get/trl/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/trl/skeleton/index.d.ts
@@ -7,6 +7,21 @@
 
 export type TC2Types = "initial";
 export type TC3Types = "intermediate" | "periodic" | "exceptional";
+export type ApprovalType =
+  | "NTA"
+  | "ECTA"
+  | "IVA"
+  | "NSSTA"
+  | "ECSSTA"
+  | "GB WVTA"
+  | "UKNI WVTA"
+  | "EU WVTA Pre 23"
+  | "EU WVTA 23 on"
+  | "QNIG"
+  | "Prov.GB WVTA"
+  | "Small series"
+  | "IVA - VCA"
+  | "IVA - DVSA/NI";
 export type EUVehicleCategory =
   | "m1"
   | "m2"
@@ -182,6 +197,11 @@ export interface TechRecordGETTRLSkeleton {
   techRecord_applicantDetails_telephoneNumber?: null | string;
   techRecord_applicantDetails_emailAddress?: null | string;
   techRecord_applicationId?: null | string;
+  techRecord_approvalType?: ApprovalType | null;
+  techRecord_approvalTypeNumber?: string | null;
+  techRecord_ntaNumber?: null | string;
+  techRecord_variantNumber?: null | string;
+  techRecord_variantVersionNumber?: null | string;
   techRecord_authIntoService?: string | null;
   techRecord_batchId?: string | null;
   techRecord_bodyType_code?: null | string;

--- a/types/v3/tech-record/get/trl/testable/index.d.ts
+++ b/types/v3/tech-record/get/trl/testable/index.d.ts
@@ -7,6 +7,21 @@
 
 export type TC2Types = "initial";
 export type TC3Types = "intermediate" | "periodic" | "exceptional";
+export type ApprovalType =
+  | "NTA"
+  | "ECTA"
+  | "IVA"
+  | "NSSTA"
+  | "ECSSTA"
+  | "GB WVTA"
+  | "UKNI WVTA"
+  | "EU WVTA Pre 23"
+  | "EU WVTA 23 on"
+  | "QNIG"
+  | "Prov.GB WVTA"
+  | "Small series"
+  | "IVA - VCA"
+  | "IVA - DVSA/NI";
 export type EUVehicleCategory =
   | "m1"
   | "m2"
@@ -199,6 +214,11 @@ export interface TechRecordGETTRLTestable {
   techRecord_applicantDetails_telephoneNumber?: null | string;
   techRecord_applicantDetails_emailAddress?: null | string;
   techRecord_applicationId?: string | null;
+  techRecord_approvalType?: ApprovalType | null;
+  techRecord_approvalTypeNumber?: string | null;
+  techRecord_ntaNumber?: null | string;
+  techRecord_variantNumber?: null | string;
+  techRecord_variantVersionNumber?: null | string;
   techRecord_authIntoService?: string | null;
   techRecord_batchId?: string | null;
   techRecord_bodyType_code: string;

--- a/types/v3/tech-record/put/psv/complete/index.d.ts
+++ b/types/v3/tech-record/put/psv/complete/index.d.ts
@@ -289,9 +289,9 @@ export interface TechRecordPUTPSVComplete {
   techRecord_brakes_brakeForceWheelsUpToHalfLocked_parkingBrakeForceB: number;
   techRecord_brakes_brakeForceWheelsUpToHalfLocked_secondaryBrakeForceB: number;
   techRecord_brakes_brakeForceWheelsUpToHalfLocked_serviceBrakeForceB: number;
-  techRecord_microfilmDocumentType?: MicrofilmDocumentType | null;
-  techRecord_microfilmRollNumber?: string | null;
-  techRecord_microfilmSerialNumber?: string | null;
+  techRecord_microfilm_microfilmDocumentType?: MicrofilmDocumentType | null;
+  techRecord_microfilm_microfilmRollNumber?: string | null;
+  techRecord_microfilm_microfilmSerialNumber?: string | null;
   techRecord_brakeCode?: string | null;
   createdTimestamp?: null | string;
   secondaryVrms?: null | string[];

--- a/types/v3/tech-record/put/psv/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/psv/skeleton/index.d.ts
@@ -286,9 +286,9 @@ export interface TechRecordPUTPSVSkeleton {
   techRecord_brakes_brakeForceWheelsUpToHalfLocked_parkingBrakeForceB?: number | null;
   techRecord_brakes_brakeForceWheelsUpToHalfLocked_secondaryBrakeForceB?: number | null;
   techRecord_brakes_brakeForceWheelsUpToHalfLocked_serviceBrakeForceB?: number | null;
-  techRecord_microfilmDocumentType?: MicrofilmDocumentType | null;
-  techRecord_microfilmRollNumber?: string | null;
-  techRecord_microfilmSerialNumber?: string | null;
+  techRecord_microfilm_microfilmDocumentType?: MicrofilmDocumentType | null;
+  techRecord_microfilm_microfilmRollNumber?: string | null;
+  techRecord_microfilm_microfilmSerialNumber?: string | null;
   techRecord_brakeCode?: string | null;
   createdTimestamp?: null | string;
   techRecord_applicationId?: string;

--- a/types/v3/tech-record/put/psv/testable/index.d.ts
+++ b/types/v3/tech-record/put/psv/testable/index.d.ts
@@ -286,9 +286,9 @@ export interface TechRecordPUTPSVTestable {
   techRecord_brakes_brakeForceWheelsUpToHalfLocked_parkingBrakeForceB?: number | null;
   techRecord_brakes_brakeForceWheelsUpToHalfLocked_secondaryBrakeForceB?: number | null;
   techRecord_brakes_brakeForceWheelsUpToHalfLocked_serviceBrakeForceB?: number | null;
-  techRecord_microfilmDocumentType?: MicrofilmDocumentType | null;
-  techRecord_microfilmRollNumber?: string | null;
-  techRecord_microfilmSerialNumber?: string | null;
+  techRecord_microfilm_microfilmDocumentType?: MicrofilmDocumentType | null;
+  techRecord_microfilm_microfilmRollNumber?: string | null;
+  techRecord_microfilm_microfilmSerialNumber?: string | null;
   techRecord_brakeCode?: string | null;
   createdTimestamp?: null | string;
   techRecord_applicationId?: null | string;

--- a/types/v3/tech-record/put/trl/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/trl/skeleton/index.d.ts
@@ -5,6 +5,21 @@
  * and run json-schema-to-typescript to regenerate this file.
  */
 
+export type ApprovalType =
+  | "NTA"
+  | "ECTA"
+  | "IVA"
+  | "NSSTA"
+  | "ECSSTA"
+  | "GB WVTA"
+  | "UKNI WVTA"
+  | "EU WVTA Pre 23"
+  | "EU WVTA 23 on"
+  | "QNIG"
+  | "Prov.GB WVTA"
+  | "Small series"
+  | "IVA - VCA"
+  | "IVA - DVSA/NI";
 export type TC2Types = "initial";
 export type TC3Types = "intermediate" | "periodic" | "exceptional";
 export type EUVehicleCategory =
@@ -147,6 +162,11 @@ export type SpeedCategorySymbol =
 
 export interface TechRecordPUTTRLSkeleton {
   partialVin?: string | null;
+  techRecord_approvalType?: ApprovalType | null;
+  techRecord_approvalTypeNumber?: string | null;
+  techRecord_ntaNumber?: null | string;
+  techRecord_variantNumber?: null | string;
+  techRecord_variantVersionNumber?: null | string;
   techRecord_createdAt?: string;
   techRecord_createdById?: string;
   techRecord_createdByName?: string;
@@ -233,7 +253,6 @@ export interface TechRecordPUTTRLSkeleton {
   techRecord_manufactureYear?: number | null;
   techRecord_manufacturerDetails?: string | null;
   techRecord_maxLoadOnCoupling?: number | null;
-  techRecord_microfilm?: string | null;
   techRecord_microfilm_microfilmDocumentType?: null | MicrofilmDocumentType;
   techRecord_microfilm_microfilmRollNumber?: string | null;
   techRecord_microfilm_microfilmSerialNumber?: string | null;

--- a/types/v3/tech-record/put/trl/testable/index.d.ts
+++ b/types/v3/tech-record/put/trl/testable/index.d.ts
@@ -5,6 +5,21 @@
  * and run json-schema-to-typescript to regenerate this file.
  */
 
+export type ApprovalType =
+  | "NTA"
+  | "ECTA"
+  | "IVA"
+  | "NSSTA"
+  | "ECSSTA"
+  | "GB WVTA"
+  | "UKNI WVTA"
+  | "EU WVTA Pre 23"
+  | "EU WVTA 23 on"
+  | "QNIG"
+  | "Prov.GB WVTA"
+  | "Small series"
+  | "IVA - VCA"
+  | "IVA - DVSA/NI";
 export type TC2Types = "initial";
 export type TC3Types = "intermediate" | "periodic" | "exceptional";
 export type EUVehicleCategory =
@@ -147,6 +162,11 @@ export type SpeedCategorySymbol =
 
 export interface TechRecordPUTTRLTestable {
   partialVin?: string | null;
+  techRecord_approvalType?: ApprovalType | null;
+  techRecord_approvalTypeNumber?: string | null;
+  techRecord_ntaNumber?: null | string;
+  techRecord_variantNumber?: null | string;
+  techRecord_variantVersionNumber?: null | string;
   techRecord_createdAt?: string;
   techRecord_createdById?: string;
   techRecord_createdByName?: string;
@@ -233,7 +253,6 @@ export interface TechRecordPUTTRLTestable {
   techRecord_manufactureYear?: number | null;
   techRecord_manufacturerDetails?: string | null;
   techRecord_maxLoadOnCoupling?: number | null;
-  techRecord_microfilm?: string | null;
   techRecord_microfilm_microfilmDocumentType?: null | MicrofilmDocumentType;
   techRecord_microfilm_microfilmRollNumber?: string | null;
   techRecord_microfilm_microfilmSerialNumber?: string | null;


### PR DESCRIPTION
CB2-8667

adds approvalType to trailers to aid with letters 

closes #67

[CB2-8667](https://dvsa.atlassian.net/browse/CB2-8667)

<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

- adds approval type to trailers 
- update microfilm object for psv
- add back in null object to get for dda dimensions and microfilm

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
