### PR TITLE
patch(*): make createdTimestamp field consistent across record types

### DIFF
--- a/json-definitions/v3/tech-record/get/psv/complete/index.json
+++ b/json-definitions/v3/tech-record/get/psv/complete/index.json
@@ -4,6 +4,7 @@
   "additionalProperties": false,
   "required": [
     "vin",
+    "createdTimestamp",
     "systemNumber",
     "primaryVrm",
     "techRecord_vehicleConfiguration",
@@ -841,7 +842,6 @@
     },
     "createdTimestamp": {
       "type": [
-        "null",
         "string"
       ]
     },

--- a/json-definitions/v3/tech-record/get/psv/testable/index.json
+++ b/json-definitions/v3/tech-record/get/psv/testable/index.json
@@ -5,6 +5,7 @@
   "required": [
     "vin",
     "systemNumber",
+    "createdTimestamp",
     "primaryVrm",
     "techRecord_vehicleConfiguration",
     "techRecord_vehicleSize",
@@ -871,7 +872,6 @@
     },
     "createdTimestamp": {
       "type": [
-        "null",
         "string"
       ]
     },

--- a/json-definitions/v3/tech-record/put/motorcycle/complete/index.json
+++ b/json-definitions/v3/tech-record/put/motorcycle/complete/index.json
@@ -74,12 +74,6 @@
       ],
       "maxLength": 255
     },
-    "createdTimestamp": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
     "partialVin": {
       "type": [
         "null",

--- a/json-definitions/v3/tech-record/put/motorcycle/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/motorcycle/skeleton/index.json
@@ -64,12 +64,6 @@
       ],
       "maxLength": 255
     },
-    "createdTimestamp": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
     "partialVin": {
       "type": [
         "null",

--- a/json-definitions/v3/tech-record/put/psv/complete/index.json
+++ b/json-definitions/v3/tech-record/put/psv/complete/index.json
@@ -828,12 +828,6 @@
         "null"
       ]
     },
-    "createdTimestamp": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
     "secondaryVrms": {
       "type": [
         "null",

--- a/json-definitions/v3/tech-record/put/psv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/psv/skeleton/index.json
@@ -886,12 +886,6 @@
         "null"
       ]
     },
-    "createdTimestamp": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
     "techRecord_applicationId": {
       "type": "string"
     },

--- a/json-definitions/v3/tech-record/put/psv/testable/index.json
+++ b/json-definitions/v3/tech-record/put/psv/testable/index.json
@@ -864,12 +864,6 @@
         "null"
       ]
     },
-    "createdTimestamp": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
     "techRecord_applicationId": {
       "type": [
         "null",

--- a/json-schemas/v3/tech-record/get/psv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/psv/complete/index.json
@@ -4,6 +4,7 @@
 	"additionalProperties": false,
 	"required": [
 		"vin",
+		"createdTimestamp",
 		"systemNumber",
 		"primaryVrm",
 		"techRecord_vehicleConfiguration",
@@ -1066,7 +1067,6 @@
 		},
 		"createdTimestamp": {
 			"type": [
-				"null",
 				"string"
 			]
 		},

--- a/json-schemas/v3/tech-record/get/psv/testable/index.json
+++ b/json-schemas/v3/tech-record/get/psv/testable/index.json
@@ -5,6 +5,7 @@
 	"required": [
 		"vin",
 		"systemNumber",
+		"createdTimestamp",
 		"primaryVrm",
 		"techRecord_vehicleConfiguration",
 		"techRecord_vehicleSize",
@@ -1096,7 +1097,6 @@
 		},
 		"createdTimestamp": {
 			"type": [
-				"null",
 				"string"
 			]
 		},

--- a/json-schemas/v3/tech-record/put/motorcycle/complete/index.json
+++ b/json-schemas/v3/tech-record/put/motorcycle/complete/index.json
@@ -74,12 +74,6 @@
 			],
 			"maxLength": 255
 		},
-		"createdTimestamp": {
-			"type": [
-				"null",
-				"string"
-			]
-		},
 		"partialVin": {
 			"type": [
 				"null",

--- a/json-schemas/v3/tech-record/put/motorcycle/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/motorcycle/skeleton/index.json
@@ -64,12 +64,6 @@
 			],
 			"maxLength": 255
 		},
-		"createdTimestamp": {
-			"type": [
-				"null",
-				"string"
-			]
-		},
 		"partialVin": {
 			"type": [
 				"null",

--- a/json-schemas/v3/tech-record/put/psv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/psv/complete/index.json
@@ -1053,12 +1053,6 @@
 				"null"
 			]
 		},
-		"createdTimestamp": {
-			"type": [
-				"null",
-				"string"
-			]
-		},
 		"secondaryVrms": {
 			"type": [
 				"null",

--- a/json-schemas/v3/tech-record/put/psv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/psv/skeleton/index.json
@@ -1111,12 +1111,6 @@
 				"null"
 			]
 		},
-		"createdTimestamp": {
-			"type": [
-				"null",
-				"string"
-			]
-		},
 		"techRecord_applicationId": {
 			"type": "string"
 		},

--- a/json-schemas/v3/tech-record/put/psv/testable/index.json
+++ b/json-schemas/v3/tech-record/put/psv/testable/index.json
@@ -1089,12 +1089,6 @@
 				"null"
 			]
 		},
-		"createdTimestamp": {
-			"type": [
-				"null",
-				"string"
-			]
-		},
 		"techRecord_applicationId": {
 			"type": [
 				"null",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.9",
+  "version": "3.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "3.0.9",
+      "version": "3.0.10",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.9",
+  "version": "3.0.10",
   "description": "type definitions for cvs vta application",
   "main": "index.js",
   "repository": {

--- a/types/v3/tech-record/get/psv/complete/index.d.ts
+++ b/types/v3/tech-record/get/psv/complete/index.d.ts
@@ -297,7 +297,7 @@ export interface TechRecordGETPSVComplete {
   techRecord_microfilm_microfilmRollNumber?: string | null;
   techRecord_microfilm_microfilmSerialNumber?: string | null;
   techRecord_brakeCode?: string | null;
-  createdTimestamp?: null | string;
+  createdTimestamp: string;
   techRecord_updateType?: null | string;
 }
 export interface PSVAxlesComplete {

--- a/types/v3/tech-record/get/psv/testable/index.d.ts
+++ b/types/v3/tech-record/get/psv/testable/index.d.ts
@@ -293,7 +293,7 @@ export interface TechRecordGETPSVTestable {
   techRecord_microfilm_microfilmRollNumber?: string | null;
   techRecord_microfilm_microfilmSerialNumber?: string | null;
   techRecord_brakeCode?: string | null;
-  createdTimestamp?: null | string;
+  createdTimestamp: string;
   techRecord_applicationId?: null | string;
   secondaryVrms?: null | string[];
   techRecord_updateType?: null | string;

--- a/types/v3/tech-record/put/motorcycle/complete/index.d.ts
+++ b/types/v3/tech-record/put/motorcycle/complete/index.d.ts
@@ -50,7 +50,6 @@ export interface TechRecordPUTMotorcycleComplete {
   techRecord_applicantDetails_postCode?: null | string;
   techRecord_applicantDetails_telephoneNumber?: null | string;
   techRecord_applicantDetails_emailAddress?: null | string;
-  createdTimestamp?: null | string;
   partialVin?: null | string;
   primaryVrm?: null | string;
   systemNumber?: null | string;

--- a/types/v3/tech-record/put/motorcycle/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/motorcycle/skeleton/index.d.ts
@@ -48,7 +48,6 @@ export interface TechRecordPUTMotorcycleSkeleton {
   techRecord_applicantDetails_postCode?: null | string;
   techRecord_applicantDetails_telephoneNumber?: null | string;
   techRecord_applicantDetails_emailAddress?: null | string;
-  createdTimestamp?: null | string;
   partialVin?: null | string;
   primaryVrm?: null | string;
   systemNumber?: null | string;

--- a/types/v3/tech-record/put/psv/complete/index.d.ts
+++ b/types/v3/tech-record/put/psv/complete/index.d.ts
@@ -293,7 +293,6 @@ export interface TechRecordPUTPSVComplete {
   techRecord_microfilm_microfilmRollNumber?: string | null;
   techRecord_microfilm_microfilmSerialNumber?: string | null;
   techRecord_brakeCode?: string | null;
-  createdTimestamp?: null | string;
   secondaryVrms?: null | string[];
   techRecord_updateType?: null | string;
 }

--- a/types/v3/tech-record/put/psv/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/psv/skeleton/index.d.ts
@@ -290,7 +290,6 @@ export interface TechRecordPUTPSVSkeleton {
   techRecord_microfilm_microfilmRollNumber?: string | null;
   techRecord_microfilm_microfilmSerialNumber?: string | null;
   techRecord_brakeCode?: string | null;
-  createdTimestamp?: null | string;
   techRecord_applicationId?: string;
   secondaryVrms?: string[];
   techRecord_updateType?: null | string;

--- a/types/v3/tech-record/put/psv/testable/index.d.ts
+++ b/types/v3/tech-record/put/psv/testable/index.d.ts
@@ -290,7 +290,6 @@ export interface TechRecordPUTPSVTestable {
   techRecord_microfilm_microfilmRollNumber?: string | null;
   techRecord_microfilm_microfilmSerialNumber?: string | null;
   techRecord_brakeCode?: string | null;
-  createdTimestamp?: null | string;
   techRecord_applicationId?: null | string;
   secondaryVrms?: null | string[];
   techRecord_updateType?: null | string;


### PR DESCRIPTION
## Ticket title

Make `createdTimestamp` consistent across record types:
- Should not be sent on PUT request
- Cannot be undefined or null on a GET request


<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

- Make `createdTimestamp` consistent across record types

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
