### PR TITLE
patch(cb2-8667): correct trailer field types

### DIFF
--- a/json-definitions/v3/tech-record/get/trl/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/trl/skeleton/index.json
@@ -322,7 +322,7 @@
     },
     "techRecord_alterationMarker": {
       "type": [
-        "string",
+        "boolean",
         "null"
       ]
     },
@@ -449,7 +449,7 @@
     },
     "techRecord_brakes_antilockBrakingSystem": {
       "type": [
-        "string",
+        "boolean",
         "null"
       ]
     },
@@ -1008,7 +1008,7 @@
     },
     "techRecord_roadFriendly": {
       "type": [
-        "string",
+        "boolean",
         "null"
       ]
     },

--- a/json-definitions/v3/tech-record/get/trl/testable/index.json
+++ b/json-definitions/v3/tech-record/get/trl/testable/index.json
@@ -325,7 +325,7 @@
     },
     "techRecord_alterationMarker": {
       "type": [
-        "string",
+        "boolean",
         "null"
       ]
     },

--- a/json-definitions/v3/tech-record/put/trl/complete/index.json
+++ b/json-definitions/v3/tech-record/put/trl/complete/index.json
@@ -349,7 +349,7 @@
     },
     "techRecord_alterationMarker": {
       "type": [
-        "string",
+        "boolean",
         "null"
       ]
     },

--- a/json-definitions/v3/tech-record/put/trl/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/trl/skeleton/index.json
@@ -355,7 +355,7 @@
     },
     "techRecord_alterationMarker": {
       "type": [
-        "string",
+        "boolean",
         "null"
       ]
     },
@@ -438,7 +438,7 @@
     },
     "techRecord_brakes_antilockBrakingSystem": {
       "type": [
-        "string",
+        "boolean",
         "null"
       ]
     },
@@ -848,7 +848,7 @@
     },
     "techRecord_roadFriendly": {
       "type": [
-        "string",
+        "boolean",
         "null"
       ]
     },

--- a/json-definitions/v3/tech-record/put/trl/testable/index.json
+++ b/json-definitions/v3/tech-record/put/trl/testable/index.json
@@ -359,7 +359,7 @@
     },
     "techRecord_alterationMarker": {
       "type": [
-        "string",
+        "boolean",
         "null"
       ]
     },

--- a/json-schemas/v3/tech-record/get/trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/trl/skeleton/index.json
@@ -332,7 +332,7 @@
 		},
 		"techRecord_alterationMarker": {
 			"type": [
-				"string",
+				"boolean",
 				"null"
 			]
 		},
@@ -476,7 +476,7 @@
 		},
 		"techRecord_brakes_antilockBrakingSystem": {
 			"type": [
-				"string",
+				"boolean",
 				"null"
 			]
 		},
@@ -1171,7 +1171,7 @@
 		},
 		"techRecord_roadFriendly": {
 			"type": [
-				"string",
+				"boolean",
 				"null"
 			]
 		},

--- a/json-schemas/v3/tech-record/get/trl/testable/index.json
+++ b/json-schemas/v3/tech-record/get/trl/testable/index.json
@@ -335,7 +335,7 @@
 		},
 		"techRecord_alterationMarker": {
 			"type": [
-				"string",
+				"boolean",
 				"null"
 			]
 		},

--- a/json-schemas/v3/tech-record/put/trl/complete/index.json
+++ b/json-schemas/v3/tech-record/put/trl/complete/index.json
@@ -359,7 +359,7 @@
 		},
 		"techRecord_alterationMarker": {
 			"type": [
-				"string",
+				"boolean",
 				"null"
 			]
 		},

--- a/json-schemas/v3/tech-record/put/trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/trl/skeleton/index.json
@@ -382,7 +382,7 @@
 		},
 		"techRecord_alterationMarker": {
 			"type": [
-				"string",
+				"boolean",
 				"null"
 			]
 		},
@@ -465,7 +465,7 @@
 		},
 		"techRecord_brakes_antilockBrakingSystem": {
 			"type": [
-				"string",
+				"boolean",
 				"null"
 			]
 		},
@@ -988,7 +988,7 @@
 		},
 		"techRecord_roadFriendly": {
 			"type": [
-				"string",
+				"boolean",
 				"null"
 			]
 		},

--- a/json-schemas/v3/tech-record/put/trl/testable/index.json
+++ b/json-schemas/v3/tech-record/put/trl/testable/index.json
@@ -386,7 +386,7 @@
 		},
 		"techRecord_alterationMarker": {
 			"type": [
-				"string",
+				"boolean",
 				"null"
 			]
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.12",
+  "version": "3.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "3.0.12",
+      "version": "3.0.13",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.12",
+  "version": "3.0.13",
   "description": "type definitions for cvs vta application",
   "main": "index.js",
   "repository": {

--- a/types/v3/tech-record/get/trl/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/trl/skeleton/index.d.ts
@@ -204,7 +204,7 @@ export interface TechRecordGETTRLSkeleton {
   techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo?: string | null;
   techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo?: string[] | null;
   techRecord_adrDetails_tank_tankDetails_tankStatement_productList?: string | null;
-  techRecord_alterationMarker?: string | null;
+  techRecord_alterationMarker?: boolean | null;
   techRecord_applicantDetails_name?: string | null;
   techRecord_applicantDetails_address1?: null | string;
   techRecord_applicantDetails_address2?: null | string;
@@ -223,7 +223,7 @@ export interface TechRecordGETTRLSkeleton {
   techRecord_batchId?: string | null;
   techRecord_bodyType_code?: null | string;
   techRecord_bodyType_description?: null | string;
-  techRecord_brakes_antilockBrakingSystem?: string | null;
+  techRecord_brakes_antilockBrakingSystem?: boolean | null;
   techRecord_brakes_dtpNumber?: string | null;
   techRecord_brakes_loadSensingValve?: boolean | null;
   techRecord_centreOfRearmostAxleToRearOfTrl?: number | null;
@@ -280,7 +280,7 @@ export interface TechRecordGETTRLSkeleton {
   techRecord_reasonForCreation: string;
   techRecord_recordCompleteness: "skeleton";
   techRecord_regnDate?: string | null;
-  techRecord_roadFriendly?: string | null;
+  techRecord_roadFriendly?: boolean | null;
   techRecord_statusCode: StatusCode;
   techRecord_suspensionType?: string | null;
   techRecord_tyreUseCode?: string | null;

--- a/types/v3/tech-record/get/trl/testable/index.d.ts
+++ b/types/v3/tech-record/get/trl/testable/index.d.ts
@@ -204,7 +204,7 @@ export interface TechRecordGETTRLTestable {
   techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo?: string | null;
   techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo?: string[] | null;
   techRecord_adrDetails_tank_tankDetails_tankStatement_productList?: string | null;
-  techRecord_alterationMarker?: string | null;
+  techRecord_alterationMarker?: boolean | null;
   techRecord_applicantDetails_name?: string | null;
   techRecord_applicantDetails_address1?: null | string;
   techRecord_applicantDetails_address2?: null | string;

--- a/types/v3/tech-record/put/trl/complete/index.d.ts
+++ b/types/v3/tech-record/put/trl/complete/index.d.ts
@@ -225,7 +225,7 @@ export interface TechRecordPUTTRLComplete {
   techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo?: string | null;
   techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo?: string[] | null;
   techRecord_adrDetails_tank_tankDetails_tankStatement_productList?: string | null;
-  techRecord_alterationMarker?: string | null;
+  techRecord_alterationMarker?: boolean | null;
   techRecord_applicantDetails_name?: string | null;
   techRecord_applicantDetails_address1?: null | string;
   techRecord_applicantDetails_address2?: null | string;

--- a/types/v3/tech-record/put/trl/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/trl/skeleton/index.d.ts
@@ -210,7 +210,7 @@ export interface TechRecordPUTTRLSkeleton {
   techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo?: string | null;
   techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo?: string[] | null;
   techRecord_adrDetails_tank_tankDetails_tankStatement_productList?: string | null;
-  techRecord_alterationMarker?: string | null;
+  techRecord_alterationMarker?: boolean | null;
   techRecord_applicantDetails_name?: string | null;
   techRecord_applicantDetails_address1?: null | string;
   techRecord_applicantDetails_address2?: null | string;
@@ -224,7 +224,7 @@ export interface TechRecordPUTTRLSkeleton {
   techRecord_batchId?: string | null;
   techRecord_bodyType_code?: string;
   techRecord_bodyType_description?: string;
-  techRecord_brakes_antilockBrakingSystem?: string | null;
+  techRecord_brakes_antilockBrakingSystem?: boolean | null;
   techRecord_brakes_dtpNumber?: string | null;
   techRecord_brakes_loadSensingValve?: boolean | null;
   techRecord_centreOfRearmostAxleToRearOfTrl?: number | null;
@@ -275,7 +275,7 @@ export interface TechRecordPUTTRLSkeleton {
   techRecord_rearAxleToRearTrl?: number | null;
   techRecord_reasonForCreation: string;
   techRecord_regnDate?: string | null;
-  techRecord_roadFriendly?: string | null;
+  techRecord_roadFriendly?: boolean | null;
   techRecord_statusCode: StatusCode;
   techRecord_suspensionType?: string | null;
   techRecord_tyreUseCode?: string | null;

--- a/types/v3/tech-record/put/trl/testable/index.d.ts
+++ b/types/v3/tech-record/put/trl/testable/index.d.ts
@@ -210,7 +210,7 @@ export interface TechRecordPUTTRLTestable {
   techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo?: string | null;
   techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo?: string[] | null;
   techRecord_adrDetails_tank_tankDetails_tankStatement_productList?: string | null;
-  techRecord_alterationMarker?: string | null;
+  techRecord_alterationMarker?: boolean | null;
   techRecord_applicantDetails_name?: string | null;
   techRecord_applicantDetails_address1?: null | string;
   techRecord_applicantDetails_address2?: null | string;


### PR DESCRIPTION
## techRecord_brakes_antilockBrakingSystem, techRecord_alterationMarker and techRecord_roadFriendly need to be boolean for trailer

Closes [81](https://github.com/dvsa/cvs-type-definitions/issues/81)

[CB2-8667](https://dvsa.atlassian.net/browse/CB2-8667)

<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

- techRecord_brakes_antilockBrakingSystem, techRecord_alterationMarker and techRecord_roadFriendly changed to boolean 

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
