### PR TITLE
patch(cb2-8667): repair completeness calculation for hgv and trl

### DIFF
--- a/json-definitions/v3/tech-record/get/hgv/complete/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/complete/index.json
@@ -18,7 +18,6 @@
     "techRecord_vehicleConfiguration",
     "techRecord_vehicleClass_code",
     "techRecord_vehicleClass_description",
-    "techRecord_numberOfWheelsDriven",
     "techRecord_approvalType",
     "techRecord_manufactureYear",
     "techRecord_bodyType_code",
@@ -423,9 +422,17 @@
     },
     "techRecord_axles": {
       "type": "array",
+      "minItems": 1,
       "items": {
         "type": "object",
         "title": "HGV Axles",
+        "required": [
+          "weights_gbWeight",
+          "weights_designWeight",
+          "tyres_tyreCode",
+          "tyres_tyreSize",
+          "tyres_fitmentCode"
+        ],
         "additionalProperties": false,
         "properties": {
           "parkingBrakeMrk": {
@@ -577,11 +584,7 @@
       ]
     },
     "techRecord_euVehicleCategory": {
-      "anyOf": [
-        {
-          "$ref": "../../../enums/euVehicleCategory.ignore.json"
-        }
-      ]
+      "$ref": "../../../enums/euVehicleCategory.ignore.json"
     },
     "techRecord_frontAxleToRearAxle": {
       "type": "integer",

--- a/json-definitions/v3/tech-record/get/trl/complete/index.json
+++ b/json-definitions/v3/tech-record/get/trl/complete/index.json
@@ -37,7 +37,8 @@
     "techRecord_bodyType_description",
     "techRecord_bodyType_code",
     "techRecord_vehicleConfiguration",
-    "vin"
+    "vin",
+    "techRecord_euVehicleCategory"
   ],
   "properties": {
     "createdTimestamp": {
@@ -560,14 +561,7 @@
       "maximum": 99
     },
     "techRecord_euVehicleCategory": {
-      "anyOf": [
-        {
-          "$ref": "../../../enums/euVehicleCategory.ignore.json"
-        },
-        {
-          "type": "null"
-        }
-      ]
+      "$ref": "../../../enums/euVehicleCategory.ignore.json"
     },
     "techRecord_euroStandard": {
       "anyOf": [

--- a/json-definitions/v3/tech-record/get/trl/complete/index.json
+++ b/json-definitions/v3/tech-record/get/trl/complete/index.json
@@ -1037,23 +1037,25 @@
       "type": "string"
     },
     "techRecord_axles": {
-      "type": [
-        "null",
-        "array"
-      ],
+      "type": "array",
+      "minItems": 1,
       "items": {
-        "type": [
-          "null",
-          "object"
-        ],
+        "type": "object",
         "title": "TRL Axles",
         "additionalProperties": false,
+        "required": [
+          "weights_gbWeight",
+          "weights_designWeight",
+          "tyres_tyreCode",
+          "tyres_tyreSize",
+          "tyres_fitmentCode",
+          "parkingBrakeMrk",
+          "brakes_brakeActuator",
+          "brakes_leverLength"
+        ],
         "properties": {
           "parkingBrakeMrk": {
-            "type": [
-              "boolean",
-              "null"
-            ]
+            "type": "boolean"
           },
           "axleNumber": {
             "type": [
@@ -1062,18 +1064,12 @@
             ]
           },
           "brakes_brakeActuator": {
-            "type": [
-              "null",
-              "integer"
-            ],
+            "type": "integer",
             "minimum": 0,
             "maximum": 999
           },
           "brakes_leverLength": {
-            "type": [
-              "null",
-              "integer"
-            ],
+            "type": "integer",
             "minimum": 0,
             "maximum": 999
           },
@@ -1084,18 +1080,12 @@
             ]
           },
           "weights_gbWeight": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": "integer",
             "minimum": 0,
             "maximum": 99999
           },
           "weights_designWeight": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": "integer",
             "minimum": 0,
             "maximum": 99999
           },
@@ -1116,18 +1106,12 @@
             "maximum": 99999
           },
           "tyres_tyreCode": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": "integer",
             "minimum": 0,
             "maximum": 99999
           },
           "tyres_tyreSize": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": "string",
             "maxLength": 12
           },
           "tyres_plyRating": {
@@ -1137,14 +1121,7 @@
             ]
           },
           "tyres_fitmentCode": {
-            "anyOf": [
-              {
-                "type": "null"
-              },
-              {
-                "$ref": "../../../enums/fitmentCode.ignore.json"
-              }
-            ]
+            "$ref": "../../../enums/fitmentCode.ignore.json"
           },
           "tyres_dataTrAxles": {
             "type": [

--- a/json-definitions/v3/tech-record/put/hgv/complete/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/complete/index.json
@@ -10,7 +10,6 @@
     "techRecord_vehicleConfiguration",
     "techRecord_vehicleClass_code",
     "techRecord_vehicleClass_description",
-    "techRecord_numberOfWheelsDriven",
     "techRecord_approvalType",
     "techRecord_manufactureYear",
     "techRecord_bodyType_code",
@@ -430,10 +429,18 @@
     },
     "techRecord_axles": {
       "type": "array",
+      "minItems": 1,
       "items": {
         "type": "object",
         "title": "HGV Axles",
         "additionalProperties": false,
+        "required": [
+          "weights_gbWeight",
+          "weights_designWeight",
+          "tyres_tyreCode",
+          "tyres_tyreSize",
+          "tyres_fitmentCode"
+        ],
         "properties": {
           "parkingBrakeMrk": {
             "type": "boolean"
@@ -575,11 +582,7 @@
       ]
     },
     "techRecord_euVehicleCategory": {
-      "anyOf": [
-        {
-          "$ref": "../../../enums/euVehicleCategory.ignore.json"
-        }
-      ]
+      "$ref": "../../../enums/euVehicleCategory.ignore.json"
     },
     "techRecord_frontAxleToRearAxle": {
       "type": "integer",
@@ -705,9 +708,6 @@
     "techRecord_model": {
       "type": "string",
       "maxLength": 30
-    },
-    "techRecord_numberOfWheelsDriven": {
-      "type": "integer"
     },
     "techRecord_noOfAxles": {
       "anyOf": [

--- a/json-definitions/v3/tech-record/put/hgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/skeleton/index.json
@@ -752,12 +752,6 @@
       ],
       "maxLength": 30
     },
-    "techRecord_numberOfWheelsDriven": {
-      "type": [
-        "integer",
-        "null"
-      ]
-    },
     "techRecord_noOfAxles": {
       "anyOf": [
         {

--- a/json-definitions/v3/tech-record/put/hgv/testable/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/testable/index.json
@@ -9,8 +9,7 @@
     "vin",
     "techRecord_vehicleConfiguration",
     "techRecord_vehicleClass_code",
-    "techRecord_vehicleClass_description",
-    "techRecord_numberOfWheelsDriven"
+    "techRecord_vehicleClass_description"
   ],
   "properties": {
     "secondaryVrms": {
@@ -737,9 +736,6 @@
         "null"
       ],
       "maxLength": 30
-    },
-    "techRecord_numberOfWheelsDriven": {
-      "type": "integer"
     },
     "techRecord_noOfAxles": {
       "anyOf": [

--- a/json-definitions/v3/tech-record/put/trl/complete/index.json
+++ b/json-definitions/v3/tech-record/put/trl/complete/index.json
@@ -29,7 +29,8 @@
     "techRecord_bodyType_description",
     "techRecord_bodyType_code",
     "techRecord_vehicleConfiguration",
-    "vin"
+    "vin",
+    "techRecord_euVehicleCategory"
   ],
   "properties": {
     "partialVin": {
@@ -558,14 +559,7 @@
       "maximum": 99
     },
     "techRecord_euVehicleCategory": {
-      "anyOf": [
-        {
-          "$ref": "../../../enums/euVehicleCategory.ignore.json"
-        },
-        {
-          "type": "null"
-        }
-      ]
+      "$ref": "../../../enums/euVehicleCategory.ignore.json"
     },
     "techRecord_euroStandard": {
       "anyOf": [

--- a/json-definitions/v3/tech-record/put/trl/complete/index.json
+++ b/json-definitions/v3/tech-record/put/trl/complete/index.json
@@ -1008,20 +1008,25 @@
       "type": "string"
     },
     "techRecord_axles": {
-      "type": [
-        "null",
-        "array"
-      ],
+      "type": "array",
+      "minItems": 1,
       "items": {
         "type": "object",
         "title": "TRL Axles",
         "additionalProperties": false,
+        "required": [
+          "weights_gbWeight",
+          "weights_designWeight",
+          "tyres_tyreCode",
+          "tyres_tyreSize",
+          "tyres_fitmentCode",
+          "parkingBrakeMrk",
+          "brakes_brakeActuator",
+          "brakes_leverLength"
+        ],
         "properties": {
           "parkingBrakeMrk": {
-            "type": [
-              "boolean",
-              "null"
-            ]
+            "type": "boolean"
           },
           "axleNumber": {
             "type": [
@@ -1030,18 +1035,12 @@
             ]
           },
           "brakes_brakeActuator": {
-            "type": [
-              "null",
-              "integer"
-            ],
+            "type": "integer",
             "minimum": 0,
             "maximum": 999
           },
           "brakes_leverLength": {
-            "type": [
-              "null",
-              "integer"
-            ],
+            "type": "integer",
             "minimum": 0,
             "maximum": 999
           },
@@ -1052,18 +1051,12 @@
             ]
           },
           "weights_gbWeight": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": "integer",
             "minimum": 0,
             "maximum": 99999
           },
           "weights_designWeight": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": "integer",
             "minimum": 0,
             "maximum": 99999
           },
@@ -1084,18 +1077,12 @@
             "maximum": 99999
           },
           "tyres_tyreCode": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": "integer",
             "minimum": 0,
             "maximum": 99999
           },
           "tyres_tyreSize": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": "string",
             "maxLength": 12
           },
           "tyres_plyRating": {
@@ -1105,14 +1092,7 @@
             ]
           },
           "tyres_fitmentCode": {
-            "anyOf": [
-              {
-                "type": "null"
-              },
-              {
-                "$ref": "../../../enums/fitmentCode.ignore.json"
-              }
-            ]
+            "$ref": "../../../enums/fitmentCode.ignore.json"
           },
           "tyres_dataTrAxles": {
             "type": [

--- a/json-schemas/v3/tech-record/get/hgv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/complete/index.json
@@ -18,7 +18,6 @@
 		"techRecord_vehicleConfiguration",
 		"techRecord_vehicleClass_code",
 		"techRecord_vehicleClass_description",
-		"techRecord_numberOfWheelsDriven",
 		"techRecord_approvalType",
 		"techRecord_manufactureYear",
 		"techRecord_bodyType_code",
@@ -433,9 +432,17 @@
 		},
 		"techRecord_axles": {
 			"type": "array",
+			"minItems": 1,
 			"items": {
 				"type": "object",
 				"title": "HGV Axles",
+				"required": [
+					"weights_gbWeight",
+					"weights_designWeight",
+					"tyres_tyreCode",
+					"tyres_tyreSize",
+					"tyres_fitmentCode"
+				],
 				"additionalProperties": false,
 				"properties": {
 					"parkingBrakeMrk": {
@@ -592,31 +599,27 @@
 			]
 		},
 		"techRecord_euVehicleCategory": {
-			"anyOf": [
-				{
-					"title": "EU vehicle category",
-					"type": "string",
-					"enum": [
-						"m1",
-						"m2",
-						"m3",
-						"n1",
-						"n2",
-						"n3",
-						"o1",
-						"o2",
-						"o3",
-						"o4",
-						"l1e-a",
-						"l1e",
-						"l2e",
-						"l3e",
-						"l4e",
-						"l5e",
-						"l6e",
-						"l7e"
-					]
-				}
+			"title": "EU vehicle category",
+			"type": "string",
+			"enum": [
+				"m1",
+				"m2",
+				"m3",
+				"n1",
+				"n2",
+				"n3",
+				"o1",
+				"o2",
+				"o3",
+				"o4",
+				"l1e-a",
+				"l1e",
+				"l2e",
+				"l3e",
+				"l4e",
+				"l5e",
+				"l6e",
+				"l7e"
 			]
 		},
 		"techRecord_frontAxleToRearAxle": {

--- a/json-schemas/v3/tech-record/get/trl/complete/index.json
+++ b/json-schemas/v3/tech-record/get/trl/complete/index.json
@@ -37,7 +37,8 @@
 		"techRecord_bodyType_description",
 		"techRecord_bodyType_code",
 		"techRecord_vehicleConfiguration",
-		"vin"
+		"vin",
+		"techRecord_euVehicleCategory"
 	],
 	"properties": {
 		"createdTimestamp": {
@@ -587,34 +588,27 @@
 			"maximum": 99
 		},
 		"techRecord_euVehicleCategory": {
-			"anyOf": [
-				{
-					"title": "EU vehicle category",
-					"type": "string",
-					"enum": [
-						"m1",
-						"m2",
-						"m3",
-						"n1",
-						"n2",
-						"n3",
-						"o1",
-						"o2",
-						"o3",
-						"o4",
-						"l1e-a",
-						"l1e",
-						"l2e",
-						"l3e",
-						"l4e",
-						"l5e",
-						"l6e",
-						"l7e"
-					]
-				},
-				{
-					"type": "null"
-				}
+			"title": "EU vehicle category",
+			"type": "string",
+			"enum": [
+				"m1",
+				"m2",
+				"m3",
+				"n1",
+				"n2",
+				"n3",
+				"o1",
+				"o2",
+				"o3",
+				"o4",
+				"l1e-a",
+				"l1e",
+				"l2e",
+				"l3e",
+				"l4e",
+				"l5e",
+				"l6e",
+				"l7e"
 			]
 		},
 		"techRecord_euroStandard": {

--- a/json-schemas/v3/tech-record/get/trl/complete/index.json
+++ b/json-schemas/v3/tech-record/get/trl/complete/index.json
@@ -1236,23 +1236,25 @@
 			"type": "string"
 		},
 		"techRecord_axles": {
-			"type": [
-				"null",
-				"array"
-			],
+			"type": "array",
+			"minItems": 1,
 			"items": {
-				"type": [
-					"null",
-					"object"
-				],
+				"type": "object",
 				"title": "TRL Axles",
 				"additionalProperties": false,
+				"required": [
+					"weights_gbWeight",
+					"weights_designWeight",
+					"tyres_tyreCode",
+					"tyres_tyreSize",
+					"tyres_fitmentCode",
+					"parkingBrakeMrk",
+					"brakes_brakeActuator",
+					"brakes_leverLength"
+				],
 				"properties": {
 					"parkingBrakeMrk": {
-						"type": [
-							"boolean",
-							"null"
-						]
+						"type": "boolean"
 					},
 					"axleNumber": {
 						"type": [
@@ -1261,18 +1263,12 @@
 						]
 					},
 					"brakes_brakeActuator": {
-						"type": [
-							"null",
-							"integer"
-						],
+						"type": "integer",
 						"minimum": 0,
 						"maximum": 999
 					},
 					"brakes_leverLength": {
-						"type": [
-							"null",
-							"integer"
-						],
+						"type": "integer",
 						"minimum": 0,
 						"maximum": 999
 					},
@@ -1283,18 +1279,12 @@
 						]
 					},
 					"weights_gbWeight": {
-						"type": [
-							"integer",
-							"null"
-						],
+						"type": "integer",
 						"minimum": 0,
 						"maximum": 99999
 					},
 					"weights_designWeight": {
-						"type": [
-							"integer",
-							"null"
-						],
+						"type": "integer",
 						"minimum": 0,
 						"maximum": 99999
 					},
@@ -1315,18 +1305,12 @@
 						"maximum": 99999
 					},
 					"tyres_tyreCode": {
-						"type": [
-							"integer",
-							"null"
-						],
+						"type": "integer",
 						"minimum": 0,
 						"maximum": 99999
 					},
 					"tyres_tyreSize": {
-						"type": [
-							"string",
-							"null"
-						],
+						"type": "string",
 						"maxLength": 12
 					},
 					"tyres_plyRating": {
@@ -1336,18 +1320,11 @@
 						]
 					},
 					"tyres_fitmentCode": {
-						"anyOf": [
-							{
-								"type": "null"
-							},
-							{
-								"title": "Fitment Code",
-								"type": "string",
-								"enum": [
-									"single",
-									"double"
-								]
-							}
+						"title": "Fitment Code",
+						"type": "string",
+						"enum": [
+							"single",
+							"double"
 						]
 					},
 					"tyres_dataTrAxles": {

--- a/json-schemas/v3/tech-record/put/hgv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/complete/index.json
@@ -10,7 +10,6 @@
 		"techRecord_vehicleConfiguration",
 		"techRecord_vehicleClass_code",
 		"techRecord_vehicleClass_description",
-		"techRecord_numberOfWheelsDriven",
 		"techRecord_approvalType",
 		"techRecord_manufactureYear",
 		"techRecord_bodyType_code",
@@ -440,10 +439,18 @@
 		},
 		"techRecord_axles": {
 			"type": "array",
+			"minItems": 1,
 			"items": {
 				"type": "object",
 				"title": "HGV Axles",
 				"additionalProperties": false,
+				"required": [
+					"weights_gbWeight",
+					"weights_designWeight",
+					"tyres_tyreCode",
+					"tyres_tyreSize",
+					"tyres_fitmentCode"
+				],
 				"properties": {
 					"parkingBrakeMrk": {
 						"type": "boolean"
@@ -590,31 +597,27 @@
 			]
 		},
 		"techRecord_euVehicleCategory": {
-			"anyOf": [
-				{
-					"title": "EU vehicle category",
-					"type": "string",
-					"enum": [
-						"m1",
-						"m2",
-						"m3",
-						"n1",
-						"n2",
-						"n3",
-						"o1",
-						"o2",
-						"o3",
-						"o4",
-						"l1e-a",
-						"l1e",
-						"l2e",
-						"l3e",
-						"l4e",
-						"l5e",
-						"l6e",
-						"l7e"
-					]
-				}
+			"title": "EU vehicle category",
+			"type": "string",
+			"enum": [
+				"m1",
+				"m2",
+				"m3",
+				"n1",
+				"n2",
+				"n3",
+				"o1",
+				"o2",
+				"o3",
+				"o4",
+				"l1e-a",
+				"l1e",
+				"l2e",
+				"l3e",
+				"l4e",
+				"l5e",
+				"l6e",
+				"l7e"
 			]
 		},
 		"techRecord_frontAxleToRearAxle": {
@@ -811,9 +814,6 @@
 		"techRecord_model": {
 			"type": "string",
 			"maxLength": 30
-		},
-		"techRecord_numberOfWheelsDriven": {
-			"type": "integer"
 		},
 		"techRecord_noOfAxles": {
 			"anyOf": [

--- a/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
@@ -858,12 +858,6 @@
 			],
 			"maxLength": 30
 		},
-		"techRecord_numberOfWheelsDriven": {
-			"type": [
-				"integer",
-				"null"
-			]
-		},
 		"techRecord_noOfAxles": {
 			"anyOf": [
 				{

--- a/json-schemas/v3/tech-record/put/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/testable/index.json
@@ -9,8 +9,7 @@
 		"vin",
 		"techRecord_vehicleConfiguration",
 		"techRecord_vehicleClass_code",
-		"techRecord_vehicleClass_description",
-		"techRecord_numberOfWheelsDriven"
+		"techRecord_vehicleClass_description"
 	],
 	"properties": {
 		"secondaryVrms": {
@@ -843,9 +842,6 @@
 				"null"
 			],
 			"maxLength": 30
-		},
-		"techRecord_numberOfWheelsDriven": {
-			"type": "integer"
 		},
 		"techRecord_noOfAxles": {
 			"anyOf": [

--- a/json-schemas/v3/tech-record/put/trl/complete/index.json
+++ b/json-schemas/v3/tech-record/put/trl/complete/index.json
@@ -1207,20 +1207,25 @@
 			"type": "string"
 		},
 		"techRecord_axles": {
-			"type": [
-				"null",
-				"array"
-			],
+			"type": "array",
+			"minItems": 1,
 			"items": {
 				"type": "object",
 				"title": "TRL Axles",
 				"additionalProperties": false,
+				"required": [
+					"weights_gbWeight",
+					"weights_designWeight",
+					"tyres_tyreCode",
+					"tyres_tyreSize",
+					"tyres_fitmentCode",
+					"parkingBrakeMrk",
+					"brakes_brakeActuator",
+					"brakes_leverLength"
+				],
 				"properties": {
 					"parkingBrakeMrk": {
-						"type": [
-							"boolean",
-							"null"
-						]
+						"type": "boolean"
 					},
 					"axleNumber": {
 						"type": [
@@ -1229,18 +1234,12 @@
 						]
 					},
 					"brakes_brakeActuator": {
-						"type": [
-							"null",
-							"integer"
-						],
+						"type": "integer",
 						"minimum": 0,
 						"maximum": 999
 					},
 					"brakes_leverLength": {
-						"type": [
-							"null",
-							"integer"
-						],
+						"type": "integer",
 						"minimum": 0,
 						"maximum": 999
 					},
@@ -1251,18 +1250,12 @@
 						]
 					},
 					"weights_gbWeight": {
-						"type": [
-							"integer",
-							"null"
-						],
+						"type": "integer",
 						"minimum": 0,
 						"maximum": 99999
 					},
 					"weights_designWeight": {
-						"type": [
-							"integer",
-							"null"
-						],
+						"type": "integer",
 						"minimum": 0,
 						"maximum": 99999
 					},
@@ -1283,18 +1276,12 @@
 						"maximum": 99999
 					},
 					"tyres_tyreCode": {
-						"type": [
-							"integer",
-							"null"
-						],
+						"type": "integer",
 						"minimum": 0,
 						"maximum": 99999
 					},
 					"tyres_tyreSize": {
-						"type": [
-							"string",
-							"null"
-						],
+						"type": "string",
 						"maxLength": 12
 					},
 					"tyres_plyRating": {
@@ -1304,18 +1291,11 @@
 						]
 					},
 					"tyres_fitmentCode": {
-						"anyOf": [
-							{
-								"type": "null"
-							},
-							{
-								"title": "Fitment Code",
-								"type": "string",
-								"enum": [
-									"single",
-									"double"
-								]
-							}
+						"title": "Fitment Code",
+						"type": "string",
+						"enum": [
+							"single",
+							"double"
 						]
 					},
 					"tyres_dataTrAxles": {

--- a/json-schemas/v3/tech-record/put/trl/complete/index.json
+++ b/json-schemas/v3/tech-record/put/trl/complete/index.json
@@ -29,7 +29,8 @@
 		"techRecord_bodyType_description",
 		"techRecord_bodyType_code",
 		"techRecord_vehicleConfiguration",
-		"vin"
+		"vin",
+		"techRecord_euVehicleCategory"
 	],
 	"properties": {
 		"partialVin": {
@@ -585,34 +586,27 @@
 			"maximum": 99
 		},
 		"techRecord_euVehicleCategory": {
-			"anyOf": [
-				{
-					"title": "EU vehicle category",
-					"type": "string",
-					"enum": [
-						"m1",
-						"m2",
-						"m3",
-						"n1",
-						"n2",
-						"n3",
-						"o1",
-						"o2",
-						"o3",
-						"o4",
-						"l1e-a",
-						"l1e",
-						"l2e",
-						"l3e",
-						"l4e",
-						"l5e",
-						"l6e",
-						"l7e"
-					]
-				},
-				{
-					"type": "null"
-				}
+			"title": "EU vehicle category",
+			"type": "string",
+			"enum": [
+				"m1",
+				"m2",
+				"m3",
+				"n1",
+				"n2",
+				"n3",
+				"o1",
+				"o2",
+				"o3",
+				"o4",
+				"l1e-a",
+				"l1e",
+				"l2e",
+				"l3e",
+				"l4e",
+				"l5e",
+				"l6e",
+				"l7e"
 			]
 		},
 		"techRecord_euroStandard": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.13",
+  "version": "3.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "3.0.13",
+      "version": "3.0.14",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.13",
+  "version": "3.0.14",
   "description": "type definitions for cvs vta application",
   "main": "index.js",
   "repository": {

--- a/schema-validator.ts
+++ b/schema-validator.ts
@@ -4,13 +4,13 @@ import { schemas } from "./schemas";
 
 export type Schema = typeof schemas[number];
 /**
-   * Validate an object according to a JSON schema
-   * @param {Schema} schemaName `enum` - the name of the JSON schema to validate against
-   * @param {object} objectToValidate `object` - the object to validate
-   * @param {boolean | undefined} returnErrors `boolean` - Optional. Toggles between returning a boolean or the validation errors. Defaults to false.
-   * @param {boolean | undefined} logErrors `boolean` - Optional. Toggles the logging of errors to the console. Defaults to false.
-   * @returns {boolean | ErrorObject[]}`boolean | validationErrors`, depending on `returnErrors` flag.
-   */
+ * Validate an object according to a JSON schema
+ * @param {Schema} schemaName `enum` - the name of the JSON schema to validate against
+ * @param {object} objectToValidate `object` - the object to validate
+ * @param {boolean | undefined} returnErrors `boolean` - Optional. Toggles between returning a boolean or the validation errors. Defaults to false.
+ * @param {boolean | undefined} logErrors `boolean` - Optional. Toggles the logging of errors to the console. Defaults to false.
+ * @returns {boolean | ErrorObject[]}`boolean | validationErrors`, depending on `returnErrors` flag.
+ */
 export function isValidObject<B extends boolean | undefined>(
   schemaName: Schema,
   objectToValidate: object
@@ -19,6 +19,12 @@ export function isValidObject<B extends boolean | undefined>(
   schemaName: Schema,
   objectToValidate: object,
   returnErrors: B
+): B extends false ? boolean : ErrorObject[];
+export function isValidObject<B extends boolean | undefined>(
+  schemaName: Schema,
+  objectToValidate: object,
+  returnErrors: B,
+  logErrors: boolean | undefined
 ): B extends false ? boolean : ErrorObject[];
 export function isValidObject<B extends boolean | undefined>(
   schemaName: Schema,

--- a/tests/resources/data/hgvComplete.json
+++ b/tests/resources/data/hgvComplete.json
@@ -290,9 +290,6 @@
         "weights_designWeight": 11500,
         "weights_eecWeight": 11500,
         "weights_gbWeight": 11500
-      },
-      {
-        "0_axles": "1-2"
       }
     ],
     "dimensions": [

--- a/tests/resources/data/hgvComplete.json
+++ b/tests/resources/data/hgvComplete.json
@@ -93,9 +93,6 @@
         "weights_designWeight": 11500,
         "weights_eecWeight": 11500,
         "weights_gbWeight": 11500
-      },
-      {
-        "0_axles": "1-2"
       }
     ],
     "dimensions": [
@@ -202,9 +199,6 @@
         "weights_designWeight": 11500,
         "weights_eecWeight": 11500,
         "weights_gbWeight": 11500
-      },
-      {
-        "0_axles": "1-2"
       }
     ],
     "dimensions": [
@@ -395,9 +389,6 @@
         "weights_designWeight": 11500,
         "weights_eecWeight": 11500,
         "weights_gbWeight": 11500
-      },
-      {
-        "0_axles": "1-2"
       }
     ],
     "dimensions": [
@@ -504,9 +495,6 @@
         "weights_designWeight": 11500,
         "weights_eecWeight": 11500,
         "weights_gbWeight": 11500
-      },
-      {
-        "0_axles": "1-2"
       }
     ],
     "dimensions": [

--- a/tests/resources/data/trlComplete.json
+++ b/tests/resources/data/trlComplete.json
@@ -122,6 +122,7 @@
     "techRecord_dimensions_length": 7500,
     "techRecord_dimensions_width": 2200,
     "techRecord_frontAxleToRearAxle": 1700,
+    "techRecord_euVehicleCategory": "o4",
     "techRecord_rearAxleToRearTrl": 400,
     "techRecord_couplingCenterToRearAxleMax": 900,
     "techRecord_couplingCenterToRearAxleMin": 1000,

--- a/tests/resources/data/trlComplete.json
+++ b/tests/resources/data/trlComplete.json
@@ -79,6 +79,7 @@
     "techRecord_tyreUseCode": "2B",
     "techRecord_suspensionType": "Y",
     "techRecord_couplingType": "F",
+    "techRecord_euVehicleCategory": "o2",
     "techRecord_dimensions_length": 7500,
     "techRecord_dimensions_width": 2200,
     "techRecord_frontAxleToRearAxle": 1700,

--- a/types/v3/tech-record/get/hgv/complete/index.d.ts
+++ b/types/v3/tech-record/get/hgv/complete/index.d.ts
@@ -197,7 +197,10 @@ export interface TechRecordGETHGVComplete {
   techRecord_applicantDetails_telephoneNumber?: null | string;
   techRecord_applicantDetails_emailAddress?: null | string;
   techRecord_applicationId?: null | string;
-  techRecord_axles: HGVAxles[];
+  /**
+   * @minItems 1
+   */
+  techRecord_axles: [HGVAxles, ...HGVAxles[]];
   techRecord_bodyType_code: string;
   techRecord_bodyType_description: string;
   techRecord_brakes_antilockBrakingSystem?: string | null;
@@ -235,7 +238,7 @@ export interface TechRecordGETHGVComplete {
   techRecord_microfilm_microfilmRollNumber?: string | null;
   techRecord_microfilm_microfilmSerialNumber?: string | null;
   techRecord_model: string;
-  techRecord_numberOfWheelsDriven: number;
+  techRecord_numberOfWheelsDriven?: number;
   techRecord_noOfAxles?: number | null;
   techRecord_notes: string;
   techRecord_offRoad: boolean;
@@ -271,13 +274,13 @@ export interface TechRecordGETHGVComplete {
 export interface HGVAxles {
   parkingBrakeMrk?: boolean;
   axleNumber?: number;
-  weights_gbWeight?: number;
-  weights_designWeight?: number;
+  weights_gbWeight: number;
+  weights_designWeight: number;
   weights_eecWeight?: number | null;
-  tyres_tyreCode?: number;
-  tyres_tyreSize?: string;
+  tyres_tyreCode: number;
+  tyres_tyreSize: string;
   tyres_plyRating?: string | null;
-  tyres_fitmentCode?: FitmentCode;
+  tyres_fitmentCode: FitmentCode;
   tyres_dataTrAxles?: null | number;
 }
 export interface AxleSpacing {

--- a/types/v3/tech-record/get/trl/complete/index.d.ts
+++ b/types/v3/tech-record/get/trl/complete/index.d.ts
@@ -258,7 +258,7 @@ export interface TechRecordGETTRLComplete {
   techRecord_dimensions_width: number | null;
   drawbarCouplingFitted?: null | string;
   techRecord_emissionsLimit?: null | number;
-  techRecord_euVehicleCategory?: EUVehicleCategory | null;
+  techRecord_euVehicleCategory: EUVehicleCategory;
   techRecord_euroStandard?: null | EuroStandard;
   frontAxleTo5thWheelMax?: number | null;
   techRecord_frontAxleTo5thWheelMin?: number | null;

--- a/types/v3/tech-record/get/trl/complete/index.d.ts
+++ b/types/v3/tech-record/get/trl/complete/index.d.ts
@@ -162,23 +162,6 @@ export type VehicleConfiguration =
   | "four-in-line"
   | "dolly"
   | "full drawbar";
-export type TRLAxles = null | {
-  parkingBrakeMrk?: boolean | null;
-  axleNumber?: number | null;
-  brakes_brakeActuator?: null | number;
-  brakes_leverLength?: null | number;
-  brakes_springBrakeParking?: null | boolean;
-  weights_gbWeight?: number | null;
-  weights_designWeight?: number | null;
-  weights_ladenWeight?: number | null;
-  weights_kerbWeight?: number | null;
-  tyres_tyreCode?: number | null;
-  tyres_tyreSize?: string | null;
-  tyres_plyRating?: string | null;
-  tyres_fitmentCode?: null | FitmentCode;
-  tyres_dataTrAxles?: null | number;
-  tyres_speedCategorySymbol?: SpeedCategorySymbol | null;
-};
 export type FitmentCode = "single" | "double";
 export type SpeedCategorySymbol =
   | "a7"
@@ -342,7 +325,10 @@ export interface TechRecordGETTRLComplete {
   techRecord_vehicleType: "trl";
   trailerId: string;
   vin: string;
-  techRecord_axles?: null | TRLAxles[];
+  /**
+   * @minItems 1
+   */
+  techRecord_axles?: [TRLAxles, ...TRLAxles[]];
   techRecord_hiddenInVta?: null | boolean;
   techRecord_updateType?: null | string;
   techRecord_authIntoService_cocIssueDate?: string | null;
@@ -357,6 +343,23 @@ export interface TRLPlates {
   plateIssueDate?: string | null;
   plateReasonForIssue?: null | PlateReasonForIssue;
   plateIssuer?: string | null;
+}
+export interface TRLAxles {
+  parkingBrakeMrk: boolean;
+  axleNumber?: number | null;
+  brakes_brakeActuator: number;
+  brakes_leverLength: number;
+  brakes_springBrakeParking?: null | boolean;
+  weights_gbWeight: number;
+  weights_designWeight: number;
+  weights_ladenWeight?: number | null;
+  weights_kerbWeight?: number | null;
+  tyres_tyreCode: number;
+  tyres_tyreSize: string;
+  tyres_plyRating?: string | null;
+  tyres_fitmentCode: FitmentCode;
+  tyres_dataTrAxles?: null | number;
+  tyres_speedCategorySymbol?: SpeedCategorySymbol | null;
 }
 export interface AxleSpacing {
   axles?: string;

--- a/types/v3/tech-record/put/hgv/complete/index.d.ts
+++ b/types/v3/tech-record/put/hgv/complete/index.d.ts
@@ -198,7 +198,10 @@ export interface TechRecordPUTHGVComplete {
   techRecord_applicantDetails_telephoneNumber?: null | string;
   techRecord_applicantDetails_emailAddress?: null | string;
   techRecord_applicationId?: null | string;
-  techRecord_axles: HGVAxles[];
+  /**
+   * @minItems 1
+   */
+  techRecord_axles: [HGVAxles, ...HGVAxles[]];
   techRecord_bodyType_code: string;
   techRecord_bodyType_description: string;
   techRecord_brakes_antilockBrakingSystem?: string | null;
@@ -232,7 +235,6 @@ export interface TechRecordPUTHGVComplete {
   techRecord_microfilm_microfilmRollNumber?: string | null;
   techRecord_microfilm_microfilmSerialNumber?: string | null;
   techRecord_model: string;
-  techRecord_numberOfWheelsDriven: number;
   techRecord_noOfAxles?: number | null;
   techRecord_notes: string;
   techRecord_offRoad: boolean;
@@ -264,13 +266,13 @@ export interface TechRecordPUTHGVComplete {
 export interface HGVAxles {
   parkingBrakeMrk?: boolean;
   axleNumber?: number;
-  weights_gbWeight?: number;
-  weights_designWeight?: number;
+  weights_gbWeight: number;
+  weights_designWeight: number;
   weights_eecWeight?: number | null;
-  tyres_tyreCode?: number;
-  tyres_tyreSize?: string;
+  tyres_tyreCode: number;
+  tyres_tyreSize: string;
   tyres_plyRating?: string | null;
-  tyres_fitmentCode?: FitmentCode;
+  tyres_fitmentCode: FitmentCode;
   tyres_dataTrAxles?: null | number;
 }
 export interface AxleSpacing {

--- a/types/v3/tech-record/put/hgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/hgv/skeleton/index.d.ts
@@ -232,7 +232,6 @@ export interface TechRecordPUTHGVSkeleton {
   techRecord_microfilm_microfilmRollNumber?: string | null;
   techRecord_microfilm_microfilmSerialNumber?: string | null;
   techRecord_model?: string | null;
-  techRecord_numberOfWheelsDriven?: number | null;
   techRecord_noOfAxles?: number | null;
   techRecord_notes?: string | null;
   techRecord_offRoad?: boolean | null;

--- a/types/v3/tech-record/put/hgv/testable/index.d.ts
+++ b/types/v3/tech-record/put/hgv/testable/index.d.ts
@@ -232,7 +232,6 @@ export interface TechRecordPUTHGVTestable {
   techRecord_microfilm_microfilmRollNumber?: string | null;
   techRecord_microfilm_microfilmSerialNumber?: string | null;
   techRecord_model?: string | null;
-  techRecord_numberOfWheelsDriven: number;
   techRecord_noOfAxles?: number | null;
   techRecord_notes?: string | null;
   techRecord_offRoad?: boolean | null;

--- a/types/v3/tech-record/put/trl/complete/index.d.ts
+++ b/types/v3/tech-record/put/trl/complete/index.d.ts
@@ -318,7 +318,10 @@ export interface TechRecordPUTTRLComplete {
   techRecord_vehicleType: "trl";
   trailerId?: string;
   vin: string;
-  techRecord_axles?: null | TRLAxles[];
+  /**
+   * @minItems 1
+   */
+  techRecord_axles?: [TRLAxles, ...TRLAxles[]];
   techRecord_hiddenInVta?: null | boolean;
   techRecord_updateType?: null | string;
   techRecord_authIntoService_cocIssueDate?: string | null;
@@ -335,19 +338,19 @@ export interface TRLPlates {
   plateIssuer?: string | null;
 }
 export interface TRLAxles {
-  parkingBrakeMrk?: boolean | null;
+  parkingBrakeMrk: boolean;
   axleNumber?: number | null;
-  brakes_brakeActuator?: null | number;
-  brakes_leverLength?: null | number;
+  brakes_brakeActuator: number;
+  brakes_leverLength: number;
   brakes_springBrakeParking?: null | boolean;
-  weights_gbWeight?: number | null;
-  weights_designWeight?: number | null;
+  weights_gbWeight: number;
+  weights_designWeight: number;
   weights_ladenWeight?: number | null;
   weights_kerbWeight?: number | null;
-  tyres_tyreCode?: number | null;
-  tyres_tyreSize?: string | null;
+  tyres_tyreCode: number;
+  tyres_tyreSize: string;
   tyres_plyRating?: string | null;
-  tyres_fitmentCode?: null | FitmentCode;
+  tyres_fitmentCode: FitmentCode;
   tyres_dataTrAxles?: null | number;
   tyres_speedCategorySymbol?: SpeedCategorySymbol | null;
 }

--- a/types/v3/tech-record/put/trl/complete/index.d.ts
+++ b/types/v3/tech-record/put/trl/complete/index.d.ts
@@ -256,7 +256,7 @@ export interface TechRecordPUTTRLComplete {
   techRecord_dimensions_width: number | null;
   drawbarCouplingFitted?: null | string;
   techRecord_emissionsLimit?: null | number;
-  techRecord_euVehicleCategory?: EUVehicleCategory | null;
+  techRecord_euVehicleCategory: EUVehicleCategory;
   techRecord_euroStandard?: null | EuroStandard;
   frontAxleTo5thWheelMax?: number | null;
   techRecord_frontAxleTo5thWheelMin?: number | null;


### PR DESCRIPTION
## Ticket title

- Remove number of wheels driven from hgv
- Make missed fields for complete hgv and trl axles required
- Make eu vehicle category required for complete
- Improve typing on is valid object to expose the `logErrors` option

[CB2-XXXX](https://dvsa.atlassian.net/browse/CB2-XXXX)

<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

- Remove number of wheels driven from hgv
- Make missed fields for complete hgv and trl axles required
- Make eu vehicle category required for complete tech records
- Improve typing on is valid object to expose the `logErrors` option

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
