### PR TITLE
patch(cb2-8667): remove record completeness from testable trl

### DIFF
--- a/json-definitions/v3/tech-record/put/trl/testable/index.json
+++ b/json-definitions/v3/tech-record/put/trl/testable/index.json
@@ -5,7 +5,6 @@
   "required": [
     "techRecord_noOfAxles",
     "techRecord_reasonForCreation",
-    "techRecord_recordCompleteness",
     "techRecord_statusCode",
     "techRecord_vehicleClass_code",
     "techRecord_vehicleClass_description",

--- a/json-schemas/v3/tech-record/put/trl/testable/index.json
+++ b/json-schemas/v3/tech-record/put/trl/testable/index.json
@@ -5,7 +5,6 @@
 	"required": [
 		"techRecord_noOfAxles",
 		"techRecord_reasonForCreation",
-		"techRecord_recordCompleteness",
 		"techRecord_statusCode",
 		"techRecord_vehicleClass_code",
 		"techRecord_vehicleClass_description",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.18",
+  "version": "3.0.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "3.0.18",
+      "version": "3.0.19",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.18",
+  "version": "3.0.19",
   "description": "type definitions for cvs vta application",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
## Ticket title

Remove required record completeness from testable trl

[CB2-8667](https://dvsa.atlassian.net/browse/CB2-8667)

<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

- remove required `recordCompleteness` from trl testable schema.

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
