### PR TITLE
patch(cb2-8666): update min max on psvs

### DIFF
--- a/json-definitions/v3/tech-record/put/psv/testable/index.json
+++ b/json-definitions/v3/tech-record/put/psv/testable/index.json
@@ -224,7 +224,7 @@
         "null"
       ],
       "maximum": 99999,
-      "min": 0
+      "minimum": 0
     },
     "techRecord_createdByName": {
       "type": [
@@ -267,8 +267,8 @@
         "integer",
         "null"
       ],
-      "max": 99,
-      "min": 0
+      "maximum": 99,
+      "minimum": 0
     },
     "techRecord_dda_wheelchairFittings": {
       "type": [
@@ -308,8 +308,8 @@
         "integer",
         "null"
       ],
-      "min": 0,
-      "max": 99
+      "minimum": 0,
+      "maximum": 99
     },
     "techRecord_dda_outswing": {
       "type": [
@@ -330,8 +330,8 @@
         "integer",
         "null"
       ],
-      "min": 0,
-      "max": 999
+      "minimum": 0,
+      "maximum": 999
     },
     "techRecord_dda_ddaNotes": {
       "type": [
@@ -345,8 +345,8 @@
         "integer",
         "null"
       ],
-      "min": 0,
-      "max": 999
+      "minimum": 0,
+      "maximum": 999
     },
     "techRecord_speedLimiterMrk": {
       "type": [
@@ -385,16 +385,16 @@
         "null",
         "integer"
       ],
-      "min": 0,
-      "max": 99
+      "minimum": 0,
+      "maximum": 99
     },
     "techRecord_trainDesignWeight": {
       "type": [
         "integer",
         "null"
       ],
-      "min": 0,
-      "max": 99999
+      "minimum": 0,
+      "maximum": 99999
     },
     "techRecord_numberOfSeatbelts": {
       "type": [
@@ -481,72 +481,72 @@
         "number",
         "null"
       ],
-      "max": 99,
-      "min": 0
+      "maximum": 99,
+      "minimum": 0
     },
     "techRecord_grossKerbWeight": {
       "type": [
         "number",
         "null"
       ],
-      "max": 99999,
-      "min": 0
+      "maximum": 99999,
+      "minimum": 0
     },
     "techRecord_grossLadenWeight": {
       "type": [
         "number",
         "null"
       ],
-      "max": 99999,
-      "min": 0
+      "maximum": 99999,
+      "minimum": 0
     },
     "techRecord_unladenWeight": {
       "type": [
         "number",
         "null"
       ],
-      "max": 99999,
-      "min": 0
+      "maximum": 99999,
+      "minimum": 0
     },
     "techRecord_maxTrainGbWeight": {
       "type": [
         "number",
         "null"
       ],
-      "max": 99999,
-      "min": 0
+      "maximum": 99999,
+      "minimum": 0
     },
     "techRecord_dimensions_length": {
       "type": [
         "integer",
         "null"
       ],
-      "min": 0,
-      "max": 99999
+      "minimum": 0,
+      "maximum": 99999
     },
     "techRecord_dimensions_width": {
       "type": [
         "integer",
         "null"
       ],
-      "min": 0,
-      "max": 99999
+      "minimum": 0,
+      "maximum": 99999
     },
     "techRecord_dimensions_height": {
       "type": [
         "integer",
         "null"
       ],
-      "min": 0,
-      "max": 99999
+      "minimum": 0,
+      "maximum": 99999
     },
     "techRecord_frontAxleToRearAxle": {
       "type": [
         "integer",
         "null"
       ],
-      "min": 0,
-      "max": 99999
+      "minimum": 0,
+      "maximum": 99999
     },
     "techRecord_remarks": {
       "type": [

--- a/json-schemas/v3/tech-record/put/psv/testable/index.json
+++ b/json-schemas/v3/tech-record/put/psv/testable/index.json
@@ -326,7 +326,7 @@
 				"null"
 			],
 			"maximum": 99999,
-			"min": 0
+			"minimum": 0
 		},
 		"techRecord_createdByName": {
 			"type": [
@@ -369,8 +369,8 @@
 				"integer",
 				"null"
 			],
-			"max": 99,
-			"min": 0
+			"maximum": 99,
+			"minimum": 0
 		},
 		"techRecord_dda_wheelchairFittings": {
 			"type": [
@@ -410,8 +410,8 @@
 				"integer",
 				"null"
 			],
-			"min": 0,
-			"max": 99
+			"minimum": 0,
+			"maximum": 99
 		},
 		"techRecord_dda_outswing": {
 			"type": [
@@ -432,8 +432,8 @@
 				"integer",
 				"null"
 			],
-			"min": 0,
-			"max": 999
+			"minimum": 0,
+			"maximum": 999
 		},
 		"techRecord_dda_ddaNotes": {
 			"type": [
@@ -447,8 +447,8 @@
 				"integer",
 				"null"
 			],
-			"min": 0,
-			"max": 999
+			"minimum": 0,
+			"maximum": 999
 		},
 		"techRecord_speedLimiterMrk": {
 			"type": [
@@ -511,16 +511,16 @@
 				"null",
 				"integer"
 			],
-			"min": 0,
-			"max": 99
+			"minimum": 0,
+			"maximum": 99
 		},
 		"techRecord_trainDesignWeight": {
 			"type": [
 				"integer",
 				"null"
 			],
-			"min": 0,
-			"max": 99999
+			"minimum": 0,
+			"maximum": 99999
 		},
 		"techRecord_numberOfSeatbelts": {
 			"type": [
@@ -607,72 +607,72 @@
 				"number",
 				"null"
 			],
-			"max": 99,
-			"min": 0
+			"maximum": 99,
+			"minimum": 0
 		},
 		"techRecord_grossKerbWeight": {
 			"type": [
 				"number",
 				"null"
 			],
-			"max": 99999,
-			"min": 0
+			"maximum": 99999,
+			"minimum": 0
 		},
 		"techRecord_grossLadenWeight": {
 			"type": [
 				"number",
 				"null"
 			],
-			"max": 99999,
-			"min": 0
+			"maximum": 99999,
+			"minimum": 0
 		},
 		"techRecord_unladenWeight": {
 			"type": [
 				"number",
 				"null"
 			],
-			"max": 99999,
-			"min": 0
+			"maximum": 99999,
+			"minimum": 0
 		},
 		"techRecord_maxTrainGbWeight": {
 			"type": [
 				"number",
 				"null"
 			],
-			"max": 99999,
-			"min": 0
+			"maximum": 99999,
+			"minimum": 0
 		},
 		"techRecord_dimensions_length": {
 			"type": [
 				"integer",
 				"null"
 			],
-			"min": 0,
-			"max": 99999
+			"minimum": 0,
+			"maximum": 99999
 		},
 		"techRecord_dimensions_width": {
 			"type": [
 				"integer",
 				"null"
 			],
-			"min": 0,
-			"max": 99999
+			"minimum": 0,
+			"maximum": 99999
 		},
 		"techRecord_dimensions_height": {
 			"type": [
 				"integer",
 				"null"
 			],
-			"min": 0,
-			"max": 99999
+			"minimum": 0,
+			"maximum": 99999
 		},
 		"techRecord_frontAxleToRearAxle": {
 			"type": [
 				"integer",
 				"null"
 			],
-			"min": 0,
-			"max": 99999
+			"minimum": 0,
+			"maximum": 99999
 		},
 		"techRecord_remarks": {
 			"type": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.20",
+  "version": "3.0.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "3.0.20",
+      "version": "3.0.21",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.20",
+  "version": "3.0.21",
   "description": "type definitions for cvs vta application",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
## Ticket title

Update `min` and `max` to `minimum` and `maximum`

[CB2-8666](https://dvsa.atlassian.net/browse/CB2-8666)

<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

- Update `min` and `max` to `minimum` and `maximum` on PSVs

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
