### PR TITLE
patch(*): remove audit details from put types

### DIFF
--- a/json-definitions/v3/tech-record/put/car/complete/index.json
+++ b/json-definitions/v3/tech-record/put/car/complete/index.json
@@ -81,24 +81,6 @@
         "string"
       ]
     },
-    "techRecord_createdAt": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "techRecord_createdById": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "techRecord_createdByName": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
     "secondaryVrms": {
       "type": [
         "null",

--- a/json-definitions/v3/tech-record/put/car/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/car/skeleton/index.json
@@ -77,24 +77,6 @@
         "string"
       ]
     },
-    "techRecord_createdAt": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "techRecord_createdById": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "techRecord_createdByName": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
     "secondaryVrms": {
       "type": [
         "null",

--- a/json-definitions/v3/tech-record/put/hgv/complete/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/complete/index.json
@@ -56,24 +56,6 @@
         "null"
       ]
     },
-    "techRecord_createdAt": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "techRecord_createdById": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "techRecord_createdByName": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
     "techRecord_adrDetails_vehicleDetails_type": {
       "type": [
         "string",

--- a/json-definitions/v3/tech-record/put/hgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/skeleton/index.json
@@ -21,24 +21,6 @@
         "null"
       ]
     },
-    "techRecord_createdAt": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "techRecord_createdById": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "techRecord_createdByName": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
     "techRecord_adrDetails_vehicleDetails_type": {
       "type": [
         "string",

--- a/json-definitions/v3/tech-record/put/hgv/testable/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/testable/index.json
@@ -24,15 +24,6 @@
         "null"
       ]
     },
-    "techRecord_createdAt": {
-      "type": "string"
-    },
-    "techRecord_createdById": {
-      "type": "string"
-    },
-    "techRecord_createdByName": {
-      "type": "string"
-    },
     "techRecord_adrDetails_vehicleDetails_type": {
       "type": [
         "string",

--- a/json-definitions/v3/tech-record/put/lgv/complete/index.json
+++ b/json-definitions/v3/tech-record/put/lgv/complete/index.json
@@ -128,15 +128,6 @@
     "techRecord_updateType": {
       "type": "string"
     },
-    "techRecord_createdAt": {
-      "type": "string"
-    },
-    "techRecord_createdById": {
-      "type": "string"
-    },
-    "techRecord_createdByName": {
-      "type": "string"
-    },
     "secondaryVrms": {
       "type": "array",
       "items": {

--- a/json-definitions/v3/tech-record/put/motorcycle/complete/index.json
+++ b/json-definitions/v3/tech-record/put/motorcycle/complete/index.json
@@ -92,24 +92,6 @@
         "string"
       ]
     },
-    "techRecord_createdAt": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "techRecord_createdById": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "techRecord_createdByName": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
     "techRecord_euVehicleCategory": {
       "anyOf": [
         {
@@ -118,24 +100,6 @@
         {
           "$ref": "../../../enums/euVehicleCategory.ignore.json"
         }
-      ]
-    },
-    "techRecord_lastUpdatedAt": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "techRecord_lastUpdatedById": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "techRecord_lastUpdatedByName": {
-      "type": [
-        "string",
-        "null"
       ]
     },
     "techRecord_manufactureYear": {

--- a/json-definitions/v3/tech-record/put/motorcycle/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/motorcycle/skeleton/index.json
@@ -82,24 +82,6 @@
         "string"
       ]
     },
-    "techRecord_createdAt": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "techRecord_createdById": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "techRecord_createdByName": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
     "techRecord_euVehicleCategory": {
       "anyOf": [
         {
@@ -108,24 +90,6 @@
         {
           "$ref": "../../../enums/euVehicleCategory.ignore.json"
         }
-      ]
-    },
-    "techRecord_lastUpdatedAt": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "techRecord_lastUpdatedById": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "techRecord_lastUpdatedByName": {
-      "type": [
-        "string",
-        "null"
       ]
     },
     "techRecord_manufactureYear": {

--- a/json-definitions/v3/tech-record/put/psv/complete/index.json
+++ b/json-definitions/v3/tech-record/put/psv/complete/index.json
@@ -255,36 +255,6 @@
       "maximum": 99999,
       "minimum": 0
     },
-    "techRecord_createdByName": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "techRecord_createdById": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "techRecord_lastUpdatedAt": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "techRecord_lastUpdatedByName": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "techRecord_lastUpdatedById": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
     "techRecord_dda_certificateIssued": {
       "type": "boolean"
     },

--- a/json-definitions/v3/tech-record/put/psv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/psv/skeleton/index.json
@@ -248,36 +248,6 @@
       "maximum": 99999,
       "minimum": 0
     },
-    "techRecord_createdByName": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "techRecord_createdById": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "techRecord_lastUpdatedAt": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "techRecord_lastUpdatedByName": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "techRecord_lastUpdatedById": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
     "techRecord_dda_certificateIssued": {
       "type": [
         "boolean",

--- a/json-definitions/v3/tech-record/put/psv/testable/index.json
+++ b/json-definitions/v3/tech-record/put/psv/testable/index.json
@@ -226,36 +226,6 @@
       "maximum": 99999,
       "minimum": 0
     },
-    "techRecord_createdByName": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "techRecord_createdById": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "techRecord_lastUpdatedAt": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "techRecord_lastUpdatedByName": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "techRecord_lastUpdatedById": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
     "techRecord_dda_certificateIssued": {
       "type": [
         "boolean",

--- a/json-definitions/v3/tech-record/put/trl/complete/index.json
+++ b/json-definitions/v3/tech-record/put/trl/complete/index.json
@@ -39,24 +39,6 @@
         "null"
       ]
     },
-    "techRecord_createdAt": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "techRecord_createdById": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "techRecord_createdByName": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
     "techRecord_adrDetails_vehicleDetails_type": {
       "type": [
         "string",

--- a/json-definitions/v3/tech-record/put/trl/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/trl/skeleton/index.json
@@ -53,15 +53,6 @@
         "string"
       ]
     },
-    "techRecord_createdAt": {
-      "type": "string"
-    },
-    "techRecord_createdById": {
-      "type": "string"
-    },
-    "techRecord_createdByName": {
-      "type": "string"
-    },
     "techRecord_adrDetails_vehicleDetails_type": {
       "type": [
         "string",
@@ -797,24 +788,6 @@
       ]
     },
     "techRecord_purchaserDetails_telephoneNumber": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "techRecord_lastUpdatedAt": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "techRecord_lastUpdatedByName": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "techRecord_lastUpdatedById": {
       "type": [
         "string",
         "null"

--- a/json-definitions/v3/tech-record/put/trl/testable/index.json
+++ b/json-definitions/v3/tech-record/put/trl/testable/index.json
@@ -56,15 +56,6 @@
         "string"
       ]
     },
-    "techRecord_createdAt": {
-      "type": "string"
-    },
-    "techRecord_createdById": {
-      "type": "string"
-    },
-    "techRecord_createdByName": {
-      "type": "string"
-    },
     "techRecord_adrDetails_vehicleDetails_type": {
       "type": [
         "string",

--- a/json-schemas/v3/tech-record/put/car/complete/index.json
+++ b/json-schemas/v3/tech-record/put/car/complete/index.json
@@ -104,24 +104,6 @@
 				"string"
 			]
 		},
-		"techRecord_createdAt": {
-			"type": [
-				"null",
-				"string"
-			]
-		},
-		"techRecord_createdById": {
-			"type": [
-				"null",
-				"string"
-			]
-		},
-		"techRecord_createdByName": {
-			"type": [
-				"null",
-				"string"
-			]
-		},
 		"secondaryVrms": {
 			"type": [
 				"null",

--- a/json-schemas/v3/tech-record/put/car/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/car/skeleton/index.json
@@ -83,24 +83,6 @@
 				"string"
 			]
 		},
-		"techRecord_createdAt": {
-			"type": [
-				"null",
-				"string"
-			]
-		},
-		"techRecord_createdById": {
-			"type": [
-				"null",
-				"string"
-			]
-		},
-		"techRecord_createdByName": {
-			"type": [
-				"null",
-				"string"
-			]
-		},
 		"secondaryVrms": {
 			"type": [
 				"null",

--- a/json-schemas/v3/tech-record/put/hgv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/complete/index.json
@@ -56,24 +56,6 @@
 				"null"
 			]
 		},
-		"techRecord_createdAt": {
-			"type": [
-				"null",
-				"string"
-			]
-		},
-		"techRecord_createdById": {
-			"type": [
-				"null",
-				"string"
-			]
-		},
-		"techRecord_createdByName": {
-			"type": [
-				"null",
-				"string"
-			]
-		},
 		"techRecord_adrDetails_vehicleDetails_type": {
 			"type": [
 				"string",

--- a/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
@@ -21,24 +21,6 @@
 				"null"
 			]
 		},
-		"techRecord_createdAt": {
-			"type": [
-				"null",
-				"string"
-			]
-		},
-		"techRecord_createdById": {
-			"type": [
-				"null",
-				"string"
-			]
-		},
-		"techRecord_createdByName": {
-			"type": [
-				"null",
-				"string"
-			]
-		},
 		"techRecord_adrDetails_vehicleDetails_type": {
 			"type": [
 				"string",

--- a/json-schemas/v3/tech-record/put/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/testable/index.json
@@ -24,15 +24,6 @@
 				"null"
 			]
 		},
-		"techRecord_createdAt": {
-			"type": "string"
-		},
-		"techRecord_createdById": {
-			"type": "string"
-		},
-		"techRecord_createdByName": {
-			"type": "string"
-		},
 		"techRecord_adrDetails_vehicleDetails_type": {
 			"type": [
 				"string",

--- a/json-schemas/v3/tech-record/put/lgv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/lgv/complete/index.json
@@ -172,15 +172,6 @@
 		"techRecord_updateType": {
 			"type": "string"
 		},
-		"techRecord_createdAt": {
-			"type": "string"
-		},
-		"techRecord_createdById": {
-			"type": "string"
-		},
-		"techRecord_createdByName": {
-			"type": "string"
-		},
 		"secondaryVrms": {
 			"type": "array",
 			"items": {

--- a/json-schemas/v3/tech-record/put/motorcycle/complete/index.json
+++ b/json-schemas/v3/tech-record/put/motorcycle/complete/index.json
@@ -92,24 +92,6 @@
 				"string"
 			]
 		},
-		"techRecord_createdAt": {
-			"type": [
-				"null",
-				"string"
-			]
-		},
-		"techRecord_createdById": {
-			"type": [
-				"null",
-				"string"
-			]
-		},
-		"techRecord_createdByName": {
-			"type": [
-				"null",
-				"string"
-			]
-		},
 		"techRecord_euVehicleCategory": {
 			"anyOf": [
 				{
@@ -139,24 +121,6 @@
 						"l7e"
 					]
 				}
-			]
-		},
-		"techRecord_lastUpdatedAt": {
-			"type": [
-				"string",
-				"null"
-			]
-		},
-		"techRecord_lastUpdatedById": {
-			"type": [
-				"string",
-				"null"
-			]
-		},
-		"techRecord_lastUpdatedByName": {
-			"type": [
-				"string",
-				"null"
 			]
 		},
 		"techRecord_manufactureYear": {

--- a/json-schemas/v3/tech-record/put/motorcycle/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/motorcycle/skeleton/index.json
@@ -82,24 +82,6 @@
 				"string"
 			]
 		},
-		"techRecord_createdAt": {
-			"type": [
-				"null",
-				"string"
-			]
-		},
-		"techRecord_createdById": {
-			"type": [
-				"null",
-				"string"
-			]
-		},
-		"techRecord_createdByName": {
-			"type": [
-				"null",
-				"string"
-			]
-		},
 		"techRecord_euVehicleCategory": {
 			"anyOf": [
 				{
@@ -129,24 +111,6 @@
 						"l7e"
 					]
 				}
-			]
-		},
-		"techRecord_lastUpdatedAt": {
-			"type": [
-				"string",
-				"null"
-			]
-		},
-		"techRecord_lastUpdatedById": {
-			"type": [
-				"string",
-				"null"
-			]
-		},
-		"techRecord_lastUpdatedByName": {
-			"type": [
-				"string",
-				"null"
 			]
 		},
 		"techRecord_manufactureYear": {

--- a/json-schemas/v3/tech-record/put/psv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/psv/complete/index.json
@@ -357,36 +357,6 @@
 			"maximum": 99999,
 			"minimum": 0
 		},
-		"techRecord_createdByName": {
-			"type": [
-				"string",
-				"null"
-			]
-		},
-		"techRecord_createdById": {
-			"type": [
-				"string",
-				"null"
-			]
-		},
-		"techRecord_lastUpdatedAt": {
-			"type": [
-				"string",
-				"null"
-			]
-		},
-		"techRecord_lastUpdatedByName": {
-			"type": [
-				"string",
-				"null"
-			]
-		},
-		"techRecord_lastUpdatedById": {
-			"type": [
-				"string",
-				"null"
-			]
-		},
 		"techRecord_dda_certificateIssued": {
 			"type": "boolean"
 		},

--- a/json-schemas/v3/tech-record/put/psv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/psv/skeleton/index.json
@@ -350,36 +350,6 @@
 			"maximum": 99999,
 			"minimum": 0
 		},
-		"techRecord_createdByName": {
-			"type": [
-				"string",
-				"null"
-			]
-		},
-		"techRecord_createdById": {
-			"type": [
-				"string",
-				"null"
-			]
-		},
-		"techRecord_lastUpdatedAt": {
-			"type": [
-				"string",
-				"null"
-			]
-		},
-		"techRecord_lastUpdatedByName": {
-			"type": [
-				"string",
-				"null"
-			]
-		},
-		"techRecord_lastUpdatedById": {
-			"type": [
-				"string",
-				"null"
-			]
-		},
 		"techRecord_dda_certificateIssued": {
 			"type": [
 				"boolean",

--- a/json-schemas/v3/tech-record/put/psv/testable/index.json
+++ b/json-schemas/v3/tech-record/put/psv/testable/index.json
@@ -328,36 +328,6 @@
 			"maximum": 99999,
 			"minimum": 0
 		},
-		"techRecord_createdByName": {
-			"type": [
-				"string",
-				"null"
-			]
-		},
-		"techRecord_createdById": {
-			"type": [
-				"string",
-				"null"
-			]
-		},
-		"techRecord_lastUpdatedAt": {
-			"type": [
-				"string",
-				"null"
-			]
-		},
-		"techRecord_lastUpdatedByName": {
-			"type": [
-				"string",
-				"null"
-			]
-		},
-		"techRecord_lastUpdatedById": {
-			"type": [
-				"string",
-				"null"
-			]
-		},
 		"techRecord_dda_certificateIssued": {
 			"type": [
 				"boolean",

--- a/json-schemas/v3/tech-record/put/trl/complete/index.json
+++ b/json-schemas/v3/tech-record/put/trl/complete/index.json
@@ -39,24 +39,6 @@
 				"null"
 			]
 		},
-		"techRecord_createdAt": {
-			"type": [
-				"null",
-				"string"
-			]
-		},
-		"techRecord_createdById": {
-			"type": [
-				"null",
-				"string"
-			]
-		},
-		"techRecord_createdByName": {
-			"type": [
-				"null",
-				"string"
-			]
-		},
 		"techRecord_adrDetails_vehicleDetails_type": {
 			"type": [
 				"string",

--- a/json-schemas/v3/tech-record/put/trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/trl/skeleton/index.json
@@ -70,15 +70,6 @@
 				"string"
 			]
 		},
-		"techRecord_createdAt": {
-			"type": "string"
-		},
-		"techRecord_createdById": {
-			"type": "string"
-		},
-		"techRecord_createdByName": {
-			"type": "string"
-		},
 		"techRecord_adrDetails_vehicleDetails_type": {
 			"type": [
 				"string",
@@ -937,24 +928,6 @@
 			]
 		},
 		"techRecord_purchaserDetails_telephoneNumber": {
-			"type": [
-				"string",
-				"null"
-			]
-		},
-		"techRecord_lastUpdatedAt": {
-			"type": [
-				"string",
-				"null"
-			]
-		},
-		"techRecord_lastUpdatedByName": {
-			"type": [
-				"string",
-				"null"
-			]
-		},
-		"techRecord_lastUpdatedById": {
 			"type": [
 				"string",
 				"null"

--- a/json-schemas/v3/tech-record/put/trl/testable/index.json
+++ b/json-schemas/v3/tech-record/put/trl/testable/index.json
@@ -73,15 +73,6 @@
 				"string"
 			]
 		},
-		"techRecord_createdAt": {
-			"type": "string"
-		},
-		"techRecord_createdById": {
-			"type": "string"
-		},
-		"techRecord_createdByName": {
-			"type": "string"
-		},
 		"techRecord_adrDetails_vehicleDetails_type": {
 			"type": [
 				"string",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.22",
+  "version": "3.0.23",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "3.0.22",
+      "version": "3.0.23",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.22",
+  "version": "3.0.23",
   "description": "type definitions for cvs vta application",
   "main": "index.js",
   "repository": {

--- a/types/v3/tech-record/put/car/complete/index.d.ts
+++ b/types/v3/tech-record/put/car/complete/index.d.ts
@@ -22,8 +22,5 @@ export interface TechRecordPUTCarComplete {
   techRecord_vehicleSubclass: VehicleSubclass[];
   techRecord_hiddenInVta?: null | boolean;
   techRecord_updateType?: null | string;
-  techRecord_createdAt?: null | string;
-  techRecord_createdById?: null | string;
-  techRecord_createdByName?: null | string;
   secondaryVrms?: null | string[];
 }

--- a/types/v3/tech-record/put/car/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/car/skeleton/index.d.ts
@@ -21,9 +21,6 @@ export interface TechRecordPUTCarSkeleton {
   techRecord_notes?: null | string;
   techRecord_hiddenInVta?: null | boolean;
   techRecord_updateType?: null | string;
-  techRecord_createdAt?: null | string;
-  techRecord_createdById?: null | string;
-  techRecord_createdByName?: null | string;
   secondaryVrms?: null | string[];
   techRecord_vehicleSubclass?: VehicleSubclass[];
 }

--- a/types/v3/tech-record/put/hgv/complete/index.d.ts
+++ b/types/v3/tech-record/put/hgv/complete/index.d.ts
@@ -145,9 +145,6 @@ export type ApprovalType =
 export interface TechRecordPUTHGVComplete {
   secondaryVrms?: string[];
   partialVin?: string | null;
-  techRecord_createdAt?: null | string;
-  techRecord_createdById?: null | string;
-  techRecord_createdByName?: null | string;
   techRecord_adrDetails_vehicleDetails_type?: string | null;
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;
   techRecord_adrDetails_permittedDangerousGoods?: string[] | null;

--- a/types/v3/tech-record/put/hgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/hgv/skeleton/index.d.ts
@@ -145,9 +145,6 @@ export type ApprovalType =
 export interface TechRecordPUTHGVSkeleton {
   secondaryVrms?: string[];
   partialVin?: string | null;
-  techRecord_createdAt?: null | string;
-  techRecord_createdById?: null | string;
-  techRecord_createdByName?: null | string;
   techRecord_adrDetails_vehicleDetails_type?: string | null;
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;
   techRecord_adrDetails_permittedDangerousGoods?: string[] | null;

--- a/types/v3/tech-record/put/hgv/testable/index.d.ts
+++ b/types/v3/tech-record/put/hgv/testable/index.d.ts
@@ -145,9 +145,6 @@ export type ApprovalType =
 export interface TechRecordPUTHGVTestable {
   secondaryVrms?: string[];
   partialVin?: string | null;
-  techRecord_createdAt?: string;
-  techRecord_createdById?: string;
-  techRecord_createdByName?: string;
   techRecord_adrDetails_vehicleDetails_type?: string | null;
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;
   techRecord_adrDetails_permittedDangerousGoods?: string[] | null;

--- a/types/v3/tech-record/put/lgv/complete/index.d.ts
+++ b/types/v3/tech-record/put/lgv/complete/index.d.ts
@@ -50,8 +50,5 @@ export interface TechRecordPUTLGVComplete {
   techRecord_vehicleSubclass: VehicleSubclass[];
   techRecord_hiddenInVta?: boolean;
   techRecord_updateType?: string;
-  techRecord_createdAt?: string;
-  techRecord_createdById?: string;
-  techRecord_createdByName?: string;
   secondaryVrms?: string[];
 }

--- a/types/v3/tech-record/put/motorcycle/complete/index.d.ts
+++ b/types/v3/tech-record/put/motorcycle/complete/index.d.ts
@@ -52,13 +52,7 @@ export interface TechRecordPUTMotorcycleComplete {
   partialVin?: null | string;
   primaryVrm?: null | string;
   systemNumber?: null | string;
-  techRecord_createdAt?: null | string;
-  techRecord_createdById?: null | string;
-  techRecord_createdByName?: null | string;
   techRecord_euVehicleCategory?: null | EUVehicleCategory;
-  techRecord_lastUpdatedAt?: string | null;
-  techRecord_lastUpdatedById?: string | null;
-  techRecord_lastUpdatedByName?: string | null;
   techRecord_manufactureYear?: number | null;
   techRecord_recordCompleteness?: null | string;
   techRecord_noOfAxles?: null | number;

--- a/types/v3/tech-record/put/motorcycle/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/motorcycle/skeleton/index.d.ts
@@ -51,13 +51,7 @@ export interface TechRecordPUTMotorcycleSkeleton {
   partialVin?: null | string;
   primaryVrm?: null | string;
   systemNumber?: null | string;
-  techRecord_createdAt?: null | string;
-  techRecord_createdById?: null | string;
-  techRecord_createdByName?: null | string;
   techRecord_euVehicleCategory?: null | EUVehicleCategory;
-  techRecord_lastUpdatedAt?: string | null;
-  techRecord_lastUpdatedById?: string | null;
-  techRecord_lastUpdatedByName?: string | null;
   techRecord_manufactureYear?: number | null;
   techRecord_recordCompleteness?: null | string;
   techRecord_noOfAxles?: null | number;

--- a/types/v3/tech-record/put/psv/complete/index.d.ts
+++ b/types/v3/tech-record/put/psv/complete/index.d.ts
@@ -218,11 +218,6 @@ export interface TechRecordPUTPSVComplete {
   techRecord_conversionRefNo?: string | null;
   techRecord_grossGbWeight?: number | null;
   techRecord_grossDesignWeight?: number | null;
-  techRecord_createdByName?: string | null;
-  techRecord_createdById?: string | null;
-  techRecord_lastUpdatedAt?: string | null;
-  techRecord_lastUpdatedByName?: string | null;
-  techRecord_lastUpdatedById?: string | null;
   techRecord_dda_certificateIssued: boolean;
   techRecord_dda_wheelchairCapacity?: number | null;
   techRecord_dda_wheelchairFittings?: string | null;

--- a/types/v3/tech-record/put/psv/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/psv/skeleton/index.d.ts
@@ -218,11 +218,6 @@ export interface TechRecordPUTPSVSkeleton {
   techRecord_conversionRefNo?: string | null;
   techRecord_grossGbWeight?: number | null;
   techRecord_grossDesignWeight?: number | null;
-  techRecord_createdByName?: string | null;
-  techRecord_createdById?: string | null;
-  techRecord_lastUpdatedAt?: string | null;
-  techRecord_lastUpdatedByName?: string | null;
-  techRecord_lastUpdatedById?: string | null;
   techRecord_dda_certificateIssued?: boolean | null;
   techRecord_dda_wheelchairCapacity?: number | null;
   techRecord_dda_wheelchairFittings?: string | null;

--- a/types/v3/tech-record/put/psv/testable/index.d.ts
+++ b/types/v3/tech-record/put/psv/testable/index.d.ts
@@ -218,11 +218,6 @@ export interface TechRecordPUTPSVTestable {
   techRecord_conversionRefNo?: string | null;
   techRecord_grossGbWeight?: number | null;
   techRecord_grossDesignWeight?: number | null;
-  techRecord_createdByName?: string | null;
-  techRecord_createdById?: string | null;
-  techRecord_lastUpdatedAt?: string | null;
-  techRecord_lastUpdatedByName?: string | null;
-  techRecord_lastUpdatedById?: string | null;
   techRecord_dda_certificateIssued?: boolean | null;
   techRecord_dda_wheelchairCapacity?: number | null;
   techRecord_dda_wheelchairFittings?: string | null;

--- a/types/v3/tech-record/put/trl/complete/index.d.ts
+++ b/types/v3/tech-record/put/trl/complete/index.d.ts
@@ -182,9 +182,6 @@ export type SpeedCategorySymbol =
 
 export interface TechRecordPUTTRLComplete {
   partialVin?: string | null;
-  techRecord_createdAt?: null | string;
-  techRecord_createdById?: null | string;
-  techRecord_createdByName?: null | string;
   techRecord_adrDetails_vehicleDetails_type?: string | null;
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;
   techRecord_adrDetails_permittedDangerousGoods?: string[] | null;

--- a/types/v3/tech-record/put/trl/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/trl/skeleton/index.d.ts
@@ -167,9 +167,6 @@ export interface TechRecordPUTTRLSkeleton {
   techRecord_ntaNumber?: null | string;
   techRecord_variantNumber?: null | string;
   techRecord_variantVersionNumber?: null | string;
-  techRecord_createdAt?: string;
-  techRecord_createdById?: string;
-  techRecord_createdByName?: string;
   techRecord_adrDetails_vehicleDetails_type?: string | null;
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;
   techRecord_adrDetails_permittedDangerousGoods?: string[] | null;
@@ -269,9 +266,6 @@ export interface TechRecordPUTTRLSkeleton {
   techRecord_purchaserDetails_postTown?: string | null;
   techRecord_purchaserDetails_purchaserNotes?: string | null;
   techRecord_purchaserDetails_telephoneNumber?: string | null;
-  techRecord_lastUpdatedAt?: string | null;
-  techRecord_lastUpdatedByName?: string | null;
-  techRecord_lastUpdatedById?: string | null;
   techRecord_rearAxleToRearTrl?: number | null;
   techRecord_reasonForCreation: string;
   techRecord_regnDate?: string | null;

--- a/types/v3/tech-record/put/trl/testable/index.d.ts
+++ b/types/v3/tech-record/put/trl/testable/index.d.ts
@@ -167,9 +167,6 @@ export interface TechRecordPUTTRLTestable {
   techRecord_ntaNumber?: null | string;
   techRecord_variantNumber?: null | string;
   techRecord_variantVersionNumber?: null | string;
-  techRecord_createdAt?: string;
-  techRecord_createdById?: string;
-  techRecord_createdByName?: string;
   techRecord_adrDetails_vehicleDetails_type?: string | null;
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;
   techRecord_adrDetails_permittedDangerousGoods?: string[] | null;


### PR DESCRIPTION
## Ticket title

Remove audit details from put tech record types. This information is generated/pulled from the token and overwritten, so should not have to be supplied in the payload.

This is causing some issues with small trailers currently

[CB2-8806](https://dvsa.atlassian.net/browse/CB2-8806)

<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

- Remove audit details from put technical records.

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
