### PR TITLE
patch(*): fix vehicle subclass

### DIFF
--- a/json-definitions/v3/tech-record/get/car/complete/index.json
+++ b/json-definitions/v3/tech-record/get/car/complete/index.json
@@ -195,10 +195,7 @@
       "type": "string"
     },
     "techRecord_vehicleSubclass": {
-      "type": "array",
-      "items": {
-        "$ref": "../../../enums/vehicleSubclass.ignore.json"
-      }
+      "$ref": "../../../enums/vehicleSubclass.ignore.json"
     },
     "techRecord_hiddenInVta": {
       "type": [

--- a/json-definitions/v3/tech-record/get/car/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/car/skeleton/index.json
@@ -215,10 +215,7 @@
       }
     },
     "techRecord_vehicleSubclass": {
-      "type": "array",
-      "items": {
-        "$ref": "../../../enums/vehicleSubclass.ignore.json"
-      }
+      "$ref": "../../../enums/vehicleSubclass.ignore.json"
     }
   }
 }

--- a/json-definitions/v3/tech-record/get/lgv/complete/index.json
+++ b/json-definitions/v3/tech-record/get/lgv/complete/index.json
@@ -195,10 +195,7 @@
       "type": "string"
     },
     "techRecord_vehicleSubclass": {
-      "type": "array",
-      "items": {
-        "$ref": "../../../enums/vehicleSubclass.ignore.json"
-      }
+      "$ref": "../../../enums/vehicleSubclass.ignore.json"
     },
     "techRecord_hiddenInVta": {
       "type": [

--- a/json-definitions/v3/tech-record/get/lgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/lgv/skeleton/index.json
@@ -215,10 +215,7 @@
       }
     },
     "techRecord_vehicleSubclass": {
-      "type": "array",
-      "items": {
-        "$ref": "../../../enums/vehicleSubclass.ignore.json"
-      }
+      "$ref": "../../../enums/vehicleSubclass.ignore.json"
     }
   }
 }

--- a/json-definitions/v3/tech-record/put/car/complete/index.json
+++ b/json-definitions/v3/tech-record/put/car/complete/index.json
@@ -64,10 +64,7 @@
       "type": "string"
     },
     "techRecord_vehicleSubclass": {
-      "type": "array",
-      "items": {
-        "$ref": "../../../enums/vehicleSubclass.ignore.json"
-      }
+      "$ref": "../../../enums/vehicleSubclass.ignore.json"
     },
     "techRecord_hiddenInVta": {
       "type": [

--- a/json-definitions/v3/tech-record/put/car/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/car/skeleton/index.json
@@ -87,10 +87,7 @@
       }
     },
     "techRecord_vehicleSubclass": {
-      "type": "array",
-      "items": {
-        "$ref": "../../../enums/vehicleSubclass.ignore.json"
-      }
+      "$ref": "../../../enums/vehicleSubclass.ignore.json"
     }
   }
 }

--- a/json-definitions/v3/tech-record/put/lgv/complete/index.json
+++ b/json-definitions/v3/tech-record/put/lgv/complete/index.json
@@ -117,10 +117,7 @@
       "type": "string"
     },
     "techRecord_vehicleSubclass": {
-      "type": "array",
-      "items": {
-        "$ref": "../../../enums/vehicleSubclass.ignore.json"
-      }
+      "$ref": "../../../enums/vehicleSubclass.ignore.json"
     },
     "techRecord_hiddenInVta": {
       "type": "boolean"

--- a/json-definitions/v3/tech-record/put/lgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/lgv/skeleton/index.json
@@ -137,10 +137,7 @@
       }
     },
     "techRecord_vehicleSubclass": {
-      "type": "array",
-      "items": {
-        "$ref": "../../../enums/vehicleSubclass.ignore.json"
-      }
+      "$ref": "../../../enums/vehicleSubclass.ignore.json"
     }
   }
 }

--- a/json-schemas/v3/tech-record/get/car/complete/index.json
+++ b/json-schemas/v3/tech-record/get/car/complete/index.json
@@ -237,26 +237,23 @@
 			"type": "string"
 		},
 		"techRecord_vehicleSubclass": {
+			"title": "Vehicle Subclass",
 			"type": "array",
 			"items": {
-				"title": "Vehicle Subclass",
-				"type": "array",
-				"items": {
-					"type": "string",
-					"enum": [
-						"n",
-						"p",
-						"a",
-						"s",
-						"c",
-						"l",
-						"t",
-						"e",
-						"m",
-						"r",
-						"w"
-					]
-				}
+				"type": "string",
+				"enum": [
+					"n",
+					"p",
+					"a",
+					"s",
+					"c",
+					"l",
+					"t",
+					"e",
+					"m",
+					"r",
+					"w"
+				]
 			}
 		},
 		"techRecord_hiddenInVta": {

--- a/json-schemas/v3/tech-record/get/car/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/car/skeleton/index.json
@@ -257,26 +257,23 @@
 			}
 		},
 		"techRecord_vehicleSubclass": {
+			"title": "Vehicle Subclass",
 			"type": "array",
 			"items": {
-				"title": "Vehicle Subclass",
-				"type": "array",
-				"items": {
-					"type": "string",
-					"enum": [
-						"n",
-						"p",
-						"a",
-						"s",
-						"c",
-						"l",
-						"t",
-						"e",
-						"m",
-						"r",
-						"w"
-					]
-				}
+				"type": "string",
+				"enum": [
+					"n",
+					"p",
+					"a",
+					"s",
+					"c",
+					"l",
+					"t",
+					"e",
+					"m",
+					"r",
+					"w"
+				]
 			}
 		}
 	}

--- a/json-schemas/v3/tech-record/get/lgv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/lgv/complete/index.json
@@ -237,26 +237,23 @@
 			"type": "string"
 		},
 		"techRecord_vehicleSubclass": {
+			"title": "Vehicle Subclass",
 			"type": "array",
 			"items": {
-				"title": "Vehicle Subclass",
-				"type": "array",
-				"items": {
-					"type": "string",
-					"enum": [
-						"n",
-						"p",
-						"a",
-						"s",
-						"c",
-						"l",
-						"t",
-						"e",
-						"m",
-						"r",
-						"w"
-					]
-				}
+				"type": "string",
+				"enum": [
+					"n",
+					"p",
+					"a",
+					"s",
+					"c",
+					"l",
+					"t",
+					"e",
+					"m",
+					"r",
+					"w"
+				]
 			}
 		},
 		"techRecord_hiddenInVta": {

--- a/json-schemas/v3/tech-record/get/lgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/lgv/skeleton/index.json
@@ -257,26 +257,23 @@
 			}
 		},
 		"techRecord_vehicleSubclass": {
+			"title": "Vehicle Subclass",
 			"type": "array",
 			"items": {
-				"title": "Vehicle Subclass",
-				"type": "array",
-				"items": {
-					"type": "string",
-					"enum": [
-						"n",
-						"p",
-						"a",
-						"s",
-						"c",
-						"l",
-						"t",
-						"e",
-						"m",
-						"r",
-						"w"
-					]
-				}
+				"type": "string",
+				"enum": [
+					"n",
+					"p",
+					"a",
+					"s",
+					"c",
+					"l",
+					"t",
+					"e",
+					"m",
+					"r",
+					"w"
+				]
 			}
 		}
 	}

--- a/json-schemas/v3/tech-record/put/car/complete/index.json
+++ b/json-schemas/v3/tech-record/put/car/complete/index.json
@@ -70,26 +70,23 @@
 			"type": "string"
 		},
 		"techRecord_vehicleSubclass": {
+			"title": "Vehicle Subclass",
 			"type": "array",
 			"items": {
-				"title": "Vehicle Subclass",
-				"type": "array",
-				"items": {
-					"type": "string",
-					"enum": [
-						"n",
-						"p",
-						"a",
-						"s",
-						"c",
-						"l",
-						"t",
-						"e",
-						"m",
-						"r",
-						"w"
-					]
-				}
+				"type": "string",
+				"enum": [
+					"n",
+					"p",
+					"a",
+					"s",
+					"c",
+					"l",
+					"t",
+					"e",
+					"m",
+					"r",
+					"w"
+				]
 			}
 		},
 		"techRecord_hiddenInVta": {

--- a/json-schemas/v3/tech-record/put/car/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/car/skeleton/index.json
@@ -93,26 +93,23 @@
 			}
 		},
 		"techRecord_vehicleSubclass": {
+			"title": "Vehicle Subclass",
 			"type": "array",
 			"items": {
-				"title": "Vehicle Subclass",
-				"type": "array",
-				"items": {
-					"type": "string",
-					"enum": [
-						"n",
-						"p",
-						"a",
-						"s",
-						"c",
-						"l",
-						"t",
-						"e",
-						"m",
-						"r",
-						"w"
-					]
-				}
+				"type": "string",
+				"enum": [
+					"n",
+					"p",
+					"a",
+					"s",
+					"c",
+					"l",
+					"t",
+					"e",
+					"m",
+					"r",
+					"w"
+				]
 			}
 		}
 	}

--- a/json-schemas/v3/tech-record/put/lgv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/lgv/complete/index.json
@@ -144,26 +144,23 @@
 			"type": "string"
 		},
 		"techRecord_vehicleSubclass": {
+			"title": "Vehicle Subclass",
 			"type": "array",
 			"items": {
-				"title": "Vehicle Subclass",
-				"type": "array",
-				"items": {
-					"type": "string",
-					"enum": [
-						"n",
-						"p",
-						"a",
-						"s",
-						"c",
-						"l",
-						"t",
-						"e",
-						"m",
-						"r",
-						"w"
-					]
-				}
+				"type": "string",
+				"enum": [
+					"n",
+					"p",
+					"a",
+					"s",
+					"c",
+					"l",
+					"t",
+					"e",
+					"m",
+					"r",
+					"w"
+				]
 			}
 		},
 		"techRecord_hiddenInVta": {

--- a/json-schemas/v3/tech-record/put/lgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/lgv/skeleton/index.json
@@ -164,26 +164,23 @@
 			}
 		},
 		"techRecord_vehicleSubclass": {
+			"title": "Vehicle Subclass",
 			"type": "array",
 			"items": {
-				"title": "Vehicle Subclass",
-				"type": "array",
-				"items": {
-					"type": "string",
-					"enum": [
-						"n",
-						"p",
-						"a",
-						"s",
-						"c",
-						"l",
-						"t",
-						"e",
-						"m",
-						"r",
-						"w"
-					]
-				}
+				"type": "string",
+				"enum": [
+					"n",
+					"p",
+					"a",
+					"s",
+					"c",
+					"l",
+					"t",
+					"e",
+					"m",
+					"r",
+					"w"
+				]
 			}
 		}
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.23",
+  "version": "3.0.24",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "3.0.23",
+      "version": "3.0.24",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.23",
+  "version": "3.0.24",
   "description": "type definitions for cvs vta application",
   "main": "index.js",
   "repository": {

--- a/types/v3/tech-record/get/car/complete/index.d.ts
+++ b/types/v3/tech-record/get/car/complete/index.d.ts
@@ -70,7 +70,7 @@ export interface TechRecordGETCarComplete {
   techRecord_vehicleConfiguration?: null | VehicleConfiguration;
   techRecord_vehicleType: "car";
   vin: string;
-  techRecord_vehicleSubclass: VehicleSubclass[];
+  techRecord_vehicleSubclass: VehicleSubclass;
   techRecord_hiddenInVta?: null | boolean;
   techRecord_updateType?: null | string;
   secondaryVrms?: null | string[];

--- a/types/v3/tech-record/get/car/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/car/skeleton/index.d.ts
@@ -73,5 +73,5 @@ export interface TechRecordGETCarSkeleton {
   techRecord_hiddenInVta?: null | boolean;
   techRecord_updateType?: null | string;
   secondaryVrms?: null | string[];
-  techRecord_vehicleSubclass?: VehicleSubclass[];
+  techRecord_vehicleSubclass?: VehicleSubclass;
 }

--- a/types/v3/tech-record/get/lgv/complete/index.d.ts
+++ b/types/v3/tech-record/get/lgv/complete/index.d.ts
@@ -70,7 +70,7 @@ export interface TechRecordGETLGVComplete {
   techRecord_vehicleConfiguration?: null | VehicleConfiguration;
   techRecord_vehicleType: "lgv";
   vin: string;
-  techRecord_vehicleSubclass: VehicleSubclass[];
+  techRecord_vehicleSubclass: VehicleSubclass;
   techRecord_hiddenInVta?: null | boolean;
   techRecord_updateType?: null | string;
   secondaryVrms?: null | string[];

--- a/types/v3/tech-record/get/lgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/lgv/skeleton/index.d.ts
@@ -73,5 +73,5 @@ export interface TechRecordGETLGVSkeleton {
   techRecord_hiddenInVta?: null | boolean;
   techRecord_updateType?: null | string;
   secondaryVrms?: null | string[];
-  techRecord_vehicleSubclass?: VehicleSubclass[];
+  techRecord_vehicleSubclass?: VehicleSubclass;
 }

--- a/types/v3/tech-record/put/car/complete/index.d.ts
+++ b/types/v3/tech-record/put/car/complete/index.d.ts
@@ -19,7 +19,7 @@ export interface TechRecordPUTCarComplete {
   techRecord_manufactureYear?: number | null;
   techRecord_noOfAxles?: number | null;
   techRecord_notes?: string;
-  techRecord_vehicleSubclass: VehicleSubclass[];
+  techRecord_vehicleSubclass: VehicleSubclass;
   techRecord_hiddenInVta?: null | boolean;
   techRecord_updateType?: null | string;
   secondaryVrms?: null | string[];

--- a/types/v3/tech-record/put/car/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/car/skeleton/index.d.ts
@@ -22,5 +22,5 @@ export interface TechRecordPUTCarSkeleton {
   techRecord_hiddenInVta?: null | boolean;
   techRecord_updateType?: null | string;
   secondaryVrms?: null | string[];
-  techRecord_vehicleSubclass?: VehicleSubclass[];
+  techRecord_vehicleSubclass?: VehicleSubclass;
 }

--- a/types/v3/tech-record/put/lgv/complete/index.d.ts
+++ b/types/v3/tech-record/put/lgv/complete/index.d.ts
@@ -47,7 +47,7 @@ export interface TechRecordPUTLGVComplete {
   techRecord_manufactureYear?: number | null;
   techRecord_noOfAxles?: number | null;
   techRecord_notes?: string;
-  techRecord_vehicleSubclass: VehicleSubclass[];
+  techRecord_vehicleSubclass: VehicleSubclass;
   techRecord_hiddenInVta?: boolean;
   techRecord_updateType?: string;
   secondaryVrms?: string[];

--- a/types/v3/tech-record/put/lgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/lgv/skeleton/index.d.ts
@@ -53,5 +53,5 @@ export interface TechRecordPUTLGVSkeleton {
   techRecord_createdById?: string;
   techRecord_createdByName?: string;
   secondaryVrms?: string[];
-  techRecord_vehicleSubclass?: VehicleSubclass[];
+  techRecord_vehicleSubclass?: VehicleSubclass;
 }


### PR DESCRIPTION
## Ticket title

- Vehicle subclass is an array in the enum. The change in https://github.com/dvsa/cvs-type-definitions/pull/84 made in an array of arrays. This can be seen in the full json-schemas or the typescript types.


<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

- Fix vehicle subclass

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
