### PR TITLE
patch(cb2-8806): removing vehicle class code from PUT schemas

### DIFF
--- a/json-definitions/v3/tech-record/put/hgv/complete/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/complete/index.json
@@ -8,7 +8,6 @@
     "techRecord_vehicleType",
     "vin",
     "techRecord_vehicleConfiguration",
-    "techRecord_vehicleClass_code",
     "techRecord_vehicleClass_description",
     "techRecord_approvalType",
     "techRecord_manufactureYear",
@@ -803,9 +802,6 @@
     "techRecord_tyreUseCode": {
       "type": "string",
       "maxLength": 2
-    },
-    "techRecord_vehicleClass_code": {
-      "type": "string"
     },
     "techRecord_vehicleClass_description": {
       "$ref": "../../../enums/vehicleClassDescription.ignore.json"

--- a/json-definitions/v3/tech-record/put/hgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/skeleton/index.json
@@ -871,12 +871,6 @@
       ],
       "maxLength": 2
     },
-    "techRecord_vehicleClass_code": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
     "techRecord_vehicleClass_description": {
       "anyOf": [
         {

--- a/json-definitions/v3/tech-record/put/hgv/testable/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/testable/index.json
@@ -8,7 +8,6 @@
     "techRecord_vehicleType",
     "vin",
     "techRecord_vehicleConfiguration",
-    "techRecord_vehicleClass_code",
     "techRecord_vehicleClass_description"
   ],
   "properties": {
@@ -861,9 +860,6 @@
         "null"
       ],
       "maxLength": 2
-    },
-    "techRecord_vehicleClass_code": {
-      "type": "string"
     },
     "techRecord_vehicleClass_description": {
       "$ref": "../../../enums/vehicleClassDescription.ignore.json"

--- a/json-definitions/v3/tech-record/put/motorcycle/complete/index.json
+++ b/json-definitions/v3/tech-record/put/motorcycle/complete/index.json
@@ -5,7 +5,6 @@
   "required": [
     "techRecord_numberOfWheelsDriven",
     "techRecord_vehicleClass_description",
-    "techRecord_vehicleClass_code",
     "techRecord_reasonForCreation",
     "vin"
   ],
@@ -148,9 +147,6 @@
     },
     "techRecord_vehicleClass_description": {
       "$ref": "../../../enums/vehicleClassDescription.ignore.json"
-    },
-    "techRecord_vehicleClass_code": {
-      "type": "string"
     },
     "techRecord_vehicleConfiguration": {
       "anyOf": [

--- a/json-definitions/v3/tech-record/put/motorcycle/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/motorcycle/skeleton/index.json
@@ -4,7 +4,6 @@
   "additionalProperties": false,
   "required": [
     "techRecord_vehicleClass_description",
-    "techRecord_vehicleClass_code",
     "techRecord_reasonForCreation",
     "vin"
   ],
@@ -138,9 +137,6 @@
     },
     "techRecord_vehicleClass_description": {
       "$ref": "../../../enums/vehicleClassDescription.ignore.json"
-    },
-    "techRecord_vehicleClass_code": {
-      "type": "string"
     },
     "techRecord_vehicleConfiguration": {
       "anyOf": [

--- a/json-definitions/v3/tech-record/put/psv/complete/index.json
+++ b/json-definitions/v3/tech-record/put/psv/complete/index.json
@@ -97,12 +97,6 @@
         "null"
       ]
     },
-    "techRecord_vehicleClass_code": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
     "techRecord_vehicleClass_description": {
       "$ref": "../../../enums/vehicleClassDescription.ignore.json"
     },

--- a/json-definitions/v3/tech-record/put/psv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/psv/skeleton/index.json
@@ -89,12 +89,6 @@
         "null"
       ]
     },
-    "techRecord_vehicleClass_code": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
     "techRecord_vehicleClass_description": {
       "$ref": "../../../enums/vehicleClassDescription.ignore.json"
     },

--- a/json-definitions/v3/tech-record/put/psv/testable/index.json
+++ b/json-definitions/v3/tech-record/put/psv/testable/index.json
@@ -70,12 +70,6 @@
         "null"
       ]
     },
-    "techRecord_vehicleClass_code": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
     "techRecord_vehicleClass_description": {
       "$ref": "../../../enums/vehicleClassDescription.ignore.json"
     },

--- a/json-definitions/v3/tech-record/put/small trl/complete/index.json
+++ b/json-definitions/v3/tech-record/put/small trl/complete/index.json
@@ -5,7 +5,6 @@
     "required": [
         "vin",
         "techRecord_statusCode",
-        "techRecord_vehicleClass_code",
         "techRecord_vehicleClass_description",
         "techRecord_vehicleType",
         "techRecord_euVehicleCategory",
@@ -93,9 +92,6 @@
         },
         "techRecord_statusCode": {
             "$ref": "../../../enums/statusCode.ignore.json"
-        },
-        "techRecord_vehicleClass_code": {
-            "type": "string"
         },
         "techRecord_vehicleClass_description": {
             "$ref": "../../../enums/vehicleClassDescription.ignore.json"

--- a/json-definitions/v3/tech-record/put/small trl/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/small trl/skeleton/index.json
@@ -5,7 +5,6 @@
     "required": [
         "vin",
         "techRecord_statusCode",
-        "techRecord_vehicleClass_code",
         "techRecord_vehicleClass_description",
         "techRecord_vehicleType",
         "techRecord_euVehicleCategory",
@@ -91,9 +90,6 @@
         },
         "techRecord_statusCode": {
             "$ref": "../../../enums/statusCode.ignore.json"
-        },
-        "techRecord_vehicleClass_code": {
-            "type": "string"
         },
         "techRecord_vehicleClass_description": {
             "$ref": "../../../enums/vehicleClassDescription.ignore.json"

--- a/json-definitions/v3/tech-record/put/trl/complete/index.json
+++ b/json-definitions/v3/tech-record/put/trl/complete/index.json
@@ -23,7 +23,6 @@
     "techRecord_roadFriendly",
     "techRecord_reasonForCreation",
     "techRecord_statusCode",
-    "techRecord_vehicleClass_code",
     "techRecord_vehicleClass_description",
     "techRecord_vehicleType",
     "techRecord_bodyType_description",
@@ -1018,9 +1017,6 @@
         "null",
         "string"
       ]
-    },
-    "techRecord_vehicleClass_code": {
-      "type": "string"
     },
     "techRecord_vehicleClass_description": {
       "$ref": "../../../enums/vehicleClassDescription.ignore.json"

--- a/json-definitions/v3/tech-record/put/trl/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/trl/skeleton/index.json
@@ -5,7 +5,6 @@
   "required": [
     "techRecord_reasonForCreation",
     "techRecord_statusCode",
-    "techRecord_vehicleClass_code",
     "techRecord_vehicleClass_description",
     "techRecord_vehicleConfiguration",
     "techRecord_vehicleType",
@@ -841,9 +840,6 @@
         "null"
       ],
       "maxLength": 2
-    },
-    "techRecord_vehicleClass_code": {
-      "type": "string"
     },
     "techRecord_vehicleClass_description": {
       "$ref": "../../../enums/vehicleClassDescription.ignore.json"

--- a/json-definitions/v3/tech-record/put/trl/testable/index.json
+++ b/json-definitions/v3/tech-record/put/trl/testable/index.json
@@ -6,7 +6,6 @@
     "techRecord_noOfAxles",
     "techRecord_reasonForCreation",
     "techRecord_statusCode",
-    "techRecord_vehicleClass_code",
     "techRecord_vehicleClass_description",
     "techRecord_vehicleType",
     "techRecord_bodyType_description",
@@ -928,9 +927,6 @@
         "null"
       ],
       "maxLength": 2
-    },
-    "techRecord_vehicleClass_code": {
-      "type": "string"
     },
     "techRecord_vehicleClass_description": {
       "$ref": "../../../enums/vehicleClassDescription.ignore.json"

--- a/json-schemas/v3/tech-record/put/hgv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/complete/index.json
@@ -8,7 +8,6 @@
 		"techRecord_vehicleType",
 		"vin",
 		"techRecord_vehicleConfiguration",
-		"techRecord_vehicleClass_code",
 		"techRecord_vehicleClass_description",
 		"techRecord_approvalType",
 		"techRecord_manufactureYear",
@@ -924,9 +923,6 @@
 		"techRecord_tyreUseCode": {
 			"type": "string",
 			"maxLength": 2
-		},
-		"techRecord_vehicleClass_code": {
-			"type": "string"
 		},
 		"techRecord_vehicleClass_description": {
 			"title": "Vehicle Class Description",

--- a/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
@@ -992,12 +992,6 @@
 			],
 			"maxLength": 2
 		},
-		"techRecord_vehicleClass_code": {
-			"type": [
-				"null",
-				"string"
-			]
-		},
 		"techRecord_vehicleClass_description": {
 			"anyOf": [
 				{

--- a/json-schemas/v3/tech-record/put/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/testable/index.json
@@ -8,7 +8,6 @@
 		"techRecord_vehicleType",
 		"vin",
 		"techRecord_vehicleConfiguration",
-		"techRecord_vehicleClass_code",
 		"techRecord_vehicleClass_description"
 	],
 	"properties": {
@@ -982,9 +981,6 @@
 				"null"
 			],
 			"maxLength": 2
-		},
-		"techRecord_vehicleClass_code": {
-			"type": "string"
 		},
 		"techRecord_vehicleClass_description": {
 			"title": "Vehicle Class Description",

--- a/json-schemas/v3/tech-record/put/motorcycle/complete/index.json
+++ b/json-schemas/v3/tech-record/put/motorcycle/complete/index.json
@@ -5,7 +5,6 @@
 	"required": [
 		"techRecord_numberOfWheelsDriven",
 		"techRecord_vehicleClass_description",
-		"techRecord_vehicleClass_code",
 		"techRecord_reasonForCreation",
 		"vin"
 	],
@@ -189,9 +188,6 @@
 				"MOT class 7",
 				"MOT class 5"
 			]
-		},
-		"techRecord_vehicleClass_code": {
-			"type": "string"
 		},
 		"techRecord_vehicleConfiguration": {
 			"anyOf": [

--- a/json-schemas/v3/tech-record/put/motorcycle/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/motorcycle/skeleton/index.json
@@ -4,7 +4,6 @@
 	"additionalProperties": false,
 	"required": [
 		"techRecord_vehicleClass_description",
-		"techRecord_vehicleClass_code",
 		"techRecord_reasonForCreation",
 		"vin"
 	],
@@ -179,9 +178,6 @@
 				"MOT class 7",
 				"MOT class 5"
 			]
-		},
-		"techRecord_vehicleClass_code": {
-			"type": "string"
 		},
 		"techRecord_vehicleConfiguration": {
 			"anyOf": [

--- a/json-schemas/v3/tech-record/put/psv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/psv/complete/index.json
@@ -123,12 +123,6 @@
 				"null"
 			]
 		},
-		"techRecord_vehicleClass_code": {
-			"type": [
-				"null",
-				"string"
-			]
-		},
 		"techRecord_vehicleClass_description": {
 			"title": "Vehicle Class Description",
 			"type": "string",

--- a/json-schemas/v3/tech-record/put/psv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/psv/skeleton/index.json
@@ -115,12 +115,6 @@
 				"null"
 			]
 		},
-		"techRecord_vehicleClass_code": {
-			"type": [
-				"null",
-				"string"
-			]
-		},
 		"techRecord_vehicleClass_description": {
 			"title": "Vehicle Class Description",
 			"type": "string",

--- a/json-schemas/v3/tech-record/put/psv/testable/index.json
+++ b/json-schemas/v3/tech-record/put/psv/testable/index.json
@@ -96,12 +96,6 @@
 				"null"
 			]
 		},
-		"techRecord_vehicleClass_code": {
-			"type": [
-				"null",
-				"string"
-			]
-		},
 		"techRecord_vehicleClass_description": {
 			"title": "Vehicle Class Description",
 			"type": "string",

--- a/json-schemas/v3/tech-record/put/small trl/complete/index.json
+++ b/json-schemas/v3/tech-record/put/small trl/complete/index.json
@@ -5,7 +5,6 @@
 	"required": [
 		"vin",
 		"techRecord_statusCode",
-		"techRecord_vehicleClass_code",
 		"techRecord_vehicleClass_description",
 		"techRecord_vehicleType",
 		"techRecord_euVehicleCategory",
@@ -99,9 +98,6 @@
 				"current",
 				"archived"
 			]
-		},
-		"techRecord_vehicleClass_code": {
-			"type": "string"
 		},
 		"techRecord_vehicleClass_description": {
 			"title": "Vehicle Class Description",

--- a/json-schemas/v3/tech-record/put/small trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/small trl/skeleton/index.json
@@ -5,7 +5,6 @@
 	"required": [
 		"vin",
 		"techRecord_statusCode",
-		"techRecord_vehicleClass_code",
 		"techRecord_vehicleClass_description",
 		"techRecord_vehicleType",
 		"techRecord_euVehicleCategory",
@@ -97,9 +96,6 @@
 				"current",
 				"archived"
 			]
-		},
-		"techRecord_vehicleClass_code": {
-			"type": "string"
 		},
 		"techRecord_vehicleClass_description": {
 			"title": "Vehicle Class Description",

--- a/json-schemas/v3/tech-record/put/trl/complete/index.json
+++ b/json-schemas/v3/tech-record/put/trl/complete/index.json
@@ -23,7 +23,6 @@
 		"techRecord_roadFriendly",
 		"techRecord_reasonForCreation",
 		"techRecord_statusCode",
-		"techRecord_vehicleClass_code",
 		"techRecord_vehicleClass_description",
 		"techRecord_vehicleType",
 		"techRecord_bodyType_description",
@@ -1188,9 +1187,6 @@
 				"null",
 				"string"
 			]
-		},
-		"techRecord_vehicleClass_code": {
-			"type": "string"
 		},
 		"techRecord_vehicleClass_description": {
 			"title": "Vehicle Class Description",

--- a/json-schemas/v3/tech-record/put/trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/trl/skeleton/index.json
@@ -5,7 +5,6 @@
 	"required": [
 		"techRecord_reasonForCreation",
 		"techRecord_statusCode",
-		"techRecord_vehicleClass_code",
 		"techRecord_vehicleClass_description",
 		"techRecord_vehicleConfiguration",
 		"techRecord_vehicleType",
@@ -987,9 +986,6 @@
 				"null"
 			],
 			"maxLength": 2
-		},
-		"techRecord_vehicleClass_code": {
-			"type": "string"
 		},
 		"techRecord_vehicleClass_description": {
 			"title": "Vehicle Class Description",

--- a/json-schemas/v3/tech-record/put/trl/testable/index.json
+++ b/json-schemas/v3/tech-record/put/trl/testable/index.json
@@ -6,7 +6,6 @@
 		"techRecord_noOfAxles",
 		"techRecord_reasonForCreation",
 		"techRecord_statusCode",
-		"techRecord_vehicleClass_code",
 		"techRecord_vehicleClass_description",
 		"techRecord_vehicleType",
 		"techRecord_bodyType_description",
@@ -1074,9 +1073,6 @@
 				"null"
 			],
 			"maxLength": 2
-		},
-		"techRecord_vehicleClass_code": {
-			"type": "string"
 		},
 		"techRecord_vehicleClass_description": {
 			"title": "Vehicle Class Description",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.27",
+  "version": "3.0.28",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "3.0.27",
+      "version": "3.0.28",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.27",
+  "version": "3.0.28",
   "description": "type definitions for cvs vta application",
   "main": "index.js",
   "repository": {

--- a/types/v3/tech-record/put/hgv/complete/index.d.ts
+++ b/types/v3/tech-record/put/hgv/complete/index.d.ts
@@ -246,7 +246,6 @@ export interface TechRecordPUTHGVComplete {
   techRecord_trainEecWeight?: number | null;
   techRecord_trainGbWeight: number;
   techRecord_tyreUseCode: string;
-  techRecord_vehicleClass_code: string;
   techRecord_vehicleClass_description: VehicleClassDescription;
   techRecord_vehicleConfiguration: VehicleConfiguration;
   techRecord_approvalType: ApprovalType;

--- a/types/v3/tech-record/put/hgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/hgv/skeleton/index.d.ts
@@ -243,7 +243,6 @@ export interface TechRecordPUTHGVSkeleton {
   techRecord_trainEecWeight?: number | null;
   techRecord_trainGbWeight?: number | null;
   techRecord_tyreUseCode?: string | null;
-  techRecord_vehicleClass_code?: null | string;
   techRecord_vehicleClass_description?: null | VehicleClassDescription;
   techRecord_vehicleConfiguration?: VehicleConfiguration | null;
   techRecord_approvalType?: ApprovalType | null;

--- a/types/v3/tech-record/put/hgv/testable/index.d.ts
+++ b/types/v3/tech-record/put/hgv/testable/index.d.ts
@@ -243,7 +243,6 @@ export interface TechRecordPUTHGVTestable {
   techRecord_trainEecWeight?: number | null;
   techRecord_trainGbWeight?: number | null;
   techRecord_tyreUseCode?: string | null;
-  techRecord_vehicleClass_code: string;
   techRecord_vehicleClass_description: VehicleClassDescription;
   techRecord_vehicleConfiguration: VehicleConfiguration;
   techRecord_approvalType?: ApprovalType | null;

--- a/types/v3/tech-record/put/motorcycle/complete/index.d.ts
+++ b/types/v3/tech-record/put/motorcycle/complete/index.d.ts
@@ -73,7 +73,6 @@ export interface TechRecordPUTMotorcycleComplete {
   techRecord_regnDate?: string | null;
   techRecord_statusCode?: null | StatusCode;
   techRecord_vehicleClass_description: VehicleClassDescription;
-  techRecord_vehicleClass_code: string;
   techRecord_vehicleConfiguration?: null | VehicleConfiguration;
   techRecord_vehicleType?: "motorcycle";
   vin: string;

--- a/types/v3/tech-record/put/motorcycle/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/motorcycle/skeleton/index.d.ts
@@ -72,7 +72,6 @@ export interface TechRecordPUTMotorcycleSkeleton {
   techRecord_regnDate?: string | null;
   techRecord_statusCode?: null | StatusCode;
   techRecord_vehicleClass_description: VehicleClassDescription;
-  techRecord_vehicleClass_code: string;
   techRecord_vehicleConfiguration?: null | VehicleConfiguration;
   techRecord_vehicleType?: "motorcycle";
   vin: string;

--- a/types/v3/tech-record/put/psv/complete/index.d.ts
+++ b/types/v3/tech-record/put/psv/complete/index.d.ts
@@ -197,7 +197,6 @@ export interface TechRecordPUTPSVComplete {
   techRecord_seatsLowerDeck: number;
   techRecord_seatsUpperDeck: number;
   techRecord_numberOfWheelsDriven: number | null;
-  techRecord_vehicleClass_code?: null | string;
   techRecord_vehicleClass_description: VehicleClassDescription;
   techRecord_hiddenInVta?: null | boolean;
   techRecord_recordCompleteness?: null | string;

--- a/types/v3/tech-record/put/psv/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/psv/skeleton/index.d.ts
@@ -197,7 +197,6 @@ export interface TechRecordPUTPSVSkeleton {
   techRecord_seatsLowerDeck?: number | null;
   techRecord_seatsUpperDeck?: number | null;
   techRecord_numberOfWheelsDriven?: number | null;
-  techRecord_vehicleClass_code?: null | string;
   techRecord_vehicleClass_description: VehicleClassDescription;
   techRecord_hiddenInVta?: null | boolean;
   techRecord_recordCompleteness?: null | string;

--- a/types/v3/tech-record/put/psv/testable/index.d.ts
+++ b/types/v3/tech-record/put/psv/testable/index.d.ts
@@ -197,7 +197,6 @@ export interface TechRecordPUTPSVTestable {
   techRecord_seatsLowerDeck: number;
   techRecord_seatsUpperDeck: number;
   techRecord_numberOfWheelsDriven: number | null;
-  techRecord_vehicleClass_code?: null | string;
   techRecord_vehicleClass_description: VehicleClassDescription;
   techRecord_hiddenInVta?: null | boolean;
   techRecord_recordCompleteness?: null | string;

--- a/types/v3/tech-record/put/small trl/complete/index.d.ts
+++ b/types/v3/tech-record/put/small trl/complete/index.d.ts
@@ -48,7 +48,6 @@ export interface TechRecordPUTSmallTRLComplete {
   techRecord_notes?: string | null;
   techRecord_reasonForCreation: string;
   techRecord_statusCode: StatusCode;
-  techRecord_vehicleClass_code: string;
   techRecord_vehicleClass_description: VehicleClassDescription;
   techRecord_vehicleConfiguration: VehicleConfiguration;
   techRecord_vehicleSubclass?: VehicleSubclass;

--- a/types/v3/tech-record/put/small trl/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/small trl/skeleton/index.d.ts
@@ -48,7 +48,6 @@ export interface TechRecordPUTSmallTRLSkeleton {
   techRecord_notes?: string | null;
   techRecord_reasonForCreation: string;
   techRecord_statusCode: StatusCode;
-  techRecord_vehicleClass_code: string;
   techRecord_vehicleClass_description: VehicleClassDescription;
   techRecord_vehicleConfiguration?: null | VehicleConfiguration;
   techRecord_vehicleSubclass?: VehicleSubclass;

--- a/types/v3/tech-record/put/trl/complete/index.d.ts
+++ b/types/v3/tech-record/put/trl/complete/index.d.ts
@@ -319,7 +319,6 @@ export interface TechRecordPUTTRLComplete {
   techRecord_tyreUseCode: string | null;
   techRecord_variantNumber?: null | string;
   techRecord_variantVersionNumber?: null | string;
-  techRecord_vehicleClass_code: string;
   techRecord_vehicleClass_description: VehicleClassDescription;
   techRecord_vehicleConfiguration: VehicleConfiguration | null;
   techRecord_vehicleType: "trl";

--- a/types/v3/tech-record/put/trl/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/trl/skeleton/index.d.ts
@@ -273,7 +273,6 @@ export interface TechRecordPUTTRLSkeleton {
   techRecord_statusCode: StatusCode;
   techRecord_suspensionType?: string | null;
   techRecord_tyreUseCode?: string | null;
-  techRecord_vehicleClass_code: string;
   techRecord_vehicleClass_description: VehicleClassDescription;
   techRecord_vehicleConfiguration: VehicleConfiguration | null;
   techRecord_vehicleType: "trl";

--- a/types/v3/tech-record/put/trl/testable/index.d.ts
+++ b/types/v3/tech-record/put/trl/testable/index.d.ts
@@ -285,7 +285,6 @@ export interface TechRecordPUTTRLTestable {
   techRecord_suspensionType?: string | null;
   techRecord_dimensions_axleSpacing?: AxleSpacing[];
   techRecord_tyreUseCode?: string | null;
-  techRecord_vehicleClass_code: string;
   techRecord_vehicleClass_description: VehicleClassDescription;
   techRecord_vehicleConfiguration: VehicleConfiguration | null;
   techRecord_vehicleType: "trl";


### PR DESCRIPTION
## Update the PUT schemas

removing vehicle class code from PUT schemas, these will be calculated in the v3 backend

[CB2-8806](https://dvsa.atlassian.net/browse/CB2-8806)

<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

- vehicle class code removed from PUT schemas

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
