### PR TITLE
patch(*): remove drawbar and fifth wheel fields from trl

### DIFF
--- a/json-definitions/v3/tech-record/put/trl/complete/index.json
+++ b/json-definitions/v3/tech-record/put/trl/complete/index.json
@@ -525,12 +525,6 @@
       "maximum": 99999,
       "minimum": 0
     },
-    "techRecord_drawbarCouplingFitted": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
     "techRecord_emissionsLimit": {
       "type": [
         "null",
@@ -587,18 +581,6 @@
       ],
       "maximum": 99999,
       "minimum": 0
-    },
-    "techRecord_frontVehicleTo5thWheelCouplingMax": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "techRecord_frontVehicleTo5thWheelCouplingMin": {
-      "type": [
-        "string",
-        "null"
-      ]
     },
     "techRecord_fuelPropulsionSystem": {
       "$ref": "../../../enums/fuelPropulsionSystem.ignore.json"

--- a/json-schemas/v3/tech-record/put/trl/complete/index.json
+++ b/json-schemas/v3/tech-record/put/trl/complete/index.json
@@ -552,12 +552,6 @@
 			"maximum": 99999,
 			"minimum": 0
 		},
-		"techRecord_drawbarCouplingFitted": {
-			"type": [
-				"null",
-				"string"
-			]
-		},
 		"techRecord_emissionsLimit": {
 			"type": [
 				"null",
@@ -659,18 +653,6 @@
 			],
 			"maximum": 99999,
 			"minimum": 0
-		},
-		"techRecord_frontVehicleTo5thWheelCouplingMax": {
-			"type": [
-				"string",
-				"null"
-			]
-		},
-		"techRecord_frontVehicleTo5thWheelCouplingMin": {
-			"type": [
-				"string",
-				"null"
-			]
 		},
 		"techRecord_fuelPropulsionSystem": {
 			"title": "Fuel Propulsion System",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.35",
+  "version": "3.0.36",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "3.0.35",
+      "version": "3.0.36",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.35",
+  "version": "3.0.36",
   "description": "type definitions for cvs vta application",
   "main": "index.js",
   "repository": {

--- a/types/v3/tech-record/put/trl/complete/index.d.ts
+++ b/types/v3/tech-record/put/trl/complete/index.d.ts
@@ -251,7 +251,6 @@ export interface TechRecordPUTTRLComplete {
   techRecord_departmentalVehicleMarker?: boolean | null;
   techRecord_dimensions_length: number | null;
   techRecord_dimensions_width: number | null;
-  techRecord_drawbarCouplingFitted?: null | string;
   techRecord_emissionsLimit?: null | number;
   techRecord_euVehicleCategory: EUVehicleCategory;
   techRecord_euroStandard?: null | EuroStandard;
@@ -260,8 +259,6 @@ export interface TechRecordPUTTRLComplete {
   techRecord_firstUseDate: string | null;
   techRecord_frameDescription?: FrameDescription | null;
   techRecord_frontAxleToRearAxle: number | null;
-  techRecord_frontVehicleTo5thWheelCouplingMax?: string | null;
-  techRecord_frontVehicleTo5thWheelCouplingMin?: string | null;
   techRecord_fuelPropulsionSystem?: FuelPropulsionSystem;
   techRecord_functionCode?: string | null;
   techRecord_grossDesignWeight?: number | null;


### PR DESCRIPTION
## Ticket title

so those two fields I added before don't belong on a trailer

<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

- Remove drawbar and fifth wheel fields from trl

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
