### PR TITLE
patch(cb2-8806): add hidden in vta to small trls

### DIFF
--- a/json-definitions/v3/tech-record/get/small trl/complete/index.json
+++ b/json-definitions/v3/tech-record/get/small trl/complete/index.json
@@ -108,10 +108,9 @@
             ]
         },
         "techRecord_noOfAxles": {
-            "type": [
-                "integer",
-                "null"
-            ]
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 99
         },
         "techRecord_notes": {
             "type": [
@@ -152,6 +151,12 @@
         },
         "createdTimestamp": {
             "type": "string"
+        },
+        "techRecord_hiddenInVta": {
+            "type": [
+                "null",
+                "boolean"
+            ]
         }
     }
 }

--- a/json-definitions/v3/tech-record/get/small trl/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/small trl/skeleton/index.json
@@ -109,7 +109,9 @@
             "type": [
                 "integer",
                 "null"
-            ]
+            ],
+            "minimum": 0,
+            "maximum": 99
         },
         "techRecord_notes": {
             "type": [
@@ -160,6 +162,12 @@
         },
         "techRecord_recordCompleteness": {
             "const": "skeleton"
+        },
+        "techRecord_hiddenInVta": {
+            "type": [
+                "null",
+                "boolean"
+            ]
         }
     }
 }

--- a/json-definitions/v3/tech-record/put/small trl/complete/index.json
+++ b/json-definitions/v3/tech-record/put/small trl/complete/index.json
@@ -75,10 +75,9 @@
             ]
         },
         "techRecord_noOfAxles": {
-            "type": [
-                "integer",
-                "null"
-            ]
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 99
         },
         "techRecord_notes": {
             "type": [
@@ -110,6 +109,12 @@
         },
         "trailerId": {
             "type": "string"
+        },
+        "techRecord_hiddenInVta": {
+            "type": [
+                "null",
+                "boolean"
+            ]
         }
     }
 }

--- a/json-definitions/v3/tech-record/put/small trl/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/small trl/skeleton/index.json
@@ -73,9 +73,15 @@
             ]
         },
         "techRecord_noOfAxles": {
-            "type": [
-                "integer",
-                "null"
+            "anyOf": [
+                {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 99
+                },
+                {
+                    "type": "null"
+                }
             ]
         },
         "techRecord_notes": {
@@ -115,6 +121,12 @@
         },
         "trailerId": {
             "type": "string"
+        },
+        "techRecord_hiddenInVta": {
+            "type": [
+                "null",
+                "boolean"
+            ]
         }
     }
 }

--- a/json-schemas/v3/tech-record/get/small trl/complete/index.json
+++ b/json-schemas/v3/tech-record/get/small trl/complete/index.json
@@ -108,10 +108,9 @@
 			]
 		},
 		"techRecord_noOfAxles": {
-			"type": [
-				"integer",
-				"null"
-			]
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 99
 		},
 		"techRecord_notes": {
 			"type": [
@@ -204,6 +203,12 @@
 		},
 		"createdTimestamp": {
 			"type": "string"
+		},
+		"techRecord_hiddenInVta": {
+			"type": [
+				"null",
+				"boolean"
+			]
 		}
 	}
 }

--- a/json-schemas/v3/tech-record/get/small trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/small trl/skeleton/index.json
@@ -109,7 +109,9 @@
 			"type": [
 				"integer",
 				"null"
-			]
+			],
+			"minimum": 0,
+			"maximum": 99
 		},
 		"techRecord_notes": {
 			"type": [
@@ -212,6 +214,12 @@
 		},
 		"techRecord_recordCompleteness": {
 			"const": "skeleton"
+		},
+		"techRecord_hiddenInVta": {
+			"type": [
+				"null",
+				"boolean"
+			]
 		}
 	}
 }

--- a/json-schemas/v3/tech-record/put/small trl/complete/index.json
+++ b/json-schemas/v3/tech-record/put/small trl/complete/index.json
@@ -75,10 +75,9 @@
 			]
 		},
 		"techRecord_noOfAxles": {
-			"type": [
-				"integer",
-				"null"
-			]
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 99
 		},
 		"techRecord_notes": {
 			"type": [
@@ -162,6 +161,12 @@
 		},
 		"trailerId": {
 			"type": "string"
+		},
+		"techRecord_hiddenInVta": {
+			"type": [
+				"null",
+				"boolean"
+			]
 		}
 	}
 }

--- a/json-schemas/v3/tech-record/put/small trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/small trl/skeleton/index.json
@@ -73,9 +73,15 @@
 			]
 		},
 		"techRecord_noOfAxles": {
-			"type": [
-				"integer",
-				"null"
+			"anyOf": [
+				{
+					"type": "integer",
+					"minimum": 0,
+					"maximum": 99
+				},
+				{
+					"type": "null"
+				}
 			]
 		},
 		"techRecord_notes": {
@@ -167,6 +173,12 @@
 		},
 		"trailerId": {
 			"type": "string"
+		},
+		"techRecord_hiddenInVta": {
+			"type": [
+				"null",
+				"boolean"
+			]
 		}
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.38",
+  "version": "3.0.39",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "3.0.38",
+      "version": "3.0.39",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.38",
+  "version": "3.0.39",
   "description": "type definitions for cvs vta application",
   "main": "index.js",
   "repository": {

--- a/types/v3/tech-record/get/small trl/complete/index.d.ts
+++ b/types/v3/tech-record/get/small trl/complete/index.d.ts
@@ -50,7 +50,7 @@ export interface TechRecordGETSmallTRLComplete {
   techRecord_lastUpdatedById?: string | null;
   techRecord_lastUpdatedByName?: string | null;
   techRecord_manufactureYear?: number | null;
-  techRecord_noOfAxles: number | null;
+  techRecord_noOfAxles: number;
   techRecord_notes?: string | null;
   techRecord_reasonForCreation: string;
   techRecord_statusCode: StatusCode;
@@ -63,4 +63,5 @@ export interface TechRecordGETSmallTRLComplete {
   trailerId?: string;
   systemNumber: string;
   createdTimestamp: string;
+  techRecord_hiddenInVta?: null | boolean;
 }

--- a/types/v3/tech-record/get/small trl/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/small trl/skeleton/index.d.ts
@@ -64,4 +64,5 @@ export interface TechRecordGETSmallTRLSkeleton {
   systemNumber: string;
   createdTimestamp: string;
   techRecord_recordCompleteness?: "skeleton";
+  techRecord_hiddenInVta?: null | boolean;
 }

--- a/types/v3/tech-record/put/small trl/complete/index.d.ts
+++ b/types/v3/tech-record/put/small trl/complete/index.d.ts
@@ -44,7 +44,7 @@ export interface TechRecordPUTSmallTRLComplete {
   techRecord_applicantDetails_telephoneNumber?: string | null;
   techRecord_euVehicleCategory: "o1" | "o2";
   techRecord_manufactureYear?: number | null;
-  techRecord_noOfAxles: number | null;
+  techRecord_noOfAxles: number;
   techRecord_notes?: string | null;
   techRecord_reasonForCreation: string;
   techRecord_statusCode: StatusCode;
@@ -54,4 +54,5 @@ export interface TechRecordPUTSmallTRLComplete {
   techRecord_vehicleType: "trl";
   vin: string;
   trailerId?: string;
+  techRecord_hiddenInVta?: null | boolean;
 }

--- a/types/v3/tech-record/put/small trl/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/small trl/skeleton/index.d.ts
@@ -54,4 +54,5 @@ export interface TechRecordPUTSmallTRLSkeleton {
   techRecord_vehicleType: "trl";
   vin: string;
   trailerId?: string;
+  techRecord_hiddenInVta?: null | boolean;
 }


### PR DESCRIPTION
## Ticket title

Add hidden in vta to small trls

[CB2-8806](https://dvsa.atlassian.net/browse/CB2-8806)

<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

- Add hidden in VTA to small trls
- Update validation on number of axles

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
