### PR TITLE
patch(cb2-8666): techRecord_dda_certificateIssued allows null

### DIFF
--- a/json-definitions/v3/tech-record/get/psv/complete/index.json
+++ b/json-definitions/v3/tech-record/get/psv/complete/index.json
@@ -278,7 +278,10 @@
       "type": "null"
     },
     "techRecord_dda_certificateIssued": {
-      "type": "boolean"
+      "type": [
+        "boolean",
+        "null"
+      ]
     },
     "techRecord_dda_wheelchairCapacity": {
       "type": [

--- a/json-definitions/v3/tech-record/put/psv/complete/index.json
+++ b/json-definitions/v3/tech-record/put/psv/complete/index.json
@@ -236,7 +236,10 @@
       "minimum": 0
     },
     "techRecord_dda_certificateIssued": {
-      "type": "boolean"
+      "type": [
+        "boolean",
+        "null"
+      ]
     },
     "techRecord_dda_wheelchairCapacity": {
       "type": [

--- a/json-schemas/v3/tech-record/get/psv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/psv/complete/index.json
@@ -380,7 +380,10 @@
 			"type": "null"
 		},
 		"techRecord_dda_certificateIssued": {
-			"type": "boolean"
+			"type": [
+				"boolean",
+				"null"
+			]
 		},
 		"techRecord_dda_wheelchairCapacity": {
 			"type": [

--- a/json-schemas/v3/tech-record/put/psv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/psv/complete/index.json
@@ -338,7 +338,10 @@
 			"minimum": 0
 		},
 		"techRecord_dda_certificateIssued": {
-			"type": "boolean"
+			"type": [
+				"boolean",
+				"null"
+			]
 		},
 		"techRecord_dda_wheelchairCapacity": {
 			"type": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.39",
+  "version": "3.0.40",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "3.0.39",
+      "version": "3.0.40",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.39",
+  "version": "3.0.40",
   "description": "type definitions for cvs vta application",
   "main": "index.js",
   "repository": {

--- a/types/v3/tech-record/get/psv/complete/index.d.ts
+++ b/types/v3/tech-record/get/psv/complete/index.d.ts
@@ -225,7 +225,7 @@ export interface TechRecordGETPSVComplete {
   techRecord_lastUpdatedByName?: string | null;
   techRecord_lastUpdatedById?: string | null;
   techRecord_dda?: null;
-  techRecord_dda_certificateIssued: boolean;
+  techRecord_dda_certificateIssued: boolean | null;
   techRecord_dda_wheelchairCapacity?: number | null;
   techRecord_dda_wheelchairFittings?: string | null;
   techRecord_dda_wheelchairLiftPresent?: boolean | null;

--- a/types/v3/tech-record/put/psv/complete/index.d.ts
+++ b/types/v3/tech-record/put/psv/complete/index.d.ts
@@ -217,7 +217,7 @@ export interface TechRecordPUTPSVComplete {
   techRecord_conversionRefNo?: string | null;
   techRecord_grossGbWeight?: number | null;
   techRecord_grossDesignWeight?: number | null;
-  techRecord_dda_certificateIssued: boolean;
+  techRecord_dda_certificateIssued: boolean | null;
   techRecord_dda_wheelchairCapacity?: number | null;
   techRecord_dda_wheelchairFittings?: string | null;
   techRecord_dda_wheelchairLiftPresent?: boolean | null;


### PR DESCRIPTION
## techRecord_dda_certificateIssued allows null


[CB2-8666](https://dvsa.atlassian.net/browse/CB2-8666)

<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

- techRecord_dda_certificateIssued in PSV allows null as a valid value

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
