### PR TITLE
patch(cb2-0000): update required fields for skeleton trailer record

### DIFF
--- a/json-definitions/v3/tech-record/get/trl/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/trl/skeleton/index.json
@@ -13,7 +13,8 @@
     "techRecord_statusCode",
     "techRecord_vehicleClass_code",
     "techRecord_vehicleClass_description",
-    "techRecord_vehicleConfiguration",
+    "techRecord_bodyType_description",
+    "techRecord_bodyType_code",
     "techRecord_vehicleType",
     "trailerId",
     "vin"

--- a/json-definitions/v3/tech-record/put/trl/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/trl/skeleton/index.json
@@ -6,7 +6,8 @@
     "techRecord_reasonForCreation",
     "techRecord_statusCode",
     "techRecord_vehicleClass_description",
-    "techRecord_vehicleConfiguration",
+    "techRecord_bodyType_description",
+    "techRecord_bodyType_code",
     "techRecord_vehicleType",
     "vin"
   ],

--- a/json-schemas/v3/tech-record/get/trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/trl/skeleton/index.json
@@ -13,7 +13,8 @@
 		"techRecord_statusCode",
 		"techRecord_vehicleClass_code",
 		"techRecord_vehicleClass_description",
-		"techRecord_vehicleConfiguration",
+		"techRecord_bodyType_description",
+		"techRecord_bodyType_code",
 		"techRecord_vehicleType",
 		"trailerId",
 		"vin"

--- a/json-schemas/v3/tech-record/put/trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/trl/skeleton/index.json
@@ -6,7 +6,8 @@
 		"techRecord_reasonForCreation",
 		"techRecord_statusCode",
 		"techRecord_vehicleClass_description",
-		"techRecord_vehicleConfiguration",
+		"techRecord_bodyType_description",
+		"techRecord_bodyType_code",
 		"techRecord_vehicleType",
 		"vin"
 	],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.41",
-  "version": "3.0.40",
+  "version": "3.0.42",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "3.0.41",
+      "version": "3.0.42",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.41",
+  "version": "3.0.42",
   "description": "type definitions for cvs vta application",
   "main": "index.js",
   "repository": {

--- a/tests/resources/data/trlSkeleton.json
+++ b/tests/resources/data/trlSkeleton.json
@@ -164,6 +164,8 @@
     "techRecord_vehicleConfiguration": "rigid",
     "techRecord_vehicleType": "trl",
     "techRecord_statusCode": "provisional",
+    "techRecord_bodyType_code": "l",
+    "techRecord_bodyType_description": "low loader",
     "trailerId": "C530005",
     "vin": "9080977997"
   },

--- a/types/v3/tech-record/get/trl/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/trl/skeleton/index.d.ts
@@ -221,8 +221,8 @@ export interface TechRecordGETTRLSkeleton {
   techRecord_variantVersionNumber?: null | string;
   techRecord_authIntoService?: string | null;
   techRecord_batchId?: string | null;
-  techRecord_bodyType_code?: null | string;
-  techRecord_bodyType_description?: null | string;
+  techRecord_bodyType_code: null | string;
+  techRecord_bodyType_description: null | string;
   techRecord_brakes_antilockBrakingSystem?: boolean | null;
   techRecord_brakes_dtpNumber?: string | null;
   techRecord_brakes_loadSensingValve?: boolean | null;
@@ -296,7 +296,7 @@ export interface TechRecordGETTRLSkeleton {
   techRecord_tyreUseCode?: string | null;
   techRecord_vehicleClass_code: string;
   techRecord_vehicleClass_description: VehicleClassDescription;
-  techRecord_vehicleConfiguration: VehicleConfiguration | null;
+  techRecord_vehicleConfiguration?: VehicleConfiguration | null;
   techRecord_vehicleType: "trl";
   trailerId: string;
   vin: string;

--- a/types/v3/tech-record/put/trl/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/trl/skeleton/index.d.ts
@@ -219,8 +219,8 @@ export interface TechRecordPUTTRLSkeleton {
   techRecord_applicationId?: string;
   techRecord_authIntoService?: string | null;
   techRecord_batchId?: string | null;
-  techRecord_bodyType_code?: string;
-  techRecord_bodyType_description?: string;
+  techRecord_bodyType_code: string;
+  techRecord_bodyType_description: string;
   techRecord_brakes_antilockBrakingSystem?: boolean | null;
   techRecord_brakes_dtpNumber?: string | null;
   techRecord_brakes_loadSensingValve?: boolean | null;
@@ -274,7 +274,7 @@ export interface TechRecordPUTTRLSkeleton {
   techRecord_suspensionType?: string | null;
   techRecord_tyreUseCode?: string | null;
   techRecord_vehicleClass_description: VehicleClassDescription;
-  techRecord_vehicleConfiguration: VehicleConfiguration;
+  techRecord_vehicleConfiguration?: VehicleConfiguration;
   techRecord_vehicleType: "trl";
   trailerId?: string;
   vin: string;


### PR DESCRIPTION
## Update required fields for skeleton trailer record


<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

- techRecord_vehicleConfiguration removed from required in skeleton trailer
- techRecord_bodyType_code, techRecord_bodyType_description added to required section in skeleton trailer

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
