### PR TITLE
patch(*): remove antilock brake from hgv

### DIFF
--- a/json-definitions/v3/tech-record/get/hgv/complete/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/complete/index.json
@@ -492,12 +492,6 @@
     "techRecord_bodyType_description": {
       "type": "string"
     },
-    "techRecord_brakes_antilockBrakingSystem": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
     "techRecord_brakes_dtpNumber": {
       "type": "string",
       "maxLength": 6

--- a/json-definitions/v3/tech-record/get/hgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/skeleton/index.json
@@ -494,12 +494,6 @@
         "string"
       ]
     },
-    "techRecord_brakes_antilockBrakingSystem": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
     "techRecord_brakes_dtpNumber": {
       "type": [
         "string",

--- a/json-definitions/v3/tech-record/get/hgv/testable/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/testable/index.json
@@ -495,12 +495,6 @@
         "string"
       ]
     },
-    "techRecord_brakes_antilockBrakingSystem": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
     "techRecord_brakes_dtpNumber": {
       "type": [
         "string",

--- a/json-definitions/v3/tech-record/put/hgv/complete/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/complete/index.json
@@ -480,12 +480,6 @@
     "techRecord_bodyType_description": {
       "type": "string"
     },
-    "techRecord_brakes_antilockBrakingSystem": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
     "techRecord_brakes_dtpNumber": {
       "type": "string",
       "maxLength": 6

--- a/json-definitions/v3/tech-record/put/hgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/skeleton/index.json
@@ -480,12 +480,6 @@
         "string"
       ]
     },
-    "techRecord_brakes_antilockBrakingSystem": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
     "techRecord_brakes_dtpNumber": {
       "type": [
         "string",

--- a/json-definitions/v3/tech-record/put/hgv/testable/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/testable/index.json
@@ -473,12 +473,6 @@
     "techRecord_bodyType_description": {
       "type": "string"
     },
-    "techRecord_brakes_antilockBrakingSystem": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
     "techRecord_brakes_dtpNumber": {
       "type": [
         "string",

--- a/json-schemas/v3/tech-record/get/hgv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/complete/index.json
@@ -507,12 +507,6 @@
 		"techRecord_bodyType_description": {
 			"type": "string"
 		},
-		"techRecord_brakes_antilockBrakingSystem": {
-			"type": [
-				"string",
-				"null"
-			]
-		},
 		"techRecord_brakes_dtpNumber": {
 			"type": "string",
 			"maxLength": 6

--- a/json-schemas/v3/tech-record/get/hgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/skeleton/index.json
@@ -509,12 +509,6 @@
 				"string"
 			]
 		},
-		"techRecord_brakes_antilockBrakingSystem": {
-			"type": [
-				"string",
-				"null"
-			]
-		},
 		"techRecord_brakes_dtpNumber": {
 			"type": [
 				"string",

--- a/json-schemas/v3/tech-record/get/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/testable/index.json
@@ -510,12 +510,6 @@
 				"string"
 			]
 		},
-		"techRecord_brakes_antilockBrakingSystem": {
-			"type": [
-				"string",
-				"null"
-			]
-		},
 		"techRecord_brakes_dtpNumber": {
 			"type": [
 				"string",

--- a/json-schemas/v3/tech-record/put/hgv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/complete/index.json
@@ -495,12 +495,6 @@
 		"techRecord_bodyType_description": {
 			"type": "string"
 		},
-		"techRecord_brakes_antilockBrakingSystem": {
-			"type": [
-				"string",
-				"null"
-			]
-		},
 		"techRecord_brakes_dtpNumber": {
 			"type": "string",
 			"maxLength": 6

--- a/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
@@ -495,12 +495,6 @@
 				"string"
 			]
 		},
-		"techRecord_brakes_antilockBrakingSystem": {
-			"type": [
-				"string",
-				"null"
-			]
-		},
 		"techRecord_brakes_dtpNumber": {
 			"type": [
 				"string",

--- a/json-schemas/v3/tech-record/put/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/testable/index.json
@@ -488,12 +488,6 @@
 		"techRecord_bodyType_description": {
 			"type": "string"
 		},
-		"techRecord_brakes_antilockBrakingSystem": {
-			"type": [
-				"string",
-				"null"
-			]
-		},
 		"techRecord_brakes_dtpNumber": {
 			"type": [
 				"string",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.43",
+  "version": "3.0.44",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "3.0.43",
+      "version": "3.0.44",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.43",
+  "version": "3.0.44",
   "description": "type definitions for cvs vta application",
   "main": "index.js",
   "repository": {

--- a/types/v3/tech-record/get/hgv/complete/index.d.ts
+++ b/types/v3/tech-record/get/hgv/complete/index.d.ts
@@ -203,7 +203,6 @@ export interface TechRecordGETHGVComplete {
   techRecord_axles: [HGVAxles, ...HGVAxles[]];
   techRecord_bodyType_code: string;
   techRecord_bodyType_description: string;
-  techRecord_brakes_antilockBrakingSystem?: string | null;
   techRecord_brakes_dtpNumber: string;
   techRecord_brakes_loadSensingValve?: boolean | null;
   techRecord_conversionRefNo?: string | null;

--- a/types/v3/tech-record/get/hgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/hgv/skeleton/index.d.ts
@@ -200,7 +200,6 @@ export interface TechRecordGETHGVSkeleton {
   techRecord_axles?: null | HGVAxles[];
   techRecord_bodyType_code?: null | string;
   techRecord_bodyType_description?: null | string;
-  techRecord_brakes_antilockBrakingSystem?: string | null;
   techRecord_brakes_dtpNumber?: string | null;
   techRecord_brakes_loadSensingValve?: boolean | null;
   techRecord_conversionRefNo?: string | null;

--- a/types/v3/tech-record/get/hgv/testable/index.d.ts
+++ b/types/v3/tech-record/get/hgv/testable/index.d.ts
@@ -200,7 +200,6 @@ export interface TechRecordGETHGVTestable {
   techRecord_axles?: null | HGVAxles[];
   techRecord_bodyType_code?: null | string;
   techRecord_bodyType_description?: null | string;
-  techRecord_brakes_antilockBrakingSystem?: string | null;
   techRecord_brakes_dtpNumber?: string | null;
   techRecord_brakes_loadSensingValve?: boolean | null;
   techRecord_conversionRefNo?: string | null;

--- a/types/v3/tech-record/put/hgv/complete/index.d.ts
+++ b/types/v3/tech-record/put/hgv/complete/index.d.ts
@@ -201,7 +201,6 @@ export interface TechRecordPUTHGVComplete {
   techRecord_axles: [HGVAxles, ...HGVAxles[]];
   techRecord_bodyType_code: string;
   techRecord_bodyType_description: string;
-  techRecord_brakes_antilockBrakingSystem?: string | null;
   techRecord_brakes_dtpNumber: string;
   techRecord_brakes_loadSensingValve?: boolean | null;
   techRecord_conversionRefNo?: string | null;

--- a/types/v3/tech-record/put/hgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/hgv/skeleton/index.d.ts
@@ -198,7 +198,6 @@ export interface TechRecordPUTHGVSkeleton {
   techRecord_axles?: null | HGVAxles[];
   techRecord_bodyType_code?: null | string;
   techRecord_bodyType_description?: null | string;
-  techRecord_brakes_antilockBrakingSystem?: string | null;
   techRecord_brakes_dtpNumber?: string | null;
   techRecord_brakes_loadSensingValve?: boolean | null;
   techRecord_conversionRefNo?: string | null;

--- a/types/v3/tech-record/put/hgv/testable/index.d.ts
+++ b/types/v3/tech-record/put/hgv/testable/index.d.ts
@@ -198,7 +198,6 @@ export interface TechRecordPUTHGVTestable {
   techRecord_axles?: HGVAxles[];
   techRecord_bodyType_code?: string;
   techRecord_bodyType_description?: string;
-  techRecord_brakes_antilockBrakingSystem?: string | null;
   techRecord_brakes_dtpNumber?: string | null;
   techRecord_brakes_loadSensingValve?: boolean | null;
   techRecord_conversionRefNo?: string | null;


### PR DESCRIPTION
## Ticket title

remove antilock brake from hgv


<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

- Remove antilock brake form hgv schema

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
