### PR TITLE
fix(cb2-9196): allow nulls in techRecord_applicationId

### DIFF
--- a/json-definitions/v3/tech-record/get/hgv/testable/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/testable/index.json
@@ -393,7 +393,10 @@
       "maxLength": 255
     },
     "techRecord_applicationId": {
-      "type": "string"
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "techRecord_axles": {
       "type": [

--- a/json-definitions/v3/tech-record/get/psv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/psv/skeleton/index.json
@@ -883,7 +883,10 @@
       ]
     },
     "techRecord_applicationId": {
-      "type": "string"
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "secondaryVrms": {
       "type": [

--- a/json-definitions/v3/tech-record/put/psv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/psv/skeleton/index.json
@@ -829,7 +829,10 @@
       ]
     },
     "techRecord_applicationId": {
-      "type": "string"
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "secondaryVrms": {
       "type": "array",

--- a/json-definitions/v3/tech-record/put/trl/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/trl/skeleton/index.json
@@ -407,7 +407,10 @@
       "maxLength": 255
     },
     "techRecord_applicationId": {
-      "type": "string"
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "techRecord_authIntoService": {
       "type": [

--- a/json-schemas/v3/tech-record/get/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/testable/index.json
@@ -403,7 +403,10 @@
 			"maxLength": 255
 		},
 		"techRecord_applicationId": {
-			"type": "string"
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"techRecord_axles": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/psv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/psv/skeleton/index.json
@@ -1108,7 +1108,10 @@
 			]
 		},
 		"techRecord_applicationId": {
-			"type": "string"
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"secondaryVrms": {
 			"type": [

--- a/json-schemas/v3/tech-record/put/psv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/psv/skeleton/index.json
@@ -1054,7 +1054,10 @@
 			]
 		},
 		"techRecord_applicationId": {
-			"type": "string"
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"secondaryVrms": {
 			"type": "array",

--- a/json-schemas/v3/tech-record/put/trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/trl/skeleton/index.json
@@ -434,7 +434,10 @@
 			"maxLength": 255
 		},
 		"techRecord_applicationId": {
-			"type": "string"
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"techRecord_authIntoService": {
 			"type": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.43",
+  "version": "3.0.43-patch1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "3.0.43",
+      "version": "3.0.43-patch1",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.43",
+  "version": "3.0.43-patch1",
   "description": "type definitions for cvs vta application",
   "main": "index.js",
   "repository": {

--- a/types/v3/tech-record/get/hgv/testable/index.d.ts
+++ b/types/v3/tech-record/get/hgv/testable/index.d.ts
@@ -196,7 +196,7 @@ export interface TechRecordGETHGVTestable {
   techRecord_applicantDetails_postCode?: null | string;
   techRecord_applicantDetails_telephoneNumber?: null | string;
   techRecord_applicantDetails_emailAddress?: null | string;
-  techRecord_applicationId?: string;
+  techRecord_applicationId?: null | string;
   techRecord_axles?: null | HGVAxles[];
   techRecord_bodyType_code?: null | string;
   techRecord_bodyType_description?: null | string;

--- a/types/v3/tech-record/get/psv/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/psv/skeleton/index.d.ts
@@ -294,7 +294,7 @@ export interface TechRecordGETPSVSkeleton {
   techRecord_microfilm_microfilmSerialNumber?: string | null;
   techRecord_brakeCode?: string | null;
   createdTimestamp: string;
-  techRecord_applicationId?: string;
+  techRecord_applicationId?: null | string;
   secondaryVrms?: null | string[];
   techRecord_updateType?: null | string;
 }

--- a/types/v3/tech-record/put/psv/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/psv/skeleton/index.d.ts
@@ -282,7 +282,7 @@ export interface TechRecordPUTPSVSkeleton {
   techRecord_microfilm_microfilmRollNumber?: string | null;
   techRecord_microfilm_microfilmSerialNumber?: string | null;
   techRecord_brakeCode?: string | null;
-  techRecord_applicationId?: string;
+  techRecord_applicationId?: null | string;
   secondaryVrms?: string[];
   techRecord_updateType?: null | string;
 }

--- a/types/v3/tech-record/put/trl/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/trl/skeleton/index.d.ts
@@ -216,7 +216,7 @@ export interface TechRecordPUTTRLSkeleton {
   techRecord_applicantDetails_postCode?: null | string;
   techRecord_applicantDetails_telephoneNumber?: null | string;
   techRecord_applicantDetails_emailAddress?: null | string;
-  techRecord_applicationId?: string;
+  techRecord_applicationId?: null | string;
   techRecord_authIntoService?: string | null;
   techRecord_batchId?: string | null;
   techRecord_bodyType_code: string;


### PR DESCRIPTION
## Ticket title

Allows `null` applicationIds

[CB2-9196](https://dvsa.atlassian.net/browse/CB2-9196)

<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

-

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
