### PR TITLE
patch(cb2-9196): allow null on techRecord_applicationId

### DIFF
--- a/json-definitions/v3/tech-record/get/hgv/complete/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/complete/index.json
@@ -492,6 +492,12 @@
     "techRecord_bodyType_description": {
       "type": "string"
     },
+    "techRecord_brakes_antilockBrakingSystem": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "techRecord_brakes_dtpNumber": {
       "type": "string",
       "maxLength": 6

--- a/json-definitions/v3/tech-record/get/hgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/skeleton/index.json
@@ -494,6 +494,12 @@
         "string"
       ]
     },
+    "techRecord_brakes_antilockBrakingSystem": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "techRecord_brakes_dtpNumber": {
       "type": [
         "string",

--- a/json-definitions/v3/tech-record/get/hgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/skeleton/index.json
@@ -13,8 +13,6 @@
     "techRecord_recordCompleteness",
     "techRecord_statusCode",
     "techRecord_vehicleType",
-    "techRecord_vehicleClass_description",
-    "techRecord_bodyType_description",
     "primaryVrm",
     "vin"
   ],
@@ -491,7 +489,10 @@
       ]
     },
     "techRecord_bodyType_description": {
-      "type": "string"
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "techRecord_brakes_dtpNumber": {
       "type": [
@@ -906,7 +907,14 @@
       ]
     },
     "techRecord_vehicleClass_description": {
-        "$ref": "../../../enums/vehicleClassDescription.ignore.json" 
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "../../../enums/vehicleClassDescription.ignore.json"
+        }
+      ]
     },
     "techRecord_vehicleConfiguration": {
       "anyOf": [

--- a/json-definitions/v3/tech-record/get/hgv/testable/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/testable/index.json
@@ -495,6 +495,12 @@
         "string"
       ]
     },
+    "techRecord_brakes_antilockBrakingSystem": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "techRecord_brakes_dtpNumber": {
       "type": [
         "string",

--- a/json-definitions/v3/tech-record/get/hgv/testable/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/testable/index.json
@@ -393,7 +393,10 @@
       "maxLength": 255
     },
     "techRecord_applicationId": {
-      "type": "string"
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "techRecord_axles": {
       "type": [

--- a/json-definitions/v3/tech-record/get/hgv/testable/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/testable/index.json
@@ -18,9 +18,7 @@
     "techRecord_vehicleConfiguration",
     "techRecord_vehicleClass_code",
     "techRecord_vehicleClass_description",
-    "techRecord_numberOfWheelsDriven",
-    "techRecord_noOfAxles",
-    "techRecord_bodyType_description"
+    "techRecord_numberOfWheelsDriven"
   ],
   "properties": {
     "secondaryVrms": {
@@ -492,7 +490,10 @@
       ]
     },
     "techRecord_bodyType_description": {
-      "type": "string"
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "techRecord_brakes_dtpNumber": {
       "type": [
@@ -758,9 +759,16 @@
       "type": "integer"
     },
     "techRecord_noOfAxles": {
-      "type": "integer",
-      "minimum": 0,
-      "maximum": 99
+      "anyOf": [
+        {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 99
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "techRecord_notes": {
       "type": [

--- a/json-definitions/v3/tech-record/get/lgv/complete/index.json
+++ b/json-definitions/v3/tech-record/get/lgv/complete/index.json
@@ -11,8 +11,7 @@
     "techRecord_createdAt",
     "techRecord_createdById",
     "techRecord_createdByName",
-    "techRecord_reasonForCreation",
-    "techRecord_noOfAxles"
+    "techRecord_reasonForCreation"
   ],
   "properties": {
     "techRecord_applicantDetails_name": {
@@ -141,7 +140,10 @@
       ]
     },
     "techRecord_noOfAxles": {
-      "type": "integer"
+      "type": [
+        "null",
+        "integer"
+      ]
     },
     "techRecord_notes": {
       "type": [

--- a/json-definitions/v3/tech-record/get/motorcycle/complete/index.json
+++ b/json-definitions/v3/tech-record/get/motorcycle/complete/index.json
@@ -15,8 +15,7 @@
     "techRecord_vehicleType",
     "createdTimestamp",
     "partialVin",
-    "vin",
-    "techRecord_vehicleConfiguration"
+    "vin"
   ],
   "properties": {
     "secondaryVrms": {
@@ -191,8 +190,15 @@
       "type": "string"
     },
     "techRecord_vehicleConfiguration": {
-      "$ref": "../../../enums/vehicleConfiguration.ignore.json"
-    },  
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "../../../enums/vehicleConfiguration.ignore.json"
+        }
+      ]
+    },
     "techRecord_vehicleType": {
       "const": "motorcycle"
     },

--- a/json-definitions/v3/tech-record/get/psv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/psv/skeleton/index.json
@@ -883,7 +883,10 @@
       ]
     },
     "techRecord_applicationId": {
-      "type": "string"
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "secondaryVrms": {
       "type": [

--- a/json-definitions/v3/tech-record/put/car/complete/index.json
+++ b/json-definitions/v3/tech-record/put/car/complete/index.json
@@ -8,8 +8,7 @@
     "techRecord_vehicleType",
     "techRecord_statusCode",
     "techRecord_noOfAxles",
-    "techRecord_reasonForCreation",
-    "techRecord_vehicleConfiguration"
+    "techRecord_reasonForCreation"
   ],
   "properties": {
     "vin": {
@@ -71,9 +70,6 @@
       "items": {
         "type": "string"
       }
-    },
-    "techRecord_vehicleConfiguration": {
-      "$ref": "../../../enums/vehicleConfiguration.ignore.json"
     },
     "techRecord_euVehicleCategory": {
       "anyOf": [

--- a/json-definitions/v3/tech-record/put/car/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/car/skeleton/index.json
@@ -72,16 +72,6 @@
     "techRecord_vehicleSubclass": {
       "$ref": "../../../enums/vehicleSubclass.ignore.json"
     },
-    "techRecord_vehicleConfiguration": {
-      "anyOf": [
-        {
-          "type": "null"
-        },
-        {
-          "$ref": "../../../enums/vehicleConfiguration.ignore.json"
-        }
-      ]
-    },
     "techRecord_euVehicleCategory": {
       "anyOf": [
         {

--- a/json-definitions/v3/tech-record/put/hgv/complete/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/complete/index.json
@@ -480,6 +480,12 @@
     "techRecord_bodyType_description": {
       "type": "string"
     },
+    "techRecord_brakes_antilockBrakingSystem": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "techRecord_brakes_dtpNumber": {
       "type": "string",
       "maxLength": 6

--- a/json-definitions/v3/tech-record/put/hgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/skeleton/index.json
@@ -6,8 +6,6 @@
     "techRecord_reasonForCreation",
     "techRecord_statusCode",
     "techRecord_vehicleType",
-    "techRecord_vehicleClass_description",
-    "techRecord_bodyType_description",
     "vin"
   ],
   "properties": {
@@ -477,7 +475,10 @@
       ]
     },
     "techRecord_bodyType_description": {
-      "type": "string"
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "techRecord_brakes_dtpNumber": {
       "type": [
@@ -865,7 +866,14 @@
       "maxLength": 2
     },
     "techRecord_vehicleClass_description": {
-      "$ref": "../../../enums/vehicleClassDescription.ignore.json"
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "../../../enums/vehicleClassDescription.ignore.json"
+        }
+      ]
     },
     "techRecord_vehicleConfiguration": {
       "anyOf": [

--- a/json-definitions/v3/tech-record/put/hgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/skeleton/index.json
@@ -480,6 +480,12 @@
         "string"
       ]
     },
+    "techRecord_brakes_antilockBrakingSystem": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "techRecord_brakes_dtpNumber": {
       "type": [
         "string",

--- a/json-definitions/v3/tech-record/put/hgv/testable/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/testable/index.json
@@ -473,6 +473,12 @@
     "techRecord_bodyType_description": {
       "type": "string"
     },
+    "techRecord_brakes_antilockBrakingSystem": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "techRecord_brakes_dtpNumber": {
       "type": [
         "string",

--- a/json-definitions/v3/tech-record/put/hgv/testable/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/testable/index.json
@@ -8,9 +8,7 @@
     "techRecord_vehicleType",
     "vin",
     "techRecord_vehicleConfiguration",
-    "techRecord_vehicleClass_description",
-    "techRecord_noOfAxles",
-    "techRecord_bodyType_description"
+    "techRecord_vehicleClass_description"
   ],
   "properties": {
     "secondaryVrms": {
@@ -724,9 +722,16 @@
       "maxLength": 30
     },
     "techRecord_noOfAxles": {
-      "type": "integer",
-      "minimum": 0,
-      "maximum": 99
+      "anyOf": [
+        {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 99
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "techRecord_notes": {
       "type": [

--- a/json-definitions/v3/tech-record/put/lgv/complete/index.json
+++ b/json-definitions/v3/tech-record/put/lgv/complete/index.json
@@ -7,8 +7,7 @@
     "vin",
     "techRecord_vehicleType",
     "techRecord_statusCode",
-    "techRecord_reasonForCreation",
-    "techRecord_noOfAxles"
+    "techRecord_reasonForCreation"
   ],
   "properties": {
     "vin": {
@@ -105,7 +104,10 @@
       ]
     },
     "techRecord_noOfAxles": {
-      "type": "integer"
+      "type": [
+        "integer",
+        "null"
+      ]
     },
     "techRecord_notes": {
       "type": "string"

--- a/json-definitions/v3/tech-record/put/motorcycle/complete/index.json
+++ b/json-definitions/v3/tech-record/put/motorcycle/complete/index.json
@@ -8,7 +8,6 @@
     "techRecord_reasonForCreation",
     "techRecord_vehicleType",
     "techRecord_statusCode",
-    "techRecord_vehicleConfiguration",
     "vin"
   ],
   "properties": {
@@ -145,7 +144,14 @@
       "$ref": "../../../enums/vehicleClassDescription.ignore.json"
     },
     "techRecord_vehicleConfiguration": {
-      "$ref": "../../../enums/vehicleConfiguration.ignore.json"
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "../../../enums/vehicleConfiguration.ignore.json"
+        }
+      ]
     },
     "techRecord_vehicleType": {
       "const": "motorcycle"

--- a/json-definitions/v3/tech-record/put/psv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/psv/skeleton/index.json
@@ -829,7 +829,10 @@
       ]
     },
     "techRecord_applicationId": {
-      "type": "string"
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "secondaryVrms": {
       "type": "array",

--- a/json-definitions/v3/tech-record/put/psv/testable/index.json
+++ b/json-definitions/v3/tech-record/put/psv/testable/index.json
@@ -12,8 +12,7 @@
     "techRecord_noOfAxles",
     "techRecord_statusCode",
     "techRecord_reasonForCreation",
-    "techRecord_vehicleClass_description",
-    "techRecord_brakes_dtpNumber"
+    "techRecord_vehicleClass_description"
   ],
   "properties": {
     "vin": {
@@ -670,7 +669,10 @@
       "maxLength": 255
     },
     "techRecord_brakes_dtpNumber": {
-      "type": "string",
+      "type": [
+        "string",
+        "null"
+      ],
       "maxLength": 6
     },
     "techRecord_brakes_brakeCode": {

--- a/json-definitions/v3/tech-record/put/small trl/complete/index.json
+++ b/json-definitions/v3/tech-record/put/small trl/complete/index.json
@@ -99,14 +99,7 @@
             "$ref": "../../../enums/vehicleConfiguration.ignore.json"
         },
         "techRecord_vehicleSubclass": {
-            "anyOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "$ref": "../../../enums/vehicleSubclass.ignore.json"
-                }
-              ]
+            "$ref": "../../../enums/vehicleSubclass.ignore.json"
         },
         "techRecord_vehicleType": {
             "const": "trl"

--- a/json-definitions/v3/tech-record/put/trl/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/trl/skeleton/index.json
@@ -407,7 +407,10 @@
       "maxLength": 255
     },
     "techRecord_applicationId": {
-      "type": "string"
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "techRecord_authIntoService": {
       "type": [

--- a/json-schemas/v3/tech-record/get/hgv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/complete/index.json
@@ -507,6 +507,12 @@
 		"techRecord_bodyType_description": {
 			"type": "string"
 		},
+		"techRecord_brakes_antilockBrakingSystem": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
 		"techRecord_brakes_dtpNumber": {
 			"type": "string",
 			"maxLength": 6

--- a/json-schemas/v3/tech-record/get/hgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/skeleton/index.json
@@ -13,8 +13,6 @@
 		"techRecord_recordCompleteness",
 		"techRecord_statusCode",
 		"techRecord_vehicleType",
-		"techRecord_vehicleClass_description",
-		"techRecord_bodyType_description",
 		"primaryVrm",
 		"vin"
 	],
@@ -506,7 +504,10 @@
 			]
 		},
 		"techRecord_bodyType_description": {
-			"type": "string"
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"techRecord_brakes_dtpNumber": {
 			"type": [
@@ -1027,20 +1028,27 @@
 			]
 		},
 		"techRecord_vehicleClass_description": {
-			"title": "Vehicle Class Description",
-			"type": "string",
-			"enum": [
-				"motorbikes over 200cc or with a sidecar",
-				"not applicable",
-				"small psv (ie: less than or equal to 22 seats)",
-				"motorbikes up to 200cc",
-				"trailer",
-				"large psv(ie: greater than 23 seats)",
-				"3 wheelers",
-				"heavy goods vehicle",
-				"MOT class 4",
-				"MOT class 7",
-				"MOT class 5"
+			"anyOf": [
+				{
+					"type": "null"
+				},
+				{
+					"title": "Vehicle Class Description",
+					"type": "string",
+					"enum": [
+						"motorbikes over 200cc or with a sidecar",
+						"not applicable",
+						"small psv (ie: less than or equal to 22 seats)",
+						"motorbikes up to 200cc",
+						"trailer",
+						"large psv(ie: greater than 23 seats)",
+						"3 wheelers",
+						"heavy goods vehicle",
+						"MOT class 4",
+						"MOT class 7",
+						"MOT class 5"
+					]
+				}
 			]
 		},
 		"techRecord_vehicleConfiguration": {

--- a/json-schemas/v3/tech-record/get/hgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/skeleton/index.json
@@ -509,6 +509,12 @@
 				"string"
 			]
 		},
+		"techRecord_brakes_antilockBrakingSystem": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
 		"techRecord_brakes_dtpNumber": {
 			"type": [
 				"string",

--- a/json-schemas/v3/tech-record/get/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/testable/index.json
@@ -18,9 +18,7 @@
 		"techRecord_vehicleConfiguration",
 		"techRecord_vehicleClass_code",
 		"techRecord_vehicleClass_description",
-		"techRecord_numberOfWheelsDriven",
-		"techRecord_noOfAxles",
-		"techRecord_bodyType_description"
+		"techRecord_numberOfWheelsDriven"
 	],
 	"properties": {
 		"secondaryVrms": {
@@ -507,7 +505,10 @@
 			]
 		},
 		"techRecord_bodyType_description": {
-			"type": "string"
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"techRecord_brakes_dtpNumber": {
 			"type": [
@@ -864,9 +865,16 @@
 			"type": "integer"
 		},
 		"techRecord_noOfAxles": {
-			"type": "integer",
-			"minimum": 0,
-			"maximum": 99
+			"anyOf": [
+				{
+					"type": "integer",
+					"minimum": 0,
+					"maximum": 99
+				},
+				{
+					"type": "null"
+				}
+			]
 		},
 		"techRecord_notes": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/testable/index.json
@@ -510,6 +510,12 @@
 				"string"
 			]
 		},
+		"techRecord_brakes_antilockBrakingSystem": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
 		"techRecord_brakes_dtpNumber": {
 			"type": [
 				"string",

--- a/json-schemas/v3/tech-record/get/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/testable/index.json
@@ -403,7 +403,10 @@
 			"maxLength": 255
 		},
 		"techRecord_applicationId": {
-			"type": "string"
+			"type": [
+				"string",
+				"null"
+			]
 		},
 		"techRecord_axles": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/lgv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/lgv/complete/index.json
@@ -11,8 +11,7 @@
 		"techRecord_createdAt",
 		"techRecord_createdById",
 		"techRecord_createdByName",
-		"techRecord_reasonForCreation",
-		"techRecord_noOfAxles"
+		"techRecord_reasonForCreation"
 	],
 	"properties": {
 		"techRecord_applicantDetails_name": {
@@ -162,7 +161,10 @@
 			]
 		},
 		"techRecord_noOfAxles": {
-			"type": "integer"
+			"type": [
+				"null",
+				"integer"
+			]
 		},
 		"techRecord_notes": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/motorcycle/complete/index.json
+++ b/json-schemas/v3/tech-record/get/motorcycle/complete/index.json
@@ -15,8 +15,7 @@
 		"techRecord_vehicleType",
 		"createdTimestamp",
 		"partialVin",
-		"vin",
-		"techRecord_vehicleConfiguration"
+		"vin"
 	],
 	"properties": {
 		"secondaryVrms": {
@@ -232,21 +231,28 @@
 			"type": "string"
 		},
 		"techRecord_vehicleConfiguration": {
-			"title": "Vehicle Configuration",
-			"type": "string",
-			"enum": [
-				"rigid",
-				"articulated",
-				"centre axle drawbar",
-				"semi-car transporter",
-				"semi-trailer",
-				"long semi-trailer",
-				"low loader",
-				"other",
-				"drawbar",
-				"four-in-line",
-				"dolly",
-				"full drawbar"
+			"anyOf": [
+				{
+					"type": "null"
+				},
+				{
+					"title": "Vehicle Configuration",
+					"type": "string",
+					"enum": [
+						"rigid",
+						"articulated",
+						"centre axle drawbar",
+						"semi-car transporter",
+						"semi-trailer",
+						"long semi-trailer",
+						"low loader",
+						"other",
+						"drawbar",
+						"four-in-line",
+						"dolly",
+						"full drawbar"
+					]
+				}
 			]
 		},
 		"techRecord_vehicleType": {

--- a/json-schemas/v3/tech-record/get/psv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/psv/skeleton/index.json
@@ -1108,7 +1108,10 @@
 			]
 		},
 		"techRecord_applicationId": {
-			"type": "string"
+			"type": [
+				"string",
+				"null"
+			]
 		},
 		"secondaryVrms": {
 			"type": [

--- a/json-schemas/v3/tech-record/put/car/complete/index.json
+++ b/json-schemas/v3/tech-record/put/car/complete/index.json
@@ -8,8 +8,7 @@
 		"techRecord_vehicleType",
 		"techRecord_statusCode",
 		"techRecord_noOfAxles",
-		"techRecord_reasonForCreation",
-		"techRecord_vehicleConfiguration"
+		"techRecord_reasonForCreation"
 	],
 	"properties": {
 		"vin": {
@@ -94,24 +93,6 @@
 			"items": {
 				"type": "string"
 			}
-		},
-		"techRecord_vehicleConfiguration": {
-			"title": "Vehicle Configuration",
-			"type": "string",
-			"enum": [
-				"rigid",
-				"articulated",
-				"centre axle drawbar",
-				"semi-car transporter",
-				"semi-trailer",
-				"long semi-trailer",
-				"low loader",
-				"other",
-				"drawbar",
-				"four-in-line",
-				"dolly",
-				"full drawbar"
-			]
 		},
 		"techRecord_euVehicleCategory": {
 			"anyOf": [

--- a/json-schemas/v3/tech-record/put/car/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/car/skeleton/index.json
@@ -95,31 +95,6 @@
 				]
 			}
 		},
-		"techRecord_vehicleConfiguration": {
-			"anyOf": [
-				{
-					"type": "null"
-				},
-				{
-					"title": "Vehicle Configuration",
-					"type": "string",
-					"enum": [
-						"rigid",
-						"articulated",
-						"centre axle drawbar",
-						"semi-car transporter",
-						"semi-trailer",
-						"long semi-trailer",
-						"low loader",
-						"other",
-						"drawbar",
-						"four-in-line",
-						"dolly",
-						"full drawbar"
-					]
-				}
-			]
-		},
 		"techRecord_euVehicleCategory": {
 			"anyOf": [
 				{

--- a/json-schemas/v3/tech-record/put/hgv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/complete/index.json
@@ -495,6 +495,12 @@
 		"techRecord_bodyType_description": {
 			"type": "string"
 		},
+		"techRecord_brakes_antilockBrakingSystem": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
 		"techRecord_brakes_dtpNumber": {
 			"type": "string",
 			"maxLength": 6

--- a/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
@@ -6,8 +6,6 @@
 		"techRecord_reasonForCreation",
 		"techRecord_statusCode",
 		"techRecord_vehicleType",
-		"techRecord_vehicleClass_description",
-		"techRecord_bodyType_description",
 		"vin"
 	],
 	"properties": {
@@ -492,7 +490,10 @@
 			]
 		},
 		"techRecord_bodyType_description": {
-			"type": "string"
+			"type": [
+				"null",
+				"string"
+			]
 		},
 		"techRecord_brakes_dtpNumber": {
 			"type": [
@@ -986,20 +987,27 @@
 			"maxLength": 2
 		},
 		"techRecord_vehicleClass_description": {
-			"title": "Vehicle Class Description",
-			"type": "string",
-			"enum": [
-				"motorbikes over 200cc or with a sidecar",
-				"not applicable",
-				"small psv (ie: less than or equal to 22 seats)",
-				"motorbikes up to 200cc",
-				"trailer",
-				"large psv(ie: greater than 23 seats)",
-				"3 wheelers",
-				"heavy goods vehicle",
-				"MOT class 4",
-				"MOT class 7",
-				"MOT class 5"
+			"anyOf": [
+				{
+					"type": "null"
+				},
+				{
+					"title": "Vehicle Class Description",
+					"type": "string",
+					"enum": [
+						"motorbikes over 200cc or with a sidecar",
+						"not applicable",
+						"small psv (ie: less than or equal to 22 seats)",
+						"motorbikes up to 200cc",
+						"trailer",
+						"large psv(ie: greater than 23 seats)",
+						"3 wheelers",
+						"heavy goods vehicle",
+						"MOT class 4",
+						"MOT class 7",
+						"MOT class 5"
+					]
+				}
 			]
 		},
 		"techRecord_vehicleConfiguration": {

--- a/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
@@ -495,6 +495,12 @@
 				"string"
 			]
 		},
+		"techRecord_brakes_antilockBrakingSystem": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
 		"techRecord_brakes_dtpNumber": {
 			"type": [
 				"string",

--- a/json-schemas/v3/tech-record/put/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/testable/index.json
@@ -8,9 +8,7 @@
 		"techRecord_vehicleType",
 		"vin",
 		"techRecord_vehicleConfiguration",
-		"techRecord_vehicleClass_description",
-		"techRecord_noOfAxles",
-		"techRecord_bodyType_description"
+		"techRecord_vehicleClass_description"
 	],
 	"properties": {
 		"secondaryVrms": {
@@ -830,9 +828,16 @@
 			"maxLength": 30
 		},
 		"techRecord_noOfAxles": {
-			"type": "integer",
-			"minimum": 0,
-			"maximum": 99
+			"anyOf": [
+				{
+					"type": "integer",
+					"minimum": 0,
+					"maximum": 99
+				},
+				{
+					"type": "null"
+				}
+			]
 		},
 		"techRecord_notes": {
 			"type": [

--- a/json-schemas/v3/tech-record/put/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/testable/index.json
@@ -488,6 +488,12 @@
 		"techRecord_bodyType_description": {
 			"type": "string"
 		},
+		"techRecord_brakes_antilockBrakingSystem": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
 		"techRecord_brakes_dtpNumber": {
 			"type": [
 				"string",

--- a/json-schemas/v3/tech-record/put/lgv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/lgv/complete/index.json
@@ -7,8 +7,7 @@
 		"vin",
 		"techRecord_vehicleType",
 		"techRecord_statusCode",
-		"techRecord_reasonForCreation",
-		"techRecord_noOfAxles"
+		"techRecord_reasonForCreation"
 	],
 	"properties": {
 		"vin": {
@@ -132,7 +131,10 @@
 			]
 		},
 		"techRecord_noOfAxles": {
-			"type": "integer"
+			"type": [
+				"integer",
+				"null"
+			]
 		},
 		"techRecord_notes": {
 			"type": "string"

--- a/json-schemas/v3/tech-record/put/motorcycle/complete/index.json
+++ b/json-schemas/v3/tech-record/put/motorcycle/complete/index.json
@@ -8,7 +8,6 @@
 		"techRecord_reasonForCreation",
 		"techRecord_vehicleType",
 		"techRecord_statusCode",
-		"techRecord_vehicleConfiguration",
 		"vin"
 	],
 	"properties": {
@@ -186,21 +185,28 @@
 			]
 		},
 		"techRecord_vehicleConfiguration": {
-			"title": "Vehicle Configuration",
-			"type": "string",
-			"enum": [
-				"rigid",
-				"articulated",
-				"centre axle drawbar",
-				"semi-car transporter",
-				"semi-trailer",
-				"long semi-trailer",
-				"low loader",
-				"other",
-				"drawbar",
-				"four-in-line",
-				"dolly",
-				"full drawbar"
+			"anyOf": [
+				{
+					"type": "null"
+				},
+				{
+					"title": "Vehicle Configuration",
+					"type": "string",
+					"enum": [
+						"rigid",
+						"articulated",
+						"centre axle drawbar",
+						"semi-car transporter",
+						"semi-trailer",
+						"long semi-trailer",
+						"low loader",
+						"other",
+						"drawbar",
+						"four-in-line",
+						"dolly",
+						"full drawbar"
+					]
+				}
 			]
 		},
 		"techRecord_vehicleType": {

--- a/json-schemas/v3/tech-record/put/psv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/psv/skeleton/index.json
@@ -1054,7 +1054,10 @@
 			]
 		},
 		"techRecord_applicationId": {
-			"type": "string"
+			"type": [
+				"string",
+				"null"
+			]
 		},
 		"secondaryVrms": {
 			"type": "array",

--- a/json-schemas/v3/tech-record/put/psv/testable/index.json
+++ b/json-schemas/v3/tech-record/put/psv/testable/index.json
@@ -12,8 +12,7 @@
 		"techRecord_noOfAxles",
 		"techRecord_statusCode",
 		"techRecord_reasonForCreation",
-		"techRecord_vehicleClass_description",
-		"techRecord_brakes_dtpNumber"
+		"techRecord_vehicleClass_description"
 	],
 	"properties": {
 		"vin": {
@@ -819,7 +818,10 @@
 			"maxLength": 255
 		},
 		"techRecord_brakes_dtpNumber": {
-			"type": "string",
+			"type": [
+				"string",
+				"null"
+			],
 			"maxLength": 6
 		},
 		"techRecord_brakes_brakeCode": {

--- a/json-schemas/v3/tech-record/put/small trl/complete/index.json
+++ b/json-schemas/v3/tech-record/put/small trl/complete/index.json
@@ -134,31 +134,24 @@
 			]
 		},
 		"techRecord_vehicleSubclass": {
-			"anyOf": [
-				{
-					"type": "null"
-				},
-				{
-					"title": "Vehicle Subclass",
-					"type": "array",
-					"items": {
-						"type": "string",
-						"enum": [
-							"n",
-							"p",
-							"a",
-							"s",
-							"c",
-							"l",
-							"t",
-							"e",
-							"m",
-							"r",
-							"w"
-						]
-					}
-				}
-			]
+			"title": "Vehicle Subclass",
+			"type": "array",
+			"items": {
+				"type": "string",
+				"enum": [
+					"n",
+					"p",
+					"a",
+					"s",
+					"c",
+					"l",
+					"t",
+					"e",
+					"m",
+					"r",
+					"w"
+				]
+			}
 		},
 		"techRecord_vehicleType": {
 			"const": "trl"

--- a/json-schemas/v3/tech-record/put/trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/trl/skeleton/index.json
@@ -434,7 +434,10 @@
 			"maxLength": 255
 		},
 		"techRecord_applicationId": {
-			"type": "string"
+			"type": [
+				"string",
+				"null"
+			]
 		},
 		"techRecord_authIntoService": {
 			"type": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.43",
+  "version": "3.0.46",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "3.0.43",
+      "version": "3.0.46",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.44",
+  "version": "3.0.43",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "3.0.44",
+      "version": "3.0.43",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.45",
+  "version": "3.0.44",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "3.0.45",
+      "version": "3.0.44",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.44",
+  "version": "3.0.43",
   "description": "type definitions for cvs vta application",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.45",
+  "version": "3.0.44",
   "description": "type definitions for cvs vta application",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.43",
+  "version": "3.0.46",
   "description": "type definitions for cvs vta application",
   "main": "index.js",
   "repository": {

--- a/tests/resources/data/hgvSkeleton.json
+++ b/tests/resources/data/hgvSkeleton.json
@@ -142,10 +142,7 @@
     "techRecord_recordCompleteness": "skeleton",
     "techRecord_statusCode": "provisional",
     "techRecord_vehicleType": "hgv",
-    "vin": "DANHGV1231",
-    "techRecord_bodyType_code": "u",
-    "techRecord_bodyType_description": "artic",
-    "techRecord_vehicleClass_description": "heavy goods vehicle"
+    "vin": "DANHGV1231"
   },
   {
     "createdTimestamp": "2023-06-16T15:17:21.819Z",

--- a/tests/resources/data/hgvTestable.json
+++ b/tests/resources/data/hgvTestable.json
@@ -232,8 +232,6 @@
     "techRecord_vehicleClass_description": "heavy goods vehicle",
     "techRecord_vehicleConfiguration": "articulated",
     "techRecord_vehicleType": "hgv",
-    "techRecord_bodyType_description": "artic",
-    "techRecord_noOfAxles": 2,
     "vin": "GB01DAN0000000001"
   },
   {

--- a/types/v3/tech-record/get/hgv/complete/index.d.ts
+++ b/types/v3/tech-record/get/hgv/complete/index.d.ts
@@ -203,6 +203,7 @@ export interface TechRecordGETHGVComplete {
   techRecord_axles: [HGVAxles, ...HGVAxles[]];
   techRecord_bodyType_code: string;
   techRecord_bodyType_description: string;
+  techRecord_brakes_antilockBrakingSystem?: string | null;
   techRecord_brakes_dtpNumber: string;
   techRecord_brakes_loadSensingValve?: boolean | null;
   techRecord_conversionRefNo?: string | null;

--- a/types/v3/tech-record/get/hgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/hgv/skeleton/index.d.ts
@@ -200,6 +200,7 @@ export interface TechRecordGETHGVSkeleton {
   techRecord_axles?: null | HGVAxles[];
   techRecord_bodyType_code?: null | string;
   techRecord_bodyType_description?: null | string;
+  techRecord_brakes_antilockBrakingSystem?: string | null;
   techRecord_brakes_dtpNumber?: string | null;
   techRecord_brakes_loadSensingValve?: boolean | null;
   techRecord_conversionRefNo?: string | null;

--- a/types/v3/tech-record/get/hgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/hgv/skeleton/index.d.ts
@@ -199,7 +199,7 @@ export interface TechRecordGETHGVSkeleton {
   techRecord_applicationId?: string | null;
   techRecord_axles?: null | HGVAxles[];
   techRecord_bodyType_code?: null | string;
-  techRecord_bodyType_description: string;
+  techRecord_bodyType_description?: null | string;
   techRecord_brakes_dtpNumber?: string | null;
   techRecord_brakes_loadSensingValve?: boolean | null;
   techRecord_conversionRefNo?: string | null;
@@ -251,7 +251,7 @@ export interface TechRecordGETHGVSkeleton {
   techRecord_trainGbWeight?: number | null;
   techRecord_tyreUseCode?: string | null;
   techRecord_vehicleClass_code?: null | string;
-  techRecord_vehicleClass_description: VehicleClassDescription;
+  techRecord_vehicleClass_description?: null | VehicleClassDescription;
   techRecord_vehicleConfiguration?: VehicleConfiguration | null;
   techRecord_approvalType?: ApprovalType | null;
   techRecord_approvalTypeNumber?: string | null;

--- a/types/v3/tech-record/get/hgv/testable/index.d.ts
+++ b/types/v3/tech-record/get/hgv/testable/index.d.ts
@@ -196,7 +196,7 @@ export interface TechRecordGETHGVTestable {
   techRecord_applicantDetails_postCode?: null | string;
   techRecord_applicantDetails_telephoneNumber?: null | string;
   techRecord_applicantDetails_emailAddress?: null | string;
-  techRecord_applicationId?: string;
+  techRecord_applicationId?: string | null;
   techRecord_axles?: null | HGVAxles[];
   techRecord_bodyType_code?: null | string;
   techRecord_bodyType_description?: null | string;

--- a/types/v3/tech-record/get/hgv/testable/index.d.ts
+++ b/types/v3/tech-record/get/hgv/testable/index.d.ts
@@ -200,6 +200,7 @@ export interface TechRecordGETHGVTestable {
   techRecord_axles?: null | HGVAxles[];
   techRecord_bodyType_code?: null | string;
   techRecord_bodyType_description?: null | string;
+  techRecord_brakes_antilockBrakingSystem?: string | null;
   techRecord_brakes_dtpNumber?: string | null;
   techRecord_brakes_loadSensingValve?: boolean | null;
   techRecord_conversionRefNo?: string | null;

--- a/types/v3/tech-record/get/hgv/testable/index.d.ts
+++ b/types/v3/tech-record/get/hgv/testable/index.d.ts
@@ -199,7 +199,7 @@ export interface TechRecordGETHGVTestable {
   techRecord_applicationId?: string;
   techRecord_axles?: null | HGVAxles[];
   techRecord_bodyType_code?: null | string;
-  techRecord_bodyType_description: string;
+  techRecord_bodyType_description?: null | string;
   techRecord_brakes_dtpNumber?: string | null;
   techRecord_brakes_loadSensingValve?: boolean | null;
   techRecord_conversionRefNo?: string | null;
@@ -235,7 +235,7 @@ export interface TechRecordGETHGVTestable {
   techRecord_microfilm_microfilmSerialNumber?: string | null;
   techRecord_model?: string | null;
   techRecord_numberOfWheelsDriven: number;
-  techRecord_noOfAxles: number;
+  techRecord_noOfAxles?: number | null;
   techRecord_notes?: string | null;
   techRecord_offRoad?: boolean | null;
   techRecord_plates?: null | HGVPlates[];

--- a/types/v3/tech-record/get/lgv/complete/index.d.ts
+++ b/types/v3/tech-record/get/lgv/complete/index.d.ts
@@ -62,7 +62,7 @@ export interface TechRecordGETLGVComplete {
   techRecord_lastUpdatedByName?: string | null;
   techRecord_manufactureYear?: number | null;
   techRecord_recordCompleteness?: null | string;
-  techRecord_noOfAxles: number;
+  techRecord_noOfAxles?: null | number;
   techRecord_notes?: null | string;
   techRecord_reasonForCreation: string;
   techRecord_regnDate?: string | null;

--- a/types/v3/tech-record/get/motorcycle/complete/index.d.ts
+++ b/types/v3/tech-record/get/motorcycle/complete/index.d.ts
@@ -81,7 +81,7 @@ export interface TechRecordGETMotorcycleComplete {
   techRecord_statusCode?: null | StatusCode;
   techRecord_vehicleClass_description: VehicleClassDescription;
   techRecord_vehicleClass_code: string;
-  techRecord_vehicleConfiguration: VehicleConfiguration;
+  techRecord_vehicleConfiguration?: null | VehicleConfiguration;
   techRecord_vehicleType: "motorcycle";
   vin: string;
   techRecord_numberOfWheelsDriven: number;

--- a/types/v3/tech-record/get/psv/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/psv/skeleton/index.d.ts
@@ -294,7 +294,7 @@ export interface TechRecordGETPSVSkeleton {
   techRecord_microfilm_microfilmSerialNumber?: string | null;
   techRecord_brakeCode?: string | null;
   createdTimestamp: string;
-  techRecord_applicationId?: string;
+  techRecord_applicationId?: string | null;
   secondaryVrms?: null | string[];
   techRecord_updateType?: null | string;
 }

--- a/types/v3/tech-record/put/car/complete/index.d.ts
+++ b/types/v3/tech-record/put/car/complete/index.d.ts
@@ -7,19 +7,6 @@
 
 export type StatusCode = "provisional" | "current" | "archived";
 export type VehicleSubclass = ("n" | "p" | "a" | "s" | "c" | "l" | "t" | "e" | "m" | "r" | "w")[];
-export type VehicleConfiguration =
-  | "rigid"
-  | "articulated"
-  | "centre axle drawbar"
-  | "semi-car transporter"
-  | "semi-trailer"
-  | "long semi-trailer"
-  | "low loader"
-  | "other"
-  | "drawbar"
-  | "four-in-line"
-  | "dolly"
-  | "full drawbar";
 export type EUVehicleCategory =
   | "m1"
   | "m2"
@@ -54,7 +41,6 @@ export interface TechRecordPUTCarComplete {
   techRecord_hiddenInVta?: null | boolean;
   techRecord_updateType?: null | string;
   secondaryVrms?: null | string[];
-  techRecord_vehicleConfiguration: VehicleConfiguration;
   techRecord_euVehicleCategory?: EUVehicleCategory | null;
   techRecord_applicantDetails_name?: string | null;
   techRecord_applicantDetails_address1?: null | string;

--- a/types/v3/tech-record/put/car/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/car/skeleton/index.d.ts
@@ -7,19 +7,6 @@
 
 export type StatusCode = "provisional" | "current" | "archived";
 export type VehicleSubclass = ("n" | "p" | "a" | "s" | "c" | "l" | "t" | "e" | "m" | "r" | "w")[];
-export type VehicleConfiguration =
-  | "rigid"
-  | "articulated"
-  | "centre axle drawbar"
-  | "semi-car transporter"
-  | "semi-trailer"
-  | "long semi-trailer"
-  | "low loader"
-  | "other"
-  | "drawbar"
-  | "four-in-line"
-  | "dolly"
-  | "full drawbar";
 export type EUVehicleCategory =
   | "m1"
   | "m2"
@@ -54,7 +41,6 @@ export interface TechRecordPUTCarSkeleton {
   techRecord_updateType?: null | string;
   secondaryVrms?: null | string[];
   techRecord_vehicleSubclass?: VehicleSubclass;
-  techRecord_vehicleConfiguration?: null | VehicleConfiguration;
   techRecord_euVehicleCategory?: EUVehicleCategory | null;
   techRecord_applicantDetails_name?: string | null;
   techRecord_applicantDetails_address1?: null | string;

--- a/types/v3/tech-record/put/hgv/complete/index.d.ts
+++ b/types/v3/tech-record/put/hgv/complete/index.d.ts
@@ -201,6 +201,7 @@ export interface TechRecordPUTHGVComplete {
   techRecord_axles: [HGVAxles, ...HGVAxles[]];
   techRecord_bodyType_code: string;
   techRecord_bodyType_description: string;
+  techRecord_brakes_antilockBrakingSystem?: string | null;
   techRecord_brakes_dtpNumber: string;
   techRecord_brakes_loadSensingValve?: boolean | null;
   techRecord_conversionRefNo?: string | null;

--- a/types/v3/tech-record/put/hgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/hgv/skeleton/index.d.ts
@@ -197,7 +197,7 @@ export interface TechRecordPUTHGVSkeleton {
   techRecord_applicationId?: string | null;
   techRecord_axles?: null | HGVAxles[];
   techRecord_bodyType_code?: null | string;
-  techRecord_bodyType_description: string;
+  techRecord_bodyType_description?: null | string;
   techRecord_brakes_dtpNumber?: string | null;
   techRecord_brakes_loadSensingValve?: boolean | null;
   techRecord_conversionRefNo?: string | null;
@@ -242,7 +242,7 @@ export interface TechRecordPUTHGVSkeleton {
   techRecord_trainEecWeight?: number | null;
   techRecord_trainGbWeight?: number | null;
   techRecord_tyreUseCode?: string | null;
-  techRecord_vehicleClass_description: VehicleClassDescription;
+  techRecord_vehicleClass_description?: null | VehicleClassDescription;
   techRecord_vehicleConfiguration?: VehicleConfiguration | null;
   techRecord_approvalType?: ApprovalType | null;
   techRecord_approvalTypeNumber?: string | null;

--- a/types/v3/tech-record/put/hgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/hgv/skeleton/index.d.ts
@@ -198,6 +198,7 @@ export interface TechRecordPUTHGVSkeleton {
   techRecord_axles?: null | HGVAxles[];
   techRecord_bodyType_code?: null | string;
   techRecord_bodyType_description?: null | string;
+  techRecord_brakes_antilockBrakingSystem?: string | null;
   techRecord_brakes_dtpNumber?: string | null;
   techRecord_brakes_loadSensingValve?: boolean | null;
   techRecord_conversionRefNo?: string | null;

--- a/types/v3/tech-record/put/hgv/testable/index.d.ts
+++ b/types/v3/tech-record/put/hgv/testable/index.d.ts
@@ -198,6 +198,7 @@ export interface TechRecordPUTHGVTestable {
   techRecord_axles?: HGVAxles[];
   techRecord_bodyType_code?: string;
   techRecord_bodyType_description?: string;
+  techRecord_brakes_antilockBrakingSystem?: string | null;
   techRecord_brakes_dtpNumber?: string | null;
   techRecord_brakes_loadSensingValve?: boolean | null;
   techRecord_conversionRefNo?: string | null;

--- a/types/v3/tech-record/put/hgv/testable/index.d.ts
+++ b/types/v3/tech-record/put/hgv/testable/index.d.ts
@@ -197,7 +197,7 @@ export interface TechRecordPUTHGVTestable {
   techRecord_applicationId?: null | string;
   techRecord_axles?: HGVAxles[];
   techRecord_bodyType_code?: string;
-  techRecord_bodyType_description: string;
+  techRecord_bodyType_description?: string;
   techRecord_brakes_dtpNumber?: string | null;
   techRecord_brakes_loadSensingValve?: boolean | null;
   techRecord_conversionRefNo?: string | null;
@@ -228,7 +228,7 @@ export interface TechRecordPUTHGVTestable {
   techRecord_microfilm_microfilmRollNumber?: string | null;
   techRecord_microfilm_microfilmSerialNumber?: string | null;
   techRecord_model?: string | null;
-  techRecord_noOfAxles: number;
+  techRecord_noOfAxles?: number | null;
   techRecord_notes?: string | null;
   techRecord_offRoad?: boolean | null;
   techRecord_plates?: HGVPlates[];

--- a/types/v3/tech-record/put/lgv/complete/index.d.ts
+++ b/types/v3/tech-record/put/lgv/complete/index.d.ts
@@ -44,7 +44,7 @@ export interface TechRecordPUTLGVComplete {
   techRecord_statusCode: StatusCode;
   techRecord_regnDate?: string | null;
   techRecord_manufactureYear?: number | null;
-  techRecord_noOfAxles: number;
+  techRecord_noOfAxles?: number | null;
   techRecord_notes?: string;
   techRecord_vehicleSubclass: VehicleSubclass;
   techRecord_hiddenInVta?: boolean;

--- a/types/v3/tech-record/put/motorcycle/complete/index.d.ts
+++ b/types/v3/tech-record/put/motorcycle/complete/index.d.ts
@@ -73,7 +73,7 @@ export interface TechRecordPUTMotorcycleComplete {
   techRecord_regnDate?: string | null;
   techRecord_statusCode: StatusCode;
   techRecord_vehicleClass_description: VehicleClassDescription;
-  techRecord_vehicleConfiguration: VehicleConfiguration;
+  techRecord_vehicleConfiguration?: null | VehicleConfiguration;
   techRecord_vehicleType: "motorcycle";
   vin: string;
   techRecord_numberOfWheelsDriven: number;

--- a/types/v3/tech-record/put/psv/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/psv/skeleton/index.d.ts
@@ -282,7 +282,7 @@ export interface TechRecordPUTPSVSkeleton {
   techRecord_microfilm_microfilmRollNumber?: string | null;
   techRecord_microfilm_microfilmSerialNumber?: string | null;
   techRecord_brakeCode?: string | null;
-  techRecord_applicationId?: string;
+  techRecord_applicationId?: string | null;
   secondaryVrms?: string[];
   techRecord_updateType?: null | string;
 }

--- a/types/v3/tech-record/put/psv/testable/index.d.ts
+++ b/types/v3/tech-record/put/psv/testable/index.d.ts
@@ -264,7 +264,7 @@ export interface TechRecordPUTPSVTestable {
   techRecord_applicantDetails_postCode?: null | string;
   techRecord_applicantDetails_telephoneNumber?: null | string;
   techRecord_applicantDetails_emailAddress?: null | string;
-  techRecord_brakes_dtpNumber: string;
+  techRecord_brakes_dtpNumber?: string | null;
   techRecord_brakes_brakeCode?: string | null;
   techRecord_brakes_brakeCodeOriginal?: string | null;
   techRecord_brakes_dataTrBrakeOne?: string | null;

--- a/types/v3/tech-record/put/small trl/complete/index.d.ts
+++ b/types/v3/tech-record/put/small trl/complete/index.d.ts
@@ -50,7 +50,7 @@ export interface TechRecordPUTSmallTRLComplete {
   techRecord_statusCode: StatusCode;
   techRecord_vehicleClass_description: VehicleClassDescription;
   techRecord_vehicleConfiguration: VehicleConfiguration;
-  techRecord_vehicleSubclass?: null | VehicleSubclass;
+  techRecord_vehicleSubclass?: VehicleSubclass;
   techRecord_vehicleType: "trl";
   vin: string;
   trailerId?: string;

--- a/types/v3/tech-record/put/trl/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/trl/skeleton/index.d.ts
@@ -216,7 +216,7 @@ export interface TechRecordPUTTRLSkeleton {
   techRecord_applicantDetails_postCode?: null | string;
   techRecord_applicantDetails_telephoneNumber?: null | string;
   techRecord_applicantDetails_emailAddress?: null | string;
-  techRecord_applicationId?: string;
+  techRecord_applicationId?: string | null;
   techRecord_authIntoService?: string | null;
   techRecord_batchId?: string | null;
   techRecord_bodyType_code: string;


### PR DESCRIPTION
## Ticket title

Reverts last two commits to align with version currently in production.

Allows null to application id.

[CB2-9196](https://dvsa.atlassian.net/browse/CB2-9196)

<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

-

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
