### PR TITLE
patch(cb2-9289): update adr validation, add reverted changes

### DIFF
--- a/json-definitions/v3/tech-record/get/hgv/complete/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/complete/index.json
@@ -259,7 +259,7 @@
         "string",
         "null"
       ],
-      "maxLength": 30
+      "maxLength": 65
     },
     "techRecord_adrDetails_tank_tankDetails_tankCode": {
       "type": [

--- a/json-definitions/v3/tech-record/get/hgv/complete/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/complete/index.json
@@ -492,12 +492,6 @@
     "techRecord_bodyType_description": {
       "type": "string"
     },
-    "techRecord_brakes_antilockBrakingSystem": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
     "techRecord_brakes_dtpNumber": {
       "type": "string",
       "maxLength": 6

--- a/json-definitions/v3/tech-record/get/hgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/skeleton/index.json
@@ -13,6 +13,8 @@
     "techRecord_recordCompleteness",
     "techRecord_statusCode",
     "techRecord_vehicleType",
+    "techRecord_vehicleClass_description",
+    "techRecord_bodyType_description",
     "primaryVrm",
     "vin"
   ],
@@ -489,16 +491,7 @@
       ]
     },
     "techRecord_bodyType_description": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "techRecord_brakes_antilockBrakingSystem": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": "string"
     },
     "techRecord_brakes_dtpNumber": {
       "type": [
@@ -913,14 +906,7 @@
       ]
     },
     "techRecord_vehicleClass_description": {
-      "anyOf": [
-        {
-          "type": "null"
-        },
-        {
-          "$ref": "../../../enums/vehicleClassDescription.ignore.json"
-        }
-      ]
+        "$ref": "../../../enums/vehicleClassDescription.ignore.json" 
     },
     "techRecord_vehicleConfiguration": {
       "anyOf": [

--- a/json-definitions/v3/tech-record/get/hgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/skeleton/index.json
@@ -227,7 +227,7 @@
         "string",
         "null"
       ],
-      "maxLength": 30
+      "maxLength": 65
     },
     "techRecord_adrDetails_tank_tankDetails_tankCode": {
       "type": [

--- a/json-definitions/v3/tech-record/get/hgv/testable/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/testable/index.json
@@ -18,7 +18,9 @@
     "techRecord_vehicleConfiguration",
     "techRecord_vehicleClass_code",
     "techRecord_vehicleClass_description",
-    "techRecord_numberOfWheelsDriven"
+    "techRecord_numberOfWheelsDriven",
+    "techRecord_noOfAxles",
+    "techRecord_bodyType_description"
   ],
   "properties": {
     "secondaryVrms": {
@@ -493,16 +495,7 @@
       ]
     },
     "techRecord_bodyType_description": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "techRecord_brakes_antilockBrakingSystem": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": "string"
     },
     "techRecord_brakes_dtpNumber": {
       "type": [
@@ -768,16 +761,9 @@
       "type": "integer"
     },
     "techRecord_noOfAxles": {
-      "anyOf": [
-        {
-          "type": "integer",
-          "minimum": 0,
-          "maximum": 99
-        },
-        {
-          "type": "null"
-        }
-      ]
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 99
     },
     "techRecord_notes": {
       "type": [

--- a/json-definitions/v3/tech-record/get/hgv/testable/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/testable/index.json
@@ -231,7 +231,7 @@
         "string",
         "null"
       ],
-      "maxLength": 30
+      "maxLength": 65
     },
     "techRecord_adrDetails_tank_tankDetails_tankCode": {
       "type": [

--- a/json-definitions/v3/tech-record/get/lgv/complete/index.json
+++ b/json-definitions/v3/tech-record/get/lgv/complete/index.json
@@ -12,6 +12,7 @@
     "techRecord_createdById",
     "techRecord_createdByName",
     "techRecord_reasonForCreation",
+    "techRecord_noOfAxles",
     "techRecord_vehicleConfiguration"
   ],
   "properties": {
@@ -141,10 +142,7 @@
       ]
     },
     "techRecord_noOfAxles": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": "integer"
     },
     "techRecord_notes": {
       "type": [

--- a/json-definitions/v3/tech-record/get/motorcycle/complete/index.json
+++ b/json-definitions/v3/tech-record/get/motorcycle/complete/index.json
@@ -15,7 +15,8 @@
     "techRecord_vehicleType",
     "createdTimestamp",
     "partialVin",
-    "vin"
+    "vin",
+    "techRecord_vehicleConfiguration"
   ],
   "properties": {
     "secondaryVrms": {
@@ -190,15 +191,8 @@
       "type": "string"
     },
     "techRecord_vehicleConfiguration": {
-      "anyOf": [
-        {
-          "type": "null"
-        },
-        {
-          "$ref": "../../../enums/vehicleConfiguration.ignore.json"
-        }
-      ]
-    },
+      "$ref": "../../../enums/vehicleConfiguration.ignore.json"
+    },  
     "techRecord_vehicleType": {
       "const": "motorcycle"
     },

--- a/json-definitions/v3/tech-record/get/trl/complete/index.json
+++ b/json-definitions/v3/tech-record/get/trl/complete/index.json
@@ -241,7 +241,7 @@
         "string",
         "null"
       ],
-      "maxLength": 30
+      "maxLength": 65
     },
     "techRecord_adrDetails_tank_tankDetails_tankCode": {
       "type": [

--- a/json-definitions/v3/tech-record/get/trl/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/trl/skeleton/index.json
@@ -221,7 +221,7 @@
         "string",
         "null"
       ],
-      "maxLength": 30
+      "maxLength": 65
     },
     "techRecord_adrDetails_tank_tankDetails_tankCode": {
       "type": [

--- a/json-definitions/v3/tech-record/get/trl/testable/index.json
+++ b/json-definitions/v3/tech-record/get/trl/testable/index.json
@@ -223,7 +223,7 @@
         "string",
         "null"
       ],
-      "maxLength": 30
+      "maxLength": 65
     },
     "techRecord_adrDetails_tank_tankDetails_tankCode": {
       "type": [

--- a/json-definitions/v3/tech-record/put/hgv/complete/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/complete/index.json
@@ -480,12 +480,6 @@
     "techRecord_bodyType_description": {
       "type": "string"
     },
-    "techRecord_brakes_antilockBrakingSystem": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
     "techRecord_brakes_dtpNumber": {
       "type": "string",
       "maxLength": 6

--- a/json-definitions/v3/tech-record/put/hgv/complete/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/complete/index.json
@@ -247,7 +247,7 @@
         "string",
         "null"
       ],
-      "maxLength": 30
+      "maxLength": 65
     },
     "techRecord_adrDetails_tank_tankDetails_tankCode": {
       "type": [

--- a/json-definitions/v3/tech-record/put/hgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/skeleton/index.json
@@ -213,7 +213,7 @@
         "string",
         "null"
       ],
-      "maxLength": 30
+      "maxLength": 65
     },
     "techRecord_adrDetails_tank_tankDetails_tankCode": {
       "type": [

--- a/json-definitions/v3/tech-record/put/hgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/skeleton/index.json
@@ -6,6 +6,8 @@
     "techRecord_reasonForCreation",
     "techRecord_statusCode",
     "techRecord_vehicleType",
+    "techRecord_vehicleClass_description",
+    "techRecord_bodyType_description",
     "vin"
   ],
   "properties": {
@@ -475,16 +477,7 @@
       ]
     },
     "techRecord_bodyType_description": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "techRecord_brakes_antilockBrakingSystem": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": "string"
     },
     "techRecord_brakes_dtpNumber": {
       "type": [
@@ -872,14 +865,7 @@
       "maxLength": 2
     },
     "techRecord_vehicleClass_description": {
-      "anyOf": [
-        {
-          "type": "null"
-        },
-        {
-          "$ref": "../../../enums/vehicleClassDescription.ignore.json"
-        }
-      ]
+      "$ref": "../../../enums/vehicleClassDescription.ignore.json"
     },
     "techRecord_vehicleConfiguration": {
       "anyOf": [

--- a/json-definitions/v3/tech-record/put/hgv/testable/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/testable/index.json
@@ -8,7 +8,9 @@
     "techRecord_vehicleType",
     "vin",
     "techRecord_vehicleConfiguration",
-    "techRecord_vehicleClass_description"
+    "techRecord_vehicleClass_description",
+    "techRecord_noOfAxles",
+    "techRecord_bodyType_description"
   ],
   "properties": {
     "secondaryVrms": {
@@ -473,12 +475,6 @@
     "techRecord_bodyType_description": {
       "type": "string"
     },
-    "techRecord_brakes_antilockBrakingSystem": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
     "techRecord_brakes_dtpNumber": {
       "type": [
         "string",
@@ -728,16 +724,9 @@
       "maxLength": 30
     },
     "techRecord_noOfAxles": {
-      "anyOf": [
-        {
-          "type": "integer",
-          "minimum": 0,
-          "maximum": 99
-        },
-        {
-          "type": "null"
-        }
-      ]
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 99
     },
     "techRecord_notes": {
       "type": [

--- a/json-definitions/v3/tech-record/put/hgv/testable/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/testable/index.json
@@ -215,7 +215,7 @@
         "string",
         "null"
       ],
-      "maxLength": 30
+      "maxLength": 65
     },
     "techRecord_adrDetails_tank_tankDetails_tankCode": {
       "type": [

--- a/json-definitions/v3/tech-record/put/lgv/complete/index.json
+++ b/json-definitions/v3/tech-record/put/lgv/complete/index.json
@@ -8,6 +8,7 @@
     "techRecord_vehicleType",
     "techRecord_statusCode",
     "techRecord_reasonForCreation",
+    "techRecord_noOfAxles",
     "techRecord_vehicleConfiguration"
   ],
   "properties": {
@@ -75,10 +76,7 @@
       "type": ["integer", "null"]
     },
     "techRecord_noOfAxles": {
-      "type": [
-        "integer",
-        "null"
-      ]
+      "type": "integer"
     },
     "techRecord_notes": {
       "type": "string"

--- a/json-definitions/v3/tech-record/put/psv/testable/index.json
+++ b/json-definitions/v3/tech-record/put/psv/testable/index.json
@@ -12,7 +12,8 @@
     "techRecord_noOfAxles",
     "techRecord_statusCode",
     "techRecord_reasonForCreation",
-    "techRecord_vehicleClass_description"
+    "techRecord_vehicleClass_description",
+    "techRecord_brakes_dtpNumber"
   ],
   "properties": {
     "vin": {
@@ -669,10 +670,7 @@
       "maxLength": 255
     },
     "techRecord_brakes_dtpNumber": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": "string",
       "maxLength": 6
     },
     "techRecord_brakes_brakeCode": {

--- a/json-definitions/v3/tech-record/put/small trl/complete/index.json
+++ b/json-definitions/v3/tech-record/put/small trl/complete/index.json
@@ -99,7 +99,14 @@
             "$ref": "../../../enums/vehicleConfiguration.ignore.json"
         },
         "techRecord_vehicleSubclass": {
-            "$ref": "../../../enums/vehicleSubclass.ignore.json"
+            "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "../../../enums/vehicleSubclass.ignore.json"
+                }
+              ]
         },
         "techRecord_vehicleType": {
             "const": "trl"

--- a/json-definitions/v3/tech-record/put/trl/complete/index.json
+++ b/json-definitions/v3/tech-record/put/trl/complete/index.json
@@ -230,7 +230,7 @@
         "string",
         "null"
       ],
-      "maxLength": 30
+      "maxLength": 65
     },
     "techRecord_adrDetails_tank_tankDetails_tankCode": {
       "type": [

--- a/json-definitions/v3/tech-record/put/trl/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/trl/skeleton/index.json
@@ -245,7 +245,7 @@
         "string",
         "null"
       ],
-      "maxLength": 30
+      "maxLength": 65
     },
     "techRecord_adrDetails_tank_tankDetails_tankCode": {
       "type": [

--- a/json-definitions/v3/tech-record/put/trl/testable/index.json
+++ b/json-definitions/v3/tech-record/put/trl/testable/index.json
@@ -247,7 +247,7 @@
         "string",
         "null"
       ],
-      "maxLength": 30
+      "maxLength": 65
     },
     "techRecord_adrDetails_tank_tankDetails_tankCode": {
       "type": [

--- a/json-schemas/v3/tech-record/get/hgv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/complete/index.json
@@ -507,12 +507,6 @@
 		"techRecord_bodyType_description": {
 			"type": "string"
 		},
-		"techRecord_brakes_antilockBrakingSystem": {
-			"type": [
-				"string",
-				"null"
-			]
-		},
 		"techRecord_brakes_dtpNumber": {
 			"type": "string",
 			"maxLength": 6

--- a/json-schemas/v3/tech-record/get/hgv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/complete/index.json
@@ -259,7 +259,7 @@
 				"string",
 				"null"
 			],
-			"maxLength": 30
+			"maxLength": 65
 		},
 		"techRecord_adrDetails_tank_tankDetails_tankCode": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/hgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/skeleton/index.json
@@ -13,6 +13,8 @@
 		"techRecord_recordCompleteness",
 		"techRecord_statusCode",
 		"techRecord_vehicleType",
+		"techRecord_vehicleClass_description",
+		"techRecord_bodyType_description",
 		"primaryVrm",
 		"vin"
 	],
@@ -504,16 +506,7 @@
 			]
 		},
 		"techRecord_bodyType_description": {
-			"type": [
-				"null",
-				"string"
-			]
-		},
-		"techRecord_brakes_antilockBrakingSystem": {
-			"type": [
-				"string",
-				"null"
-			]
+			"type": "string"
 		},
 		"techRecord_brakes_dtpNumber": {
 			"type": [
@@ -1034,27 +1027,20 @@
 			]
 		},
 		"techRecord_vehicleClass_description": {
-			"anyOf": [
-				{
-					"type": "null"
-				},
-				{
-					"title": "Vehicle Class Description",
-					"type": "string",
-					"enum": [
-						"motorbikes over 200cc or with a sidecar",
-						"not applicable",
-						"small psv (ie: less than or equal to 22 seats)",
-						"motorbikes up to 200cc",
-						"trailer",
-						"large psv(ie: greater than 23 seats)",
-						"3 wheelers",
-						"heavy goods vehicle",
-						"MOT class 4",
-						"MOT class 7",
-						"MOT class 5"
-					]
-				}
+			"title": "Vehicle Class Description",
+			"type": "string",
+			"enum": [
+				"motorbikes over 200cc or with a sidecar",
+				"not applicable",
+				"small psv (ie: less than or equal to 22 seats)",
+				"motorbikes up to 200cc",
+				"trailer",
+				"large psv(ie: greater than 23 seats)",
+				"3 wheelers",
+				"heavy goods vehicle",
+				"MOT class 4",
+				"MOT class 7",
+				"MOT class 5"
 			]
 		},
 		"techRecord_vehicleConfiguration": {

--- a/json-schemas/v3/tech-record/get/hgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/skeleton/index.json
@@ -227,7 +227,7 @@
 				"string",
 				"null"
 			],
-			"maxLength": 30
+			"maxLength": 65
 		},
 		"techRecord_adrDetails_tank_tankDetails_tankCode": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/testable/index.json
@@ -18,7 +18,9 @@
 		"techRecord_vehicleConfiguration",
 		"techRecord_vehicleClass_code",
 		"techRecord_vehicleClass_description",
-		"techRecord_numberOfWheelsDriven"
+		"techRecord_numberOfWheelsDriven",
+		"techRecord_noOfAxles",
+		"techRecord_bodyType_description"
 	],
 	"properties": {
 		"secondaryVrms": {
@@ -508,16 +510,7 @@
 			]
 		},
 		"techRecord_bodyType_description": {
-			"type": [
-				"null",
-				"string"
-			]
-		},
-		"techRecord_brakes_antilockBrakingSystem": {
-			"type": [
-				"string",
-				"null"
-			]
+			"type": "string"
 		},
 		"techRecord_brakes_dtpNumber": {
 			"type": [
@@ -874,16 +867,9 @@
 			"type": "integer"
 		},
 		"techRecord_noOfAxles": {
-			"anyOf": [
-				{
-					"type": "integer",
-					"minimum": 0,
-					"maximum": 99
-				},
-				{
-					"type": "null"
-				}
-			]
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 99
 		},
 		"techRecord_notes": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/testable/index.json
@@ -231,7 +231,7 @@
 				"string",
 				"null"
 			],
-			"maxLength": 30
+			"maxLength": 65
 		},
 		"techRecord_adrDetails_tank_tankDetails_tankCode": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/lgv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/lgv/complete/index.json
@@ -12,6 +12,7 @@
 		"techRecord_createdById",
 		"techRecord_createdByName",
 		"techRecord_reasonForCreation",
+		"techRecord_noOfAxles",
 		"techRecord_vehicleConfiguration"
 	],
 	"properties": {
@@ -162,10 +163,7 @@
 			]
 		},
 		"techRecord_noOfAxles": {
-			"type": [
-				"null",
-				"integer"
-			]
+			"type": "integer"
 		},
 		"techRecord_notes": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/motorcycle/complete/index.json
+++ b/json-schemas/v3/tech-record/get/motorcycle/complete/index.json
@@ -15,7 +15,8 @@
 		"techRecord_vehicleType",
 		"createdTimestamp",
 		"partialVin",
-		"vin"
+		"vin",
+		"techRecord_vehicleConfiguration"
 	],
 	"properties": {
 		"secondaryVrms": {
@@ -231,28 +232,21 @@
 			"type": "string"
 		},
 		"techRecord_vehicleConfiguration": {
-			"anyOf": [
-				{
-					"type": "null"
-				},
-				{
-					"title": "Vehicle Configuration",
-					"type": "string",
-					"enum": [
-						"rigid",
-						"articulated",
-						"centre axle drawbar",
-						"semi-car transporter",
-						"semi-trailer",
-						"long semi-trailer",
-						"low loader",
-						"other",
-						"drawbar",
-						"four-in-line",
-						"dolly",
-						"full drawbar"
-					]
-				}
+			"title": "Vehicle Configuration",
+			"type": "string",
+			"enum": [
+				"rigid",
+				"articulated",
+				"centre axle drawbar",
+				"semi-car transporter",
+				"semi-trailer",
+				"long semi-trailer",
+				"low loader",
+				"other",
+				"drawbar",
+				"four-in-line",
+				"dolly",
+				"full drawbar"
 			]
 		},
 		"techRecord_vehicleType": {

--- a/json-schemas/v3/tech-record/get/trl/complete/index.json
+++ b/json-schemas/v3/tech-record/get/trl/complete/index.json
@@ -241,7 +241,7 @@
 				"string",
 				"null"
 			],
-			"maxLength": 30
+			"maxLength": 65
 		},
 		"techRecord_adrDetails_tank_tankDetails_tankCode": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/trl/skeleton/index.json
@@ -221,7 +221,7 @@
 				"string",
 				"null"
 			],
-			"maxLength": 30
+			"maxLength": 65
 		},
 		"techRecord_adrDetails_tank_tankDetails_tankCode": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/trl/testable/index.json
+++ b/json-schemas/v3/tech-record/get/trl/testable/index.json
@@ -223,7 +223,7 @@
 				"string",
 				"null"
 			],
-			"maxLength": 30
+			"maxLength": 65
 		},
 		"techRecord_adrDetails_tank_tankDetails_tankCode": {
 			"type": [

--- a/json-schemas/v3/tech-record/put/hgv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/complete/index.json
@@ -247,7 +247,7 @@
 				"string",
 				"null"
 			],
-			"maxLength": 30
+			"maxLength": 65
 		},
 		"techRecord_adrDetails_tank_tankDetails_tankCode": {
 			"type": [

--- a/json-schemas/v3/tech-record/put/hgv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/complete/index.json
@@ -495,12 +495,6 @@
 		"techRecord_bodyType_description": {
 			"type": "string"
 		},
-		"techRecord_brakes_antilockBrakingSystem": {
-			"type": [
-				"string",
-				"null"
-			]
-		},
 		"techRecord_brakes_dtpNumber": {
 			"type": "string",
 			"maxLength": 6

--- a/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
@@ -213,7 +213,7 @@
 				"string",
 				"null"
 			],
-			"maxLength": 30
+			"maxLength": 65
 		},
 		"techRecord_adrDetails_tank_tankDetails_tankCode": {
 			"type": [

--- a/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
@@ -6,6 +6,8 @@
 		"techRecord_reasonForCreation",
 		"techRecord_statusCode",
 		"techRecord_vehicleType",
+		"techRecord_vehicleClass_description",
+		"techRecord_bodyType_description",
 		"vin"
 	],
 	"properties": {
@@ -490,16 +492,7 @@
 			]
 		},
 		"techRecord_bodyType_description": {
-			"type": [
-				"null",
-				"string"
-			]
-		},
-		"techRecord_brakes_antilockBrakingSystem": {
-			"type": [
-				"string",
-				"null"
-			]
+			"type": "string"
 		},
 		"techRecord_brakes_dtpNumber": {
 			"type": [
@@ -993,27 +986,20 @@
 			"maxLength": 2
 		},
 		"techRecord_vehicleClass_description": {
-			"anyOf": [
-				{
-					"type": "null"
-				},
-				{
-					"title": "Vehicle Class Description",
-					"type": "string",
-					"enum": [
-						"motorbikes over 200cc or with a sidecar",
-						"not applicable",
-						"small psv (ie: less than or equal to 22 seats)",
-						"motorbikes up to 200cc",
-						"trailer",
-						"large psv(ie: greater than 23 seats)",
-						"3 wheelers",
-						"heavy goods vehicle",
-						"MOT class 4",
-						"MOT class 7",
-						"MOT class 5"
-					]
-				}
+			"title": "Vehicle Class Description",
+			"type": "string",
+			"enum": [
+				"motorbikes over 200cc or with a sidecar",
+				"not applicable",
+				"small psv (ie: less than or equal to 22 seats)",
+				"motorbikes up to 200cc",
+				"trailer",
+				"large psv(ie: greater than 23 seats)",
+				"3 wheelers",
+				"heavy goods vehicle",
+				"MOT class 4",
+				"MOT class 7",
+				"MOT class 5"
 			]
 		},
 		"techRecord_vehicleConfiguration": {

--- a/json-schemas/v3/tech-record/put/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/testable/index.json
@@ -8,7 +8,9 @@
 		"techRecord_vehicleType",
 		"vin",
 		"techRecord_vehicleConfiguration",
-		"techRecord_vehicleClass_description"
+		"techRecord_vehicleClass_description",
+		"techRecord_noOfAxles",
+		"techRecord_bodyType_description"
 	],
 	"properties": {
 		"secondaryVrms": {
@@ -488,12 +490,6 @@
 		"techRecord_bodyType_description": {
 			"type": "string"
 		},
-		"techRecord_brakes_antilockBrakingSystem": {
-			"type": [
-				"string",
-				"null"
-			]
-		},
 		"techRecord_brakes_dtpNumber": {
 			"type": [
 				"string",
@@ -834,16 +830,9 @@
 			"maxLength": 30
 		},
 		"techRecord_noOfAxles": {
-			"anyOf": [
-				{
-					"type": "integer",
-					"minimum": 0,
-					"maximum": 99
-				},
-				{
-					"type": "null"
-				}
-			]
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 99
 		},
 		"techRecord_notes": {
 			"type": [

--- a/json-schemas/v3/tech-record/put/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/testable/index.json
@@ -215,7 +215,7 @@
 				"string",
 				"null"
 			],
-			"maxLength": 30
+			"maxLength": 65
 		},
 		"techRecord_adrDetails_tank_tankDetails_tankCode": {
 			"type": [

--- a/json-schemas/v3/tech-record/put/lgv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/lgv/complete/index.json
@@ -8,6 +8,7 @@
 		"techRecord_vehicleType",
 		"techRecord_statusCode",
 		"techRecord_reasonForCreation",
+		"techRecord_noOfAxles",
 		"techRecord_vehicleConfiguration"
 	],
 	"properties": {
@@ -132,10 +133,7 @@
 			]
 		},
 		"techRecord_noOfAxles": {
-			"type": [
-				"integer",
-				"null"
-			]
+			"type": "integer"
 		},
 		"techRecord_notes": {
 			"type": "string"

--- a/json-schemas/v3/tech-record/put/psv/testable/index.json
+++ b/json-schemas/v3/tech-record/put/psv/testable/index.json
@@ -12,7 +12,8 @@
 		"techRecord_noOfAxles",
 		"techRecord_statusCode",
 		"techRecord_reasonForCreation",
-		"techRecord_vehicleClass_description"
+		"techRecord_vehicleClass_description",
+		"techRecord_brakes_dtpNumber"
 	],
 	"properties": {
 		"vin": {
@@ -818,10 +819,7 @@
 			"maxLength": 255
 		},
 		"techRecord_brakes_dtpNumber": {
-			"type": [
-				"string",
-				"null"
-			],
+			"type": "string",
 			"maxLength": 6
 		},
 		"techRecord_brakes_brakeCode": {

--- a/json-schemas/v3/tech-record/put/small trl/complete/index.json
+++ b/json-schemas/v3/tech-record/put/small trl/complete/index.json
@@ -134,24 +134,31 @@
 			]
 		},
 		"techRecord_vehicleSubclass": {
-			"title": "Vehicle Subclass",
-			"type": "array",
-			"items": {
-				"type": "string",
-				"enum": [
-					"n",
-					"p",
-					"a",
-					"s",
-					"c",
-					"l",
-					"t",
-					"e",
-					"m",
-					"r",
-					"w"
-				]
-			}
+			"anyOf": [
+				{
+					"type": "null"
+				},
+				{
+					"title": "Vehicle Subclass",
+					"type": "array",
+					"items": {
+						"type": "string",
+						"enum": [
+							"n",
+							"p",
+							"a",
+							"s",
+							"c",
+							"l",
+							"t",
+							"e",
+							"m",
+							"r",
+							"w"
+						]
+					}
+				}
+			]
 		},
 		"techRecord_vehicleType": {
 			"const": "trl"

--- a/json-schemas/v3/tech-record/put/trl/complete/index.json
+++ b/json-schemas/v3/tech-record/put/trl/complete/index.json
@@ -230,7 +230,7 @@
 				"string",
 				"null"
 			],
-			"maxLength": 30
+			"maxLength": 65
 		},
 		"techRecord_adrDetails_tank_tankDetails_tankCode": {
 			"type": [

--- a/json-schemas/v3/tech-record/put/trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/trl/skeleton/index.json
@@ -262,7 +262,7 @@
 				"string",
 				"null"
 			],
-			"maxLength": 30
+			"maxLength": 65
 		},
 		"techRecord_adrDetails_tank_tankDetails_tankCode": {
 			"type": [

--- a/json-schemas/v3/tech-record/put/trl/testable/index.json
+++ b/json-schemas/v3/tech-record/put/trl/testable/index.json
@@ -264,7 +264,7 @@
 				"string",
 				"null"
 			],
-			"maxLength": 30
+			"maxLength": 65
 		},
 		"techRecord_adrDetails_tank_tankDetails_tankCode": {
 			"type": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.48",
+  "version": "3.0.49",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "3.0.48",
+      "version": "3.0.49",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.0.48",
+  "version": "3.0.49",
   "description": "type definitions for cvs vta application",
   "main": "index.js",
   "repository": {

--- a/tests/resources/data/hgvSkeleton.json
+++ b/tests/resources/data/hgvSkeleton.json
@@ -142,7 +142,10 @@
     "techRecord_recordCompleteness": "skeleton",
     "techRecord_statusCode": "provisional",
     "techRecord_vehicleType": "hgv",
-    "vin": "DANHGV1231"
+    "vin": "DANHGV1231",
+    "techRecord_bodyType_code": "u",
+    "techRecord_bodyType_description": "artic",
+    "techRecord_vehicleClass_description": "heavy goods vehicle"
   },
   {
     "createdTimestamp": "2023-06-16T15:17:21.819Z",

--- a/tests/resources/data/hgvTestable.json
+++ b/tests/resources/data/hgvTestable.json
@@ -232,6 +232,8 @@
     "techRecord_vehicleClass_description": "heavy goods vehicle",
     "techRecord_vehicleConfiguration": "articulated",
     "techRecord_vehicleType": "hgv",
+    "techRecord_bodyType_description": "artic",
+    "techRecord_noOfAxles": 2,
     "vin": "GB01DAN0000000001"
   },
   {

--- a/types/v3/tech-record/get/hgv/complete/index.d.ts
+++ b/types/v3/tech-record/get/hgv/complete/index.d.ts
@@ -203,7 +203,6 @@ export interface TechRecordGETHGVComplete {
   techRecord_axles: [HGVAxles, ...HGVAxles[]];
   techRecord_bodyType_code: string;
   techRecord_bodyType_description: string;
-  techRecord_brakes_antilockBrakingSystem?: string | null;
   techRecord_brakes_dtpNumber: string;
   techRecord_brakes_loadSensingValve?: boolean | null;
   techRecord_conversionRefNo?: string | null;

--- a/types/v3/tech-record/get/hgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/hgv/skeleton/index.d.ts
@@ -199,8 +199,7 @@ export interface TechRecordGETHGVSkeleton {
   techRecord_applicationId?: string | null;
   techRecord_axles?: null | HGVAxles[];
   techRecord_bodyType_code?: null | string;
-  techRecord_bodyType_description?: null | string;
-  techRecord_brakes_antilockBrakingSystem?: string | null;
+  techRecord_bodyType_description: string;
   techRecord_brakes_dtpNumber?: string | null;
   techRecord_brakes_loadSensingValve?: boolean | null;
   techRecord_conversionRefNo?: string | null;
@@ -252,7 +251,7 @@ export interface TechRecordGETHGVSkeleton {
   techRecord_trainGbWeight?: number | null;
   techRecord_tyreUseCode?: string | null;
   techRecord_vehicleClass_code?: null | string;
-  techRecord_vehicleClass_description?: null | VehicleClassDescription;
+  techRecord_vehicleClass_description: VehicleClassDescription;
   techRecord_vehicleConfiguration?: VehicleConfiguration | null;
   techRecord_approvalType?: ApprovalType | null;
   techRecord_approvalTypeNumber?: string | null;

--- a/types/v3/tech-record/get/hgv/testable/index.d.ts
+++ b/types/v3/tech-record/get/hgv/testable/index.d.ts
@@ -199,8 +199,7 @@ export interface TechRecordGETHGVTestable {
   techRecord_applicationId?: string | null;
   techRecord_axles?: null | HGVAxles[];
   techRecord_bodyType_code?: null | string;
-  techRecord_bodyType_description?: null | string;
-  techRecord_brakes_antilockBrakingSystem?: string | null;
+  techRecord_bodyType_description: string;
   techRecord_brakes_dtpNumber?: string | null;
   techRecord_brakes_loadSensingValve?: boolean | null;
   techRecord_conversionRefNo?: string | null;
@@ -236,7 +235,7 @@ export interface TechRecordGETHGVTestable {
   techRecord_microfilm_microfilmSerialNumber?: string | null;
   techRecord_model?: string | null;
   techRecord_numberOfWheelsDriven: number;
-  techRecord_noOfAxles?: number | null;
+  techRecord_noOfAxles: number;
   techRecord_notes?: string | null;
   techRecord_offRoad?: boolean | null;
   techRecord_plates?: null | HGVPlates[];

--- a/types/v3/tech-record/get/lgv/complete/index.d.ts
+++ b/types/v3/tech-record/get/lgv/complete/index.d.ts
@@ -62,7 +62,7 @@ export interface TechRecordGETLGVComplete {
   techRecord_lastUpdatedByName?: string | null;
   techRecord_manufactureYear?: number | null;
   techRecord_recordCompleteness?: null | string;
-  techRecord_noOfAxles?: null | number;
+  techRecord_noOfAxles: number;
   techRecord_notes?: null | string;
   techRecord_reasonForCreation: string;
   techRecord_regnDate?: string | null;

--- a/types/v3/tech-record/get/motorcycle/complete/index.d.ts
+++ b/types/v3/tech-record/get/motorcycle/complete/index.d.ts
@@ -81,7 +81,7 @@ export interface TechRecordGETMotorcycleComplete {
   techRecord_statusCode?: null | StatusCode;
   techRecord_vehicleClass_description: VehicleClassDescription;
   techRecord_vehicleClass_code: string;
-  techRecord_vehicleConfiguration?: null | VehicleConfiguration;
+  techRecord_vehicleConfiguration: VehicleConfiguration;
   techRecord_vehicleType: "motorcycle";
   vin: string;
   techRecord_numberOfWheelsDriven: number;

--- a/types/v3/tech-record/put/hgv/complete/index.d.ts
+++ b/types/v3/tech-record/put/hgv/complete/index.d.ts
@@ -201,7 +201,6 @@ export interface TechRecordPUTHGVComplete {
   techRecord_axles: [HGVAxles, ...HGVAxles[]];
   techRecord_bodyType_code: string;
   techRecord_bodyType_description: string;
-  techRecord_brakes_antilockBrakingSystem?: string | null;
   techRecord_brakes_dtpNumber: string;
   techRecord_brakes_loadSensingValve?: boolean | null;
   techRecord_conversionRefNo?: string | null;

--- a/types/v3/tech-record/put/hgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/hgv/skeleton/index.d.ts
@@ -197,8 +197,7 @@ export interface TechRecordPUTHGVSkeleton {
   techRecord_applicationId?: string | null;
   techRecord_axles?: null | HGVAxles[];
   techRecord_bodyType_code?: null | string;
-  techRecord_bodyType_description?: null | string;
-  techRecord_brakes_antilockBrakingSystem?: string | null;
+  techRecord_bodyType_description: string;
   techRecord_brakes_dtpNumber?: string | null;
   techRecord_brakes_loadSensingValve?: boolean | null;
   techRecord_conversionRefNo?: string | null;
@@ -243,7 +242,7 @@ export interface TechRecordPUTHGVSkeleton {
   techRecord_trainEecWeight?: number | null;
   techRecord_trainGbWeight?: number | null;
   techRecord_tyreUseCode?: string | null;
-  techRecord_vehicleClass_description?: null | VehicleClassDescription;
+  techRecord_vehicleClass_description: VehicleClassDescription;
   techRecord_vehicleConfiguration?: VehicleConfiguration | null;
   techRecord_approvalType?: ApprovalType | null;
   techRecord_approvalTypeNumber?: string | null;

--- a/types/v3/tech-record/put/hgv/testable/index.d.ts
+++ b/types/v3/tech-record/put/hgv/testable/index.d.ts
@@ -197,8 +197,7 @@ export interface TechRecordPUTHGVTestable {
   techRecord_applicationId?: null | string;
   techRecord_axles?: HGVAxles[];
   techRecord_bodyType_code?: string;
-  techRecord_bodyType_description?: string;
-  techRecord_brakes_antilockBrakingSystem?: string | null;
+  techRecord_bodyType_description: string;
   techRecord_brakes_dtpNumber?: string | null;
   techRecord_brakes_loadSensingValve?: boolean | null;
   techRecord_conversionRefNo?: string | null;
@@ -229,7 +228,7 @@ export interface TechRecordPUTHGVTestable {
   techRecord_microfilm_microfilmRollNumber?: string | null;
   techRecord_microfilm_microfilmSerialNumber?: string | null;
   techRecord_model?: string | null;
-  techRecord_noOfAxles?: number | null;
+  techRecord_noOfAxles: number;
   techRecord_notes?: string | null;
   techRecord_offRoad?: boolean | null;
   techRecord_plates?: HGVPlates[];

--- a/types/v3/tech-record/put/lgv/complete/index.d.ts
+++ b/types/v3/tech-record/put/lgv/complete/index.d.ts
@@ -57,7 +57,7 @@ export interface TechRecordPUTLGVComplete {
   techRecord_statusCode: StatusCode;
   techRecord_regnDate?: string | null;
   techRecord_manufactureYear?: number | null;
-  techRecord_noOfAxles?: number | null;
+  techRecord_noOfAxles: number;
   techRecord_notes?: string;
   techRecord_vehicleSubclass: VehicleSubclass;
   techRecord_hiddenInVta?: boolean;

--- a/types/v3/tech-record/put/psv/testable/index.d.ts
+++ b/types/v3/tech-record/put/psv/testable/index.d.ts
@@ -264,7 +264,7 @@ export interface TechRecordPUTPSVTestable {
   techRecord_applicantDetails_postCode?: null | string;
   techRecord_applicantDetails_telephoneNumber?: null | string;
   techRecord_applicantDetails_emailAddress?: null | string;
-  techRecord_brakes_dtpNumber?: string | null;
+  techRecord_brakes_dtpNumber: string;
   techRecord_brakes_brakeCode?: string | null;
   techRecord_brakes_brakeCodeOriginal?: string | null;
   techRecord_brakes_dataTrBrakeOne?: string | null;

--- a/types/v3/tech-record/put/small trl/complete/index.d.ts
+++ b/types/v3/tech-record/put/small trl/complete/index.d.ts
@@ -50,7 +50,7 @@ export interface TechRecordPUTSmallTRLComplete {
   techRecord_statusCode: StatusCode;
   techRecord_vehicleClass_description: VehicleClassDescription;
   techRecord_vehicleConfiguration: VehicleConfiguration;
-  techRecord_vehicleSubclass?: VehicleSubclass;
+  techRecord_vehicleSubclass?: null | VehicleSubclass;
   techRecord_vehicleType: "trl";
   vin: string;
   trailerId?: string;


### PR DESCRIPTION
## SPIKE: Validate ADR back end spec


[CB2-9289](https://dvsa.atlassian.net/browse/CB2-9289)
Issue [116](https://github.com/dvsa/cvs-type-definitions/issues/116)

<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

- techRecord_adrDetails_tank_tankDetails_tankTypeAppNo max length changed to 65 from 30

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
