### PR TITLE
patch(cb2-9603): add enums into types package

### DIFF
--- a/json-definitions/v3/tech-record/enums/approvalType.ignore.json
+++ b/json-definitions/v3/tech-record/enums/approvalType.ignore.json
@@ -12,8 +12,8 @@
     "EU_WVTA_Pre_23",
     "EU_WVTA_23_on",
     "QNIG",
-    "Prov_GB_WVTA",
-    "Small_series",
+    "PROV_GB_WVTA",
+    "SMALL_SERIES",
     "IVA_VCA",
     "IVA_DVSA_NI"
   ],

--- a/json-definitions/v3/tech-record/enums/approvalType.ignore.json
+++ b/json-definitions/v3/tech-record/enums/approvalType.ignore.json
@@ -1,6 +1,22 @@
 {
   "title": "Approval Type",
   "type": "string",
+  "tsEnumNames": [
+    "NTA",
+    "ECTA",
+    "IVA",
+    "NSSTA",
+    "ECSSTA",
+    "GB_WVTA",
+    "UKNI_WVTA",
+    "EU_WVTA_Pre_23",
+    "EU_WVTA_23_on",
+    "QNIG",
+    "Prov_GB_WVTA",
+    "Small_series",
+    "IVA_VCA",
+    "IVA_DVSA_NI"
+  ],
   "enum": [
     "NTA",
     "ECTA",

--- a/json-definitions/v3/tech-record/enums/approvalTypeHgvOrPsv.ignore.json
+++ b/json-definitions/v3/tech-record/enums/approvalTypeHgvOrPsv.ignore.json
@@ -8,8 +8,8 @@
     "NSSTA",
     "ECSSTA",
     "GB_WVTA",
-    "Prov_GB_WVTA",
-    "Small_series",
+    "PROV_GB_WVTA",
+    "SMALL_SERIES",
     "IVA_VCA",
     "IVA_DVSA_NI"
   ],

--- a/json-definitions/v3/tech-record/enums/approvalTypeHgvOrPsv.ignore.json
+++ b/json-definitions/v3/tech-record/enums/approvalTypeHgvOrPsv.ignore.json
@@ -1,6 +1,18 @@
 {
   "title": "Approval Type",
   "type": "string",
+  "tsEnumNames": [
+    "NTA",
+    "ECTA",
+    "IVA",
+    "NSSTA",
+    "ECSSTA",
+    "GB_WVTA",
+    "Prov_GB_WVTA",
+    "Small_series",
+    "IVA_VCA",
+    "IVA_DVSA_NI"
+  ],
   "enum": [
     "NTA",
     "ECTA",

--- a/json-schemas/v3/tech-record/get/hgv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/complete/index.json
@@ -989,6 +989,18 @@
 				{
 					"title": "Approval Type",
 					"type": "string",
+					"tsEnumNames": [
+						"NTA",
+						"ECTA",
+						"IVA",
+						"NSSTA",
+						"ECSSTA",
+						"GB_WVTA",
+						"Prov_GB_WVTA",
+						"Small_series",
+						"IVA_VCA",
+						"IVA_DVSA_NI"
+					],
 					"enum": [
 						"NTA",
 						"ECTA",

--- a/json-schemas/v3/tech-record/get/hgv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/complete/index.json
@@ -996,8 +996,8 @@
 						"NSSTA",
 						"ECSSTA",
 						"GB_WVTA",
-						"Prov_GB_WVTA",
-						"Small_series",
+						"PROV_GB_WVTA",
+						"SMALL_SERIES",
 						"IVA_VCA",
 						"IVA_DVSA_NI"
 					],

--- a/json-schemas/v3/tech-record/get/hgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/skeleton/index.json
@@ -1080,8 +1080,8 @@
 						"NSSTA",
 						"ECSSTA",
 						"GB_WVTA",
-						"Prov_GB_WVTA",
-						"Small_series",
+						"PROV_GB_WVTA",
+						"SMALL_SERIES",
 						"IVA_VCA",
 						"IVA_DVSA_NI"
 					],

--- a/json-schemas/v3/tech-record/get/hgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/skeleton/index.json
@@ -1073,6 +1073,18 @@
 				{
 					"title": "Approval Type",
 					"type": "string",
+					"tsEnumNames": [
+						"NTA",
+						"ECTA",
+						"IVA",
+						"NSSTA",
+						"ECSSTA",
+						"GB_WVTA",
+						"Prov_GB_WVTA",
+						"Small_series",
+						"IVA_VCA",
+						"IVA_DVSA_NI"
+					],
 					"enum": [
 						"NTA",
 						"ECTA",

--- a/json-schemas/v3/tech-record/get/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/testable/index.json
@@ -1068,8 +1068,8 @@
 						"NSSTA",
 						"ECSSTA",
 						"GB_WVTA",
-						"Prov_GB_WVTA",
-						"Small_series",
+						"PROV_GB_WVTA",
+						"SMALL_SERIES",
 						"IVA_VCA",
 						"IVA_DVSA_NI"
 					],

--- a/json-schemas/v3/tech-record/get/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/testable/index.json
@@ -1061,6 +1061,18 @@
 				{
 					"title": "Approval Type",
 					"type": "string",
+					"tsEnumNames": [
+						"NTA",
+						"ECTA",
+						"IVA",
+						"NSSTA",
+						"ECSSTA",
+						"GB_WVTA",
+						"Prov_GB_WVTA",
+						"Small_series",
+						"IVA_VCA",
+						"IVA_DVSA_NI"
+					],
 					"enum": [
 						"NTA",
 						"ECTA",

--- a/json-schemas/v3/tech-record/get/psv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/psv/complete/index.json
@@ -235,8 +235,8 @@
 						"NSSTA",
 						"ECSSTA",
 						"GB_WVTA",
-						"Prov_GB_WVTA",
-						"Small_series",
+						"PROV_GB_WVTA",
+						"SMALL_SERIES",
 						"IVA_VCA",
 						"IVA_DVSA_NI"
 					],

--- a/json-schemas/v3/tech-record/get/psv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/psv/complete/index.json
@@ -228,6 +228,18 @@
 				{
 					"title": "Approval Type",
 					"type": "string",
+					"tsEnumNames": [
+						"NTA",
+						"ECTA",
+						"IVA",
+						"NSSTA",
+						"ECSSTA",
+						"GB_WVTA",
+						"Prov_GB_WVTA",
+						"Small_series",
+						"IVA_VCA",
+						"IVA_DVSA_NI"
+					],
 					"enum": [
 						"NTA",
 						"ECTA",

--- a/json-schemas/v3/tech-record/get/psv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/psv/skeleton/index.json
@@ -232,8 +232,8 @@
 						"NSSTA",
 						"ECSSTA",
 						"GB_WVTA",
-						"Prov_GB_WVTA",
-						"Small_series",
+						"PROV_GB_WVTA",
+						"SMALL_SERIES",
 						"IVA_VCA",
 						"IVA_DVSA_NI"
 					],

--- a/json-schemas/v3/tech-record/get/psv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/psv/skeleton/index.json
@@ -225,6 +225,18 @@
 				{
 					"title": "Approval Type",
 					"type": "string",
+					"tsEnumNames": [
+						"NTA",
+						"ECTA",
+						"IVA",
+						"NSSTA",
+						"ECSSTA",
+						"GB_WVTA",
+						"Prov_GB_WVTA",
+						"Small_series",
+						"IVA_VCA",
+						"IVA_DVSA_NI"
+					],
 					"enum": [
 						"NTA",
 						"ECTA",

--- a/json-schemas/v3/tech-record/get/psv/testable/index.json
+++ b/json-schemas/v3/tech-record/get/psv/testable/index.json
@@ -214,8 +214,8 @@
 						"NSSTA",
 						"ECSSTA",
 						"GB_WVTA",
-						"Prov_GB_WVTA",
-						"Small_series",
+						"PROV_GB_WVTA",
+						"SMALL_SERIES",
 						"IVA_VCA",
 						"IVA_DVSA_NI"
 					],

--- a/json-schemas/v3/tech-record/get/psv/testable/index.json
+++ b/json-schemas/v3/tech-record/get/psv/testable/index.json
@@ -207,6 +207,18 @@
 				{
 					"title": "Approval Type",
 					"type": "string",
+					"tsEnumNames": [
+						"NTA",
+						"ECTA",
+						"IVA",
+						"NSSTA",
+						"ECSSTA",
+						"GB_WVTA",
+						"Prov_GB_WVTA",
+						"Small_series",
+						"IVA_VCA",
+						"IVA_DVSA_NI"
+					],
 					"enum": [
 						"NTA",
 						"ECTA",

--- a/json-schemas/v3/tech-record/get/trl/complete/index.json
+++ b/json-schemas/v3/tech-record/get/trl/complete/index.json
@@ -423,6 +423,22 @@
 				{
 					"title": "Approval Type",
 					"type": "string",
+					"tsEnumNames": [
+						"NTA",
+						"ECTA",
+						"IVA",
+						"NSSTA",
+						"ECSSTA",
+						"GB_WVTA",
+						"UKNI_WVTA",
+						"EU_WVTA_Pre_23",
+						"EU_WVTA_23_on",
+						"QNIG",
+						"Prov_GB_WVTA",
+						"Small_series",
+						"IVA_VCA",
+						"IVA_DVSA_NI"
+					],
 					"enum": [
 						"NTA",
 						"ECTA",

--- a/json-schemas/v3/tech-record/get/trl/complete/index.json
+++ b/json-schemas/v3/tech-record/get/trl/complete/index.json
@@ -434,8 +434,8 @@
 						"EU_WVTA_Pre_23",
 						"EU_WVTA_23_on",
 						"QNIG",
-						"Prov_GB_WVTA",
-						"Small_series",
+						"PROV_GB_WVTA",
+						"SMALL_SERIES",
 						"IVA_VCA",
 						"IVA_DVSA_NI"
 					],

--- a/json-schemas/v3/tech-record/get/trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/trl/skeleton/index.json
@@ -414,8 +414,8 @@
 						"EU_WVTA_Pre_23",
 						"EU_WVTA_23_on",
 						"QNIG",
-						"Prov_GB_WVTA",
-						"Small_series",
+						"PROV_GB_WVTA",
+						"SMALL_SERIES",
 						"IVA_VCA",
 						"IVA_DVSA_NI"
 					],

--- a/json-schemas/v3/tech-record/get/trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/trl/skeleton/index.json
@@ -403,6 +403,22 @@
 				{
 					"title": "Approval Type",
 					"type": "string",
+					"tsEnumNames": [
+						"NTA",
+						"ECTA",
+						"IVA",
+						"NSSTA",
+						"ECSSTA",
+						"GB_WVTA",
+						"UKNI_WVTA",
+						"EU_WVTA_Pre_23",
+						"EU_WVTA_23_on",
+						"QNIG",
+						"Prov_GB_WVTA",
+						"Small_series",
+						"IVA_VCA",
+						"IVA_DVSA_NI"
+					],
 					"enum": [
 						"NTA",
 						"ECTA",

--- a/json-schemas/v3/tech-record/get/trl/testable/index.json
+++ b/json-schemas/v3/tech-record/get/trl/testable/index.json
@@ -405,6 +405,22 @@
 				{
 					"title": "Approval Type",
 					"type": "string",
+					"tsEnumNames": [
+						"NTA",
+						"ECTA",
+						"IVA",
+						"NSSTA",
+						"ECSSTA",
+						"GB_WVTA",
+						"UKNI_WVTA",
+						"EU_WVTA_Pre_23",
+						"EU_WVTA_23_on",
+						"QNIG",
+						"Prov_GB_WVTA",
+						"Small_series",
+						"IVA_VCA",
+						"IVA_DVSA_NI"
+					],
 					"enum": [
 						"NTA",
 						"ECTA",

--- a/json-schemas/v3/tech-record/get/trl/testable/index.json
+++ b/json-schemas/v3/tech-record/get/trl/testable/index.json
@@ -416,8 +416,8 @@
 						"EU_WVTA_Pre_23",
 						"EU_WVTA_23_on",
 						"QNIG",
-						"Prov_GB_WVTA",
-						"Small_series",
+						"PROV_GB_WVTA",
+						"SMALL_SERIES",
 						"IVA_VCA",
 						"IVA_DVSA_NI"
 					],

--- a/json-schemas/v3/tech-record/put/hgv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/complete/index.json
@@ -963,8 +963,8 @@
 						"NSSTA",
 						"ECSSTA",
 						"GB_WVTA",
-						"Prov_GB_WVTA",
-						"Small_series",
+						"PROV_GB_WVTA",
+						"SMALL_SERIES",
 						"IVA_VCA",
 						"IVA_DVSA_NI"
 					],

--- a/json-schemas/v3/tech-record/put/hgv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/complete/index.json
@@ -956,6 +956,18 @@
 				{
 					"title": "Approval Type",
 					"type": "string",
+					"tsEnumNames": [
+						"NTA",
+						"ECTA",
+						"IVA",
+						"NSSTA",
+						"ECSSTA",
+						"GB_WVTA",
+						"Prov_GB_WVTA",
+						"Small_series",
+						"IVA_VCA",
+						"IVA_DVSA_NI"
+					],
 					"enum": [
 						"NTA",
 						"ECTA",

--- a/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
@@ -1032,6 +1032,18 @@
 				{
 					"title": "Approval Type",
 					"type": "string",
+					"tsEnumNames": [
+						"NTA",
+						"ECTA",
+						"IVA",
+						"NSSTA",
+						"ECSSTA",
+						"GB_WVTA",
+						"Prov_GB_WVTA",
+						"Small_series",
+						"IVA_VCA",
+						"IVA_DVSA_NI"
+					],
 					"enum": [
 						"NTA",
 						"ECTA",

--- a/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
@@ -1039,8 +1039,8 @@
 						"NSSTA",
 						"ECSSTA",
 						"GB_WVTA",
-						"Prov_GB_WVTA",
-						"Small_series",
+						"PROV_GB_WVTA",
+						"SMALL_SERIES",
 						"IVA_VCA",
 						"IVA_DVSA_NI"
 					],

--- a/json-schemas/v3/tech-record/put/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/testable/index.json
@@ -1022,8 +1022,8 @@
 						"NSSTA",
 						"ECSSTA",
 						"GB_WVTA",
-						"Prov_GB_WVTA",
-						"Small_series",
+						"PROV_GB_WVTA",
+						"SMALL_SERIES",
 						"IVA_VCA",
 						"IVA_DVSA_NI"
 					],

--- a/json-schemas/v3/tech-record/put/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/testable/index.json
@@ -1015,6 +1015,18 @@
 				{
 					"title": "Approval Type",
 					"type": "string",
+					"tsEnumNames": [
+						"NTA",
+						"ECTA",
+						"IVA",
+						"NSSTA",
+						"ECSSTA",
+						"GB_WVTA",
+						"Prov_GB_WVTA",
+						"Small_series",
+						"IVA_VCA",
+						"IVA_DVSA_NI"
+					],
 					"enum": [
 						"NTA",
 						"ECTA",

--- a/json-schemas/v3/tech-record/put/psv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/psv/complete/index.json
@@ -211,8 +211,8 @@
 						"NSSTA",
 						"ECSSTA",
 						"GB_WVTA",
-						"Prov_GB_WVTA",
-						"Small_series",
+						"PROV_GB_WVTA",
+						"SMALL_SERIES",
 						"IVA_VCA",
 						"IVA_DVSA_NI"
 					],

--- a/json-schemas/v3/tech-record/put/psv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/psv/complete/index.json
@@ -204,6 +204,18 @@
 				{
 					"title": "Approval Type",
 					"type": "string",
+					"tsEnumNames": [
+						"NTA",
+						"ECTA",
+						"IVA",
+						"NSSTA",
+						"ECSSTA",
+						"GB_WVTA",
+						"Prov_GB_WVTA",
+						"Small_series",
+						"IVA_VCA",
+						"IVA_DVSA_NI"
+					],
 					"enum": [
 						"NTA",
 						"ECTA",

--- a/json-schemas/v3/tech-record/put/psv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/psv/skeleton/index.json
@@ -226,8 +226,8 @@
 						"NSSTA",
 						"ECSSTA",
 						"GB_WVTA",
-						"Prov_GB_WVTA",
-						"Small_series",
+						"PROV_GB_WVTA",
+						"SMALL_SERIES",
 						"IVA_VCA",
 						"IVA_DVSA_NI"
 					],

--- a/json-schemas/v3/tech-record/put/psv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/psv/skeleton/index.json
@@ -219,6 +219,18 @@
 				{
 					"title": "Approval Type",
 					"type": "string",
+					"tsEnumNames": [
+						"NTA",
+						"ECTA",
+						"IVA",
+						"NSSTA",
+						"ECSSTA",
+						"GB_WVTA",
+						"Prov_GB_WVTA",
+						"Small_series",
+						"IVA_VCA",
+						"IVA_DVSA_NI"
+					],
 					"enum": [
 						"NTA",
 						"ECTA",

--- a/json-schemas/v3/tech-record/put/psv/testable/index.json
+++ b/json-schemas/v3/tech-record/put/psv/testable/index.json
@@ -193,6 +193,18 @@
 				{
 					"title": "Approval Type",
 					"type": "string",
+					"tsEnumNames": [
+						"NTA",
+						"ECTA",
+						"IVA",
+						"NSSTA",
+						"ECSSTA",
+						"GB_WVTA",
+						"Prov_GB_WVTA",
+						"Small_series",
+						"IVA_VCA",
+						"IVA_DVSA_NI"
+					],
 					"enum": [
 						"NTA",
 						"ECTA",

--- a/json-schemas/v3/tech-record/put/psv/testable/index.json
+++ b/json-schemas/v3/tech-record/put/psv/testable/index.json
@@ -200,8 +200,8 @@
 						"NSSTA",
 						"ECSSTA",
 						"GB_WVTA",
-						"Prov_GB_WVTA",
-						"Small_series",
+						"PROV_GB_WVTA",
+						"SMALL_SERIES",
 						"IVA_VCA",
 						"IVA_DVSA_NI"
 					],

--- a/json-schemas/v3/tech-record/put/trl/complete/index.json
+++ b/json-schemas/v3/tech-record/put/trl/complete/index.json
@@ -412,6 +412,22 @@
 				{
 					"title": "Approval Type",
 					"type": "string",
+					"tsEnumNames": [
+						"NTA",
+						"ECTA",
+						"IVA",
+						"NSSTA",
+						"ECSSTA",
+						"GB_WVTA",
+						"UKNI_WVTA",
+						"EU_WVTA_Pre_23",
+						"EU_WVTA_23_on",
+						"QNIG",
+						"Prov_GB_WVTA",
+						"Small_series",
+						"IVA_VCA",
+						"IVA_DVSA_NI"
+					],
 					"enum": [
 						"NTA",
 						"ECTA",

--- a/json-schemas/v3/tech-record/put/trl/complete/index.json
+++ b/json-schemas/v3/tech-record/put/trl/complete/index.json
@@ -423,8 +423,8 @@
 						"EU_WVTA_Pre_23",
 						"EU_WVTA_23_on",
 						"QNIG",
-						"Prov_GB_WVTA",
-						"Small_series",
+						"PROV_GB_WVTA",
+						"SMALL_SERIES",
 						"IVA_VCA",
 						"IVA_DVSA_NI"
 					],

--- a/json-schemas/v3/tech-record/put/trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/trl/skeleton/index.json
@@ -34,8 +34,8 @@
 						"EU_WVTA_Pre_23",
 						"EU_WVTA_23_on",
 						"QNIG",
-						"Prov_GB_WVTA",
-						"Small_series",
+						"PROV_GB_WVTA",
+						"SMALL_SERIES",
 						"IVA_VCA",
 						"IVA_DVSA_NI"
 					],

--- a/json-schemas/v3/tech-record/put/trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/trl/skeleton/index.json
@@ -23,6 +23,22 @@
 				{
 					"title": "Approval Type",
 					"type": "string",
+					"tsEnumNames": [
+						"NTA",
+						"ECTA",
+						"IVA",
+						"NSSTA",
+						"ECSSTA",
+						"GB_WVTA",
+						"UKNI_WVTA",
+						"EU_WVTA_Pre_23",
+						"EU_WVTA_23_on",
+						"QNIG",
+						"Prov_GB_WVTA",
+						"Small_series",
+						"IVA_VCA",
+						"IVA_DVSA_NI"
+					],
 					"enum": [
 						"NTA",
 						"ECTA",

--- a/json-schemas/v3/tech-record/put/trl/testable/index.json
+++ b/json-schemas/v3/tech-record/put/trl/testable/index.json
@@ -25,6 +25,22 @@
 				{
 					"title": "Approval Type",
 					"type": "string",
+					"tsEnumNames": [
+						"NTA",
+						"ECTA",
+						"IVA",
+						"NSSTA",
+						"ECSSTA",
+						"GB_WVTA",
+						"UKNI_WVTA",
+						"EU_WVTA_Pre_23",
+						"EU_WVTA_23_on",
+						"QNIG",
+						"Prov_GB_WVTA",
+						"Small_series",
+						"IVA_VCA",
+						"IVA_DVSA_NI"
+					],
 					"enum": [
 						"NTA",
 						"ECTA",

--- a/json-schemas/v3/tech-record/put/trl/testable/index.json
+++ b/json-schemas/v3/tech-record/put/trl/testable/index.json
@@ -36,8 +36,8 @@
 						"EU_WVTA_Pre_23",
 						"EU_WVTA_23_on",
 						"QNIG",
-						"Prov_GB_WVTA",
-						"Small_series",
+						"PROV_GB_WVTA",
+						"SMALL_SERIES",
 						"IVA_VCA",
 						"IVA_DVSA_NI"
 					],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "type definitions for cvs vta application",
   "main": "index.js",
   "repository": {

--- a/schema-validator.ts
+++ b/schema-validator.ts
@@ -33,6 +33,7 @@ export function isValidObject<B extends boolean | undefined>(
   logErrors = false
 ): boolean | ErrorObject[] {
   const ajv = new Ajv({ removeAdditional: true, allErrors: true });
+  ajv.addKeyword('tsEnumNames')
   const schema = JSON.parse(
     readFileSync(`${__dirname}/json-schemas/${schemaName}`, "utf8")
   );

--- a/schema-validator.ts
+++ b/schema-validator.ts
@@ -33,7 +33,7 @@ export function isValidObject<B extends boolean | undefined>(
   logErrors = false
 ): boolean | ErrorObject[] {
   const ajv = new Ajv({ removeAdditional: true, allErrors: true });
-  ajv.addKeyword('tsEnumNames')
+  ajv.addKeyword('tsEnumNames');
   const schema = JSON.parse(
     readFileSync(`${__dirname}/json-schemas/${schemaName}`, "utf8")
   );

--- a/types/v3/tech-record/get/hgv/complete/index.d.ts
+++ b/types/v3/tech-record/get/hgv/complete/index.d.ts
@@ -126,17 +126,6 @@ export type VehicleConfiguration =
   | "four-in-line"
   | "dolly"
   | "full drawbar";
-export type ApprovalType =
-  | "NTA"
-  | "ECTA"
-  | "IVA"
-  | "NSSTA"
-  | "ECSSTA"
-  | "GB WVTA"
-  | "Prov.GB WVTA"
-  | "Small series"
-  | "IVA - VCA"
-  | "IVA - DVSA/NI";
 
 export interface TechRecordGETHGVComplete {
   secondaryVrms?: string[];
@@ -287,4 +276,17 @@ export interface HGVPlates {
   plateIssueDate?: string | null;
   plateReasonForIssue?: null | PlateReasonForIssue;
   plateIssuer?: string | null;
+}
+
+export const enum ApprovalType {
+  NTA = "NTA",
+  ECTA = "ECTA",
+  IVA = "IVA",
+  NSSTA = "NSSTA",
+  ECSSTA = "ECSSTA",
+  GB_WVTA = "GB WVTA",
+  Prov_GB_WVTA = "Prov.GB WVTA",
+  Small_series = "Small series",
+  IVA_VCA = "IVA - VCA",
+  IVA_DVSA_NI = "IVA - DVSA/NI"
 }

--- a/types/v3/tech-record/get/hgv/complete/index.d.ts
+++ b/types/v3/tech-record/get/hgv/complete/index.d.ts
@@ -285,8 +285,8 @@ export const enum ApprovalType {
   NSSTA = "NSSTA",
   ECSSTA = "ECSSTA",
   GB_WVTA = "GB WVTA",
-  Prov_GB_WVTA = "Prov.GB WVTA",
-  Small_series = "Small series",
+  PROV_GB_WVTA = "Prov.GB WVTA",
+  SMALL_SERIES = "Small series",
   IVA_VCA = "IVA - VCA",
   IVA_DVSA_NI = "IVA - DVSA/NI"
 }

--- a/types/v3/tech-record/get/hgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/hgv/skeleton/index.d.ts
@@ -126,17 +126,6 @@ export type VehicleConfiguration =
   | "four-in-line"
   | "dolly"
   | "full drawbar";
-export type ApprovalType =
-  | "NTA"
-  | "ECTA"
-  | "IVA"
-  | "NSSTA"
-  | "ECSSTA"
-  | "GB WVTA"
-  | "Prov.GB WVTA"
-  | "Small series"
-  | "IVA - VCA"
-  | "IVA - DVSA/NI";
 
 export interface TechRecordGETHGVSkeleton {
   secondaryVrms?: null | string[];
@@ -284,4 +273,17 @@ export interface HGVPlates {
   plateIssueDate?: string | null;
   plateReasonForIssue?: null | PlateReasonForIssue;
   plateIssuer?: string | null;
+}
+
+export const enum ApprovalType {
+  NTA = "NTA",
+  ECTA = "ECTA",
+  IVA = "IVA",
+  NSSTA = "NSSTA",
+  ECSSTA = "ECSSTA",
+  GB_WVTA = "GB WVTA",
+  Prov_GB_WVTA = "Prov.GB WVTA",
+  Small_series = "Small series",
+  IVA_VCA = "IVA - VCA",
+  IVA_DVSA_NI = "IVA - DVSA/NI"
 }

--- a/types/v3/tech-record/get/hgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/hgv/skeleton/index.d.ts
@@ -282,8 +282,8 @@ export const enum ApprovalType {
   NSSTA = "NSSTA",
   ECSSTA = "ECSSTA",
   GB_WVTA = "GB WVTA",
-  Prov_GB_WVTA = "Prov.GB WVTA",
-  Small_series = "Small series",
+  PROV_GB_WVTA = "Prov.GB WVTA",
+  SMALL_SERIES = "Small series",
   IVA_VCA = "IVA - VCA",
   IVA_DVSA_NI = "IVA - DVSA/NI"
 }

--- a/types/v3/tech-record/get/hgv/testable/index.d.ts
+++ b/types/v3/tech-record/get/hgv/testable/index.d.ts
@@ -126,17 +126,6 @@ export type VehicleConfiguration =
   | "four-in-line"
   | "dolly"
   | "full drawbar";
-export type ApprovalType =
-  | "NTA"
-  | "ECTA"
-  | "IVA"
-  | "NSSTA"
-  | "ECSSTA"
-  | "GB WVTA"
-  | "Prov.GB WVTA"
-  | "Small series"
-  | "IVA - VCA"
-  | "IVA - DVSA/NI";
 
 export interface TechRecordGETHGVTestable {
   secondaryVrms?: null | string[];
@@ -284,4 +273,17 @@ export interface HGVPlates {
   plateIssueDate?: string | null;
   plateReasonForIssue?: null | PlateReasonForIssue;
   plateIssuer?: string | null;
+}
+
+export const enum ApprovalType {
+  NTA = "NTA",
+  ECTA = "ECTA",
+  IVA = "IVA",
+  NSSTA = "NSSTA",
+  ECSSTA = "ECSSTA",
+  GB_WVTA = "GB WVTA",
+  Prov_GB_WVTA = "Prov.GB WVTA",
+  Small_series = "Small series",
+  IVA_VCA = "IVA - VCA",
+  IVA_DVSA_NI = "IVA - DVSA/NI"
 }

--- a/types/v3/tech-record/get/hgv/testable/index.d.ts
+++ b/types/v3/tech-record/get/hgv/testable/index.d.ts
@@ -282,8 +282,8 @@ export const enum ApprovalType {
   NSSTA = "NSSTA",
   ECSSTA = "ECSSTA",
   GB_WVTA = "GB WVTA",
-  Prov_GB_WVTA = "Prov.GB WVTA",
-  Small_series = "Small series",
+  PROV_GB_WVTA = "Prov.GB WVTA",
+  SMALL_SERIES = "Small series",
   IVA_VCA = "IVA - VCA",
   IVA_DVSA_NI = "IVA - DVSA/NI"
 }

--- a/types/v3/tech-record/get/psv/complete/index.d.ts
+++ b/types/v3/tech-record/get/psv/complete/index.d.ts
@@ -308,8 +308,8 @@ export const enum ApprovalType {
   NSSTA = "NSSTA",
   ECSSTA = "ECSSTA",
   GB_WVTA = "GB WVTA",
-  Prov_GB_WVTA = "Prov.GB WVTA",
-  Small_series = "Small series",
+  PROV_GB_WVTA = "Prov.GB WVTA",
+  SMALL_SERIES = "Small series",
   IVA_VCA = "IVA - VCA",
   IVA_DVSA_NI = "IVA - DVSA/NI"
 }

--- a/types/v3/tech-record/get/psv/complete/index.d.ts
+++ b/types/v3/tech-record/get/psv/complete/index.d.ts
@@ -51,17 +51,6 @@ export type EUVehicleCategory =
   | "l5e"
   | "l6e"
   | "l7e";
-export type ApprovalType =
-  | "NTA"
-  | "ECTA"
-  | "IVA"
-  | "NSSTA"
-  | "ECSSTA"
-  | "GB WVTA"
-  | "Prov.GB WVTA"
-  | "Small series"
-  | "IVA - VCA"
-  | "IVA - DVSA/NI";
 export type BodyTypeDescription =
   | "artic"
   | "articulated"
@@ -310,4 +299,17 @@ export interface PSVAxlesComplete {
   tyres_fitmentCode: FitmentCode;
   tyres_dataTrAxles?: null | number;
   tyres_speedCategorySymbol: SpeedCategorySymbol;
+}
+
+export const enum ApprovalType {
+  NTA = "NTA",
+  ECTA = "ECTA",
+  IVA = "IVA",
+  NSSTA = "NSSTA",
+  ECSSTA = "ECSSTA",
+  GB_WVTA = "GB WVTA",
+  Prov_GB_WVTA = "Prov.GB WVTA",
+  Small_series = "Small series",
+  IVA_VCA = "IVA - VCA",
+  IVA_DVSA_NI = "IVA - DVSA/NI"
 }

--- a/types/v3/tech-record/get/psv/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/psv/skeleton/index.d.ts
@@ -51,17 +51,6 @@ export type EUVehicleCategory =
   | "l5e"
   | "l6e"
   | "l7e";
-export type ApprovalType =
-  | "NTA"
-  | "ECTA"
-  | "IVA"
-  | "NSSTA"
-  | "ECSSTA"
-  | "GB WVTA"
-  | "Prov.GB WVTA"
-  | "Small series"
-  | "IVA - VCA"
-  | "IVA - DVSA/NI";
 export type BodyTypeDescription =
   | "artic"
   | "articulated"
@@ -307,4 +296,17 @@ export interface PSVAxles {
   tyres_fitmentCode?: null | FitmentCode;
   tyres_dataTrAxles?: null | number;
   tyres_speedCategorySymbol?: SpeedCategorySymbol | null;
+}
+
+export const enum ApprovalType {
+  NTA = "NTA",
+  ECTA = "ECTA",
+  IVA = "IVA",
+  NSSTA = "NSSTA",
+  ECSSTA = "ECSSTA",
+  GB_WVTA = "GB WVTA",
+  Prov_GB_WVTA = "Prov.GB WVTA",
+  Small_series = "Small series",
+  IVA_VCA = "IVA - VCA",
+  IVA_DVSA_NI = "IVA - DVSA/NI"
 }

--- a/types/v3/tech-record/get/psv/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/psv/skeleton/index.d.ts
@@ -305,8 +305,8 @@ export const enum ApprovalType {
   NSSTA = "NSSTA",
   ECSSTA = "ECSSTA",
   GB_WVTA = "GB WVTA",
-  Prov_GB_WVTA = "Prov.GB WVTA",
-  Small_series = "Small series",
+  PROV_GB_WVTA = "Prov.GB WVTA",
+  SMALL_SERIES = "Small series",
   IVA_VCA = "IVA - VCA",
   IVA_DVSA_NI = "IVA - DVSA/NI"
 }

--- a/types/v3/tech-record/get/psv/testable/index.d.ts
+++ b/types/v3/tech-record/get/psv/testable/index.d.ts
@@ -51,17 +51,6 @@ export type EUVehicleCategory =
   | "l5e"
   | "l6e"
   | "l7e";
-export type ApprovalType =
-  | "NTA"
-  | "ECTA"
-  | "IVA"
-  | "NSSTA"
-  | "ECSSTA"
-  | "GB WVTA"
-  | "Prov.GB WVTA"
-  | "Small series"
-  | "IVA - VCA"
-  | "IVA - DVSA/NI";
 export type BodyTypeDescription =
   | "artic"
   | "articulated"
@@ -307,4 +296,17 @@ export interface PSVAxles {
   tyres_fitmentCode?: null | FitmentCode;
   tyres_dataTrAxles?: null | number;
   tyres_speedCategorySymbol?: SpeedCategorySymbol | null;
+}
+
+export const enum ApprovalType {
+  NTA = "NTA",
+  ECTA = "ECTA",
+  IVA = "IVA",
+  NSSTA = "NSSTA",
+  ECSSTA = "ECSSTA",
+  GB_WVTA = "GB WVTA",
+  Prov_GB_WVTA = "Prov.GB WVTA",
+  Small_series = "Small series",
+  IVA_VCA = "IVA - VCA",
+  IVA_DVSA_NI = "IVA - DVSA/NI"
 }

--- a/types/v3/tech-record/get/psv/testable/index.d.ts
+++ b/types/v3/tech-record/get/psv/testable/index.d.ts
@@ -305,8 +305,8 @@ export const enum ApprovalType {
   NSSTA = "NSSTA",
   ECSSTA = "ECSSTA",
   GB_WVTA = "GB WVTA",
-  Prov_GB_WVTA = "Prov.GB WVTA",
-  Small_series = "Small series",
+  PROV_GB_WVTA = "Prov.GB WVTA",
+  SMALL_SERIES = "Small series",
   IVA_VCA = "IVA - VCA",
   IVA_DVSA_NI = "IVA - DVSA/NI"
 }

--- a/types/v3/tech-record/get/trl/complete/index.d.ts
+++ b/types/v3/tech-record/get/trl/complete/index.d.ts
@@ -338,8 +338,8 @@ export const enum ApprovalType {
   EU_WVTA_Pre_23 = "EU WVTA Pre 23",
   EU_WVTA_23_on = "EU WVTA 23 on",
   QNIG = "QNIG",
-  Prov_GB_WVTA = "Prov.GB WVTA",
-  Small_series = "Small series",
+  PROV_GB_WVTA = "Prov.GB WVTA",
+  SMALL_SERIES = "Small series",
   IVA_VCA = "IVA - VCA",
   IVA_DVSA_NI = "IVA - DVSA/NI"
 }

--- a/types/v3/tech-record/get/trl/complete/index.d.ts
+++ b/types/v3/tech-record/get/trl/complete/index.d.ts
@@ -7,21 +7,6 @@
 
 export type TC2Types = "initial";
 export type TC3Types = "intermediate" | "periodic" | "exceptional";
-export type ApprovalType =
-  | "NTA"
-  | "ECTA"
-  | "IVA"
-  | "NSSTA"
-  | "ECSSTA"
-  | "GB WVTA"
-  | "UKNI WVTA"
-  | "EU WVTA Pre 23"
-  | "EU WVTA 23 on"
-  | "QNIG"
-  | "Prov.GB WVTA"
-  | "Small series"
-  | "IVA - VCA"
-  | "IVA - DVSA/NI";
 export type EUVehicleCategory =
   | "m1"
   | "m2"
@@ -340,4 +325,21 @@ export interface TRLAxles {
 export interface AxleSpacing {
   axles?: string;
   value?: number | null;
+}
+
+export const enum ApprovalType {
+  NTA = "NTA",
+  ECTA = "ECTA",
+  IVA = "IVA",
+  NSSTA = "NSSTA",
+  ECSSTA = "ECSSTA",
+  GB_WVTA = "GB WVTA",
+  UKNI_WVTA = "UKNI WVTA",
+  EU_WVTA_Pre_23 = "EU WVTA Pre 23",
+  EU_WVTA_23_on = "EU WVTA 23 on",
+  QNIG = "QNIG",
+  Prov_GB_WVTA = "Prov.GB WVTA",
+  Small_series = "Small series",
+  IVA_VCA = "IVA - VCA",
+  IVA_DVSA_NI = "IVA - DVSA/NI"
 }

--- a/types/v3/tech-record/get/trl/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/trl/skeleton/index.d.ts
@@ -7,21 +7,6 @@
 
 export type TC2Types = "initial";
 export type TC3Types = "intermediate" | "periodic" | "exceptional";
-export type ApprovalType =
-  | "NTA"
-  | "ECTA"
-  | "IVA"
-  | "NSSTA"
-  | "ECSSTA"
-  | "GB WVTA"
-  | "UKNI WVTA"
-  | "EU WVTA Pre 23"
-  | "EU WVTA 23 on"
-  | "QNIG"
-  | "Prov.GB WVTA"
-  | "Small series"
-  | "IVA - VCA"
-  | "IVA - DVSA/NI";
 export type EUVehicleCategory =
   | "m1"
   | "m2"
@@ -337,4 +322,21 @@ export interface TRLPlates {
 export interface AxleSpacing {
   axles?: string;
   value?: number | null;
+}
+
+export const enum ApprovalType {
+  NTA = "NTA",
+  ECTA = "ECTA",
+  IVA = "IVA",
+  NSSTA = "NSSTA",
+  ECSSTA = "ECSSTA",
+  GB_WVTA = "GB WVTA",
+  UKNI_WVTA = "UKNI WVTA",
+  EU_WVTA_Pre_23 = "EU WVTA Pre 23",
+  EU_WVTA_23_on = "EU WVTA 23 on",
+  QNIG = "QNIG",
+  Prov_GB_WVTA = "Prov.GB WVTA",
+  Small_series = "Small series",
+  IVA_VCA = "IVA - VCA",
+  IVA_DVSA_NI = "IVA - DVSA/NI"
 }

--- a/types/v3/tech-record/get/trl/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/trl/skeleton/index.d.ts
@@ -335,8 +335,8 @@ export const enum ApprovalType {
   EU_WVTA_Pre_23 = "EU WVTA Pre 23",
   EU_WVTA_23_on = "EU WVTA 23 on",
   QNIG = "QNIG",
-  Prov_GB_WVTA = "Prov.GB WVTA",
-  Small_series = "Small series",
+  PROV_GB_WVTA = "Prov.GB WVTA",
+  SMALL_SERIES = "Small series",
   IVA_VCA = "IVA - VCA",
   IVA_DVSA_NI = "IVA - DVSA/NI"
 }

--- a/types/v3/tech-record/get/trl/testable/index.d.ts
+++ b/types/v3/tech-record/get/trl/testable/index.d.ts
@@ -7,21 +7,6 @@
 
 export type TC2Types = "initial";
 export type TC3Types = "intermediate" | "periodic" | "exceptional";
-export type ApprovalType =
-  | "NTA"
-  | "ECTA"
-  | "IVA"
-  | "NSSTA"
-  | "ECSSTA"
-  | "GB WVTA"
-  | "UKNI WVTA"
-  | "EU WVTA Pre 23"
-  | "EU WVTA 23 on"
-  | "QNIG"
-  | "Prov.GB WVTA"
-  | "Small series"
-  | "IVA - VCA"
-  | "IVA - DVSA/NI";
 export type EUVehicleCategory =
   | "m1"
   | "m2"
@@ -337,4 +322,21 @@ export interface TRLAxles {
 export interface AxleSpacing {
   axles?: string;
   value?: number | null;
+}
+
+export const enum ApprovalType {
+  NTA = "NTA",
+  ECTA = "ECTA",
+  IVA = "IVA",
+  NSSTA = "NSSTA",
+  ECSSTA = "ECSSTA",
+  GB_WVTA = "GB WVTA",
+  UKNI_WVTA = "UKNI WVTA",
+  EU_WVTA_Pre_23 = "EU WVTA Pre 23",
+  EU_WVTA_23_on = "EU WVTA 23 on",
+  QNIG = "QNIG",
+  Prov_GB_WVTA = "Prov.GB WVTA",
+  Small_series = "Small series",
+  IVA_VCA = "IVA - VCA",
+  IVA_DVSA_NI = "IVA - DVSA/NI"
 }

--- a/types/v3/tech-record/get/trl/testable/index.d.ts
+++ b/types/v3/tech-record/get/trl/testable/index.d.ts
@@ -335,8 +335,8 @@ export const enum ApprovalType {
   EU_WVTA_Pre_23 = "EU WVTA Pre 23",
   EU_WVTA_23_on = "EU WVTA 23 on",
   QNIG = "QNIG",
-  Prov_GB_WVTA = "Prov.GB WVTA",
-  Small_series = "Small series",
+  PROV_GB_WVTA = "Prov.GB WVTA",
+  SMALL_SERIES = "Small series",
   IVA_VCA = "IVA - VCA",
   IVA_DVSA_NI = "IVA - DVSA/NI"
 }

--- a/types/v3/tech-record/put/hgv/complete/index.d.ts
+++ b/types/v3/tech-record/put/hgv/complete/index.d.ts
@@ -126,17 +126,6 @@ export type VehicleConfiguration =
   | "four-in-line"
   | "dolly"
   | "full drawbar";
-export type ApprovalType =
-  | "NTA"
-  | "ECTA"
-  | "IVA"
-  | "NSSTA"
-  | "ECSSTA"
-  | "GB WVTA"
-  | "Prov.GB WVTA"
-  | "Small series"
-  | "IVA - VCA"
-  | "IVA - DVSA/NI";
 
 export interface TechRecordPUTHGVComplete {
   secondaryVrms?: string[];
@@ -275,4 +264,17 @@ export interface HGVPlates {
   plateIssueDate?: string | null;
   plateReasonForIssue?: null | PlateReasonForIssue;
   plateIssuer?: string | null;
+}
+
+export const enum ApprovalType {
+  NTA = "NTA",
+  ECTA = "ECTA",
+  IVA = "IVA",
+  NSSTA = "NSSTA",
+  ECSSTA = "ECSSTA",
+  GB_WVTA = "GB WVTA",
+  Prov_GB_WVTA = "Prov.GB WVTA",
+  Small_series = "Small series",
+  IVA_VCA = "IVA - VCA",
+  IVA_DVSA_NI = "IVA - DVSA/NI"
 }

--- a/types/v3/tech-record/put/hgv/complete/index.d.ts
+++ b/types/v3/tech-record/put/hgv/complete/index.d.ts
@@ -273,8 +273,8 @@ export const enum ApprovalType {
   NSSTA = "NSSTA",
   ECSSTA = "ECSSTA",
   GB_WVTA = "GB WVTA",
-  Prov_GB_WVTA = "Prov.GB WVTA",
-  Small_series = "Small series",
+  PROV_GB_WVTA = "Prov.GB WVTA",
+  SMALL_SERIES = "Small series",
   IVA_VCA = "IVA - VCA",
   IVA_DVSA_NI = "IVA - DVSA/NI"
 }

--- a/types/v3/tech-record/put/hgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/hgv/skeleton/index.d.ts
@@ -270,8 +270,8 @@ export const enum ApprovalType {
   NSSTA = "NSSTA",
   ECSSTA = "ECSSTA",
   GB_WVTA = "GB WVTA",
-  Prov_GB_WVTA = "Prov.GB WVTA",
-  Small_series = "Small series",
+  PROV_GB_WVTA = "Prov.GB WVTA",
+  SMALL_SERIES = "Small series",
   IVA_VCA = "IVA - VCA",
   IVA_DVSA_NI = "IVA - DVSA/NI"
 }

--- a/types/v3/tech-record/put/hgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/hgv/skeleton/index.d.ts
@@ -126,17 +126,6 @@ export type VehicleConfiguration =
   | "four-in-line"
   | "dolly"
   | "full drawbar";
-export type ApprovalType =
-  | "NTA"
-  | "ECTA"
-  | "IVA"
-  | "NSSTA"
-  | "ECSSTA"
-  | "GB WVTA"
-  | "Prov.GB WVTA"
-  | "Small series"
-  | "IVA - VCA"
-  | "IVA - DVSA/NI";
 
 export interface TechRecordPUTHGVSkeleton {
   secondaryVrms?: string[];
@@ -272,4 +261,17 @@ export interface HGVPlates {
   plateIssueDate?: string | null;
   plateReasonForIssue?: null | PlateReasonForIssue;
   plateIssuer?: string | null;
+}
+
+export const enum ApprovalType {
+  NTA = "NTA",
+  ECTA = "ECTA",
+  IVA = "IVA",
+  NSSTA = "NSSTA",
+  ECSSTA = "ECSSTA",
+  GB_WVTA = "GB WVTA",
+  Prov_GB_WVTA = "Prov.GB WVTA",
+  Small_series = "Small series",
+  IVA_VCA = "IVA - VCA",
+  IVA_DVSA_NI = "IVA - DVSA/NI"
 }

--- a/types/v3/tech-record/put/hgv/testable/index.d.ts
+++ b/types/v3/tech-record/put/hgv/testable/index.d.ts
@@ -270,8 +270,8 @@ export const enum ApprovalType {
   NSSTA = "NSSTA",
   ECSSTA = "ECSSTA",
   GB_WVTA = "GB WVTA",
-  Prov_GB_WVTA = "Prov.GB WVTA",
-  Small_series = "Small series",
+  PROV_GB_WVTA = "Prov.GB WVTA",
+  SMALL_SERIES = "Small series",
   IVA_VCA = "IVA - VCA",
   IVA_DVSA_NI = "IVA - DVSA/NI"
 }

--- a/types/v3/tech-record/put/hgv/testable/index.d.ts
+++ b/types/v3/tech-record/put/hgv/testable/index.d.ts
@@ -126,17 +126,6 @@ export type VehicleConfiguration =
   | "four-in-line"
   | "dolly"
   | "full drawbar";
-export type ApprovalType =
-  | "NTA"
-  | "ECTA"
-  | "IVA"
-  | "NSSTA"
-  | "ECSSTA"
-  | "GB WVTA"
-  | "Prov.GB WVTA"
-  | "Small series"
-  | "IVA - VCA"
-  | "IVA - DVSA/NI";
 
 export interface TechRecordPUTHGVTestable {
   secondaryVrms?: string[];
@@ -272,4 +261,17 @@ export interface HGVPlates {
   plateIssueDate?: string | null;
   plateReasonForIssue?: null | PlateReasonForIssue;
   plateIssuer?: string | null;
+}
+
+export const enum ApprovalType {
+  NTA = "NTA",
+  ECTA = "ECTA",
+  IVA = "IVA",
+  NSSTA = "NSSTA",
+  ECSSTA = "ECSSTA",
+  GB_WVTA = "GB WVTA",
+  Prov_GB_WVTA = "Prov.GB WVTA",
+  Small_series = "Small series",
+  IVA_VCA = "IVA - VCA",
+  IVA_DVSA_NI = "IVA - DVSA/NI"
 }

--- a/types/v3/tech-record/put/psv/complete/index.d.ts
+++ b/types/v3/tech-record/put/psv/complete/index.d.ts
@@ -296,8 +296,8 @@ export const enum ApprovalType {
   NSSTA = "NSSTA",
   ECSSTA = "ECSSTA",
   GB_WVTA = "GB WVTA",
-  Prov_GB_WVTA = "Prov.GB WVTA",
-  Small_series = "Small series",
+  PROV_GB_WVTA = "Prov.GB WVTA",
+  SMALL_SERIES = "Small series",
   IVA_VCA = "IVA - VCA",
   IVA_DVSA_NI = "IVA - DVSA/NI"
 }

--- a/types/v3/tech-record/put/psv/complete/index.d.ts
+++ b/types/v3/tech-record/put/psv/complete/index.d.ts
@@ -51,17 +51,6 @@ export type EUVehicleCategory =
   | "l5e"
   | "l6e"
   | "l7e";
-export type ApprovalType =
-  | "NTA"
-  | "ECTA"
-  | "IVA"
-  | "NSSTA"
-  | "ECSSTA"
-  | "GB WVTA"
-  | "Prov.GB WVTA"
-  | "Small series"
-  | "IVA - VCA"
-  | "IVA - DVSA/NI";
 export type BodyTypeDescription =
   | "artic"
   | "articulated"
@@ -298,4 +287,17 @@ export interface PSVAxlesComplete {
   tyres_fitmentCode: FitmentCode;
   tyres_dataTrAxles?: null | number;
   tyres_speedCategorySymbol: SpeedCategorySymbol;
+}
+
+export const enum ApprovalType {
+  NTA = "NTA",
+  ECTA = "ECTA",
+  IVA = "IVA",
+  NSSTA = "NSSTA",
+  ECSSTA = "ECSSTA",
+  GB_WVTA = "GB WVTA",
+  Prov_GB_WVTA = "Prov.GB WVTA",
+  Small_series = "Small series",
+  IVA_VCA = "IVA - VCA",
+  IVA_DVSA_NI = "IVA - DVSA/NI"
 }

--- a/types/v3/tech-record/put/psv/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/psv/skeleton/index.d.ts
@@ -293,8 +293,8 @@ export const enum ApprovalType {
   NSSTA = "NSSTA",
   ECSSTA = "ECSSTA",
   GB_WVTA = "GB WVTA",
-  Prov_GB_WVTA = "Prov.GB WVTA",
-  Small_series = "Small series",
+  PROV_GB_WVTA = "Prov.GB WVTA",
+  SMALL_SERIES = "Small series",
   IVA_VCA = "IVA - VCA",
   IVA_DVSA_NI = "IVA - DVSA/NI"
 }

--- a/types/v3/tech-record/put/psv/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/psv/skeleton/index.d.ts
@@ -51,17 +51,6 @@ export type EUVehicleCategory =
   | "l5e"
   | "l6e"
   | "l7e";
-export type ApprovalType =
-  | "NTA"
-  | "ECTA"
-  | "IVA"
-  | "NSSTA"
-  | "ECSSTA"
-  | "GB WVTA"
-  | "Prov.GB WVTA"
-  | "Small series"
-  | "IVA - VCA"
-  | "IVA - DVSA/NI";
 export type BodyTypeDescription =
   | "artic"
   | "articulated"
@@ -295,4 +284,17 @@ export interface PSVAxles {
   tyres_fitmentCode?: null | FitmentCode;
   tyres_dataTrAxles?: null | number;
   tyres_speedCategorySymbol?: SpeedCategorySymbol | null;
+}
+
+export const enum ApprovalType {
+  NTA = "NTA",
+  ECTA = "ECTA",
+  IVA = "IVA",
+  NSSTA = "NSSTA",
+  ECSSTA = "ECSSTA",
+  GB_WVTA = "GB WVTA",
+  Prov_GB_WVTA = "Prov.GB WVTA",
+  Small_series = "Small series",
+  IVA_VCA = "IVA - VCA",
+  IVA_DVSA_NI = "IVA - DVSA/NI"
 }

--- a/types/v3/tech-record/put/psv/testable/index.d.ts
+++ b/types/v3/tech-record/put/psv/testable/index.d.ts
@@ -293,8 +293,8 @@ export const enum ApprovalType {
   NSSTA = "NSSTA",
   ECSSTA = "ECSSTA",
   GB_WVTA = "GB WVTA",
-  Prov_GB_WVTA = "Prov.GB WVTA",
-  Small_series = "Small series",
+  PROV_GB_WVTA = "Prov.GB WVTA",
+  SMALL_SERIES = "Small series",
   IVA_VCA = "IVA - VCA",
   IVA_DVSA_NI = "IVA - DVSA/NI"
 }

--- a/types/v3/tech-record/put/psv/testable/index.d.ts
+++ b/types/v3/tech-record/put/psv/testable/index.d.ts
@@ -51,17 +51,6 @@ export type EUVehicleCategory =
   | "l5e"
   | "l6e"
   | "l7e";
-export type ApprovalType =
-  | "NTA"
-  | "ECTA"
-  | "IVA"
-  | "NSSTA"
-  | "ECSSTA"
-  | "GB WVTA"
-  | "Prov.GB WVTA"
-  | "Small series"
-  | "IVA - VCA"
-  | "IVA - DVSA/NI";
 export type BodyTypeDescription =
   | "artic"
   | "articulated"
@@ -295,4 +284,17 @@ export interface PSVAxles {
   tyres_fitmentCode?: null | FitmentCode;
   tyres_dataTrAxles?: null | number;
   tyres_speedCategorySymbol?: SpeedCategorySymbol | null;
+}
+
+export const enum ApprovalType {
+  NTA = "NTA",
+  ECTA = "ECTA",
+  IVA = "IVA",
+  NSSTA = "NSSTA",
+  ECSSTA = "ECSSTA",
+  GB_WVTA = "GB WVTA",
+  Prov_GB_WVTA = "Prov.GB WVTA",
+  Small_series = "Small series",
+  IVA_VCA = "IVA - VCA",
+  IVA_DVSA_NI = "IVA - DVSA/NI"
 }

--- a/types/v3/tech-record/put/trl/complete/index.d.ts
+++ b/types/v3/tech-record/put/trl/complete/index.d.ts
@@ -7,21 +7,6 @@
 
 export type TC2Types = "initial";
 export type TC3Types = "intermediate" | "periodic" | "exceptional";
-export type ApprovalType =
-  | "NTA"
-  | "ECTA"
-  | "IVA"
-  | "NSSTA"
-  | "ECSSTA"
-  | "GB WVTA"
-  | "UKNI WVTA"
-  | "EU WVTA Pre 23"
-  | "EU WVTA 23 on"
-  | "QNIG"
-  | "Prov.GB WVTA"
-  | "Small series"
-  | "IVA - VCA"
-  | "IVA - DVSA/NI";
 export type EUVehicleCategory =
   | "m1"
   | "m2"
@@ -329,4 +314,21 @@ export interface TRLAxles {
 export interface AxleSpacing {
   axles?: string;
   value?: number | null;
+}
+
+export const enum ApprovalType {
+  NTA = "NTA",
+  ECTA = "ECTA",
+  IVA = "IVA",
+  NSSTA = "NSSTA",
+  ECSSTA = "ECSSTA",
+  GB_WVTA = "GB WVTA",
+  UKNI_WVTA = "UKNI WVTA",
+  EU_WVTA_Pre_23 = "EU WVTA Pre 23",
+  EU_WVTA_23_on = "EU WVTA 23 on",
+  QNIG = "QNIG",
+  Prov_GB_WVTA = "Prov.GB WVTA",
+  Small_series = "Small series",
+  IVA_VCA = "IVA - VCA",
+  IVA_DVSA_NI = "IVA - DVSA/NI"
 }

--- a/types/v3/tech-record/put/trl/complete/index.d.ts
+++ b/types/v3/tech-record/put/trl/complete/index.d.ts
@@ -327,8 +327,8 @@ export const enum ApprovalType {
   EU_WVTA_Pre_23 = "EU WVTA Pre 23",
   EU_WVTA_23_on = "EU WVTA 23 on",
   QNIG = "QNIG",
-  Prov_GB_WVTA = "Prov.GB WVTA",
-  Small_series = "Small series",
+  PROV_GB_WVTA = "Prov.GB WVTA",
+  SMALL_SERIES = "Small series",
   IVA_VCA = "IVA - VCA",
   IVA_DVSA_NI = "IVA - DVSA/NI"
 }

--- a/types/v3/tech-record/put/trl/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/trl/skeleton/index.d.ts
@@ -324,8 +324,8 @@ export const enum ApprovalType {
   EU_WVTA_Pre_23 = "EU WVTA Pre 23",
   EU_WVTA_23_on = "EU WVTA 23 on",
   QNIG = "QNIG",
-  Prov_GB_WVTA = "Prov.GB WVTA",
-  Small_series = "Small series",
+  PROV_GB_WVTA = "Prov.GB WVTA",
+  SMALL_SERIES = "Small series",
   IVA_VCA = "IVA - VCA",
   IVA_DVSA_NI = "IVA - DVSA/NI"
 }

--- a/types/v3/tech-record/put/trl/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/trl/skeleton/index.d.ts
@@ -5,21 +5,6 @@
  * and run json-schema-to-typescript to regenerate this file.
  */
 
-export type ApprovalType =
-  | "NTA"
-  | "ECTA"
-  | "IVA"
-  | "NSSTA"
-  | "ECSSTA"
-  | "GB WVTA"
-  | "UKNI WVTA"
-  | "EU WVTA Pre 23"
-  | "EU WVTA 23 on"
-  | "QNIG"
-  | "Prov.GB WVTA"
-  | "Small series"
-  | "IVA - VCA"
-  | "IVA - DVSA/NI";
 export type TC2Types = "initial";
 export type TC3Types = "intermediate" | "periodic" | "exceptional";
 export type EUVehicleCategory =
@@ -326,4 +311,21 @@ export interface TRLAxles {
   tyres_fitmentCode?: null | FitmentCode;
   tyres_dataTrAxles?: null | number;
   tyres_speedCategorySymbol?: SpeedCategorySymbol | null;
+}
+
+export const enum ApprovalType {
+  NTA = "NTA",
+  ECTA = "ECTA",
+  IVA = "IVA",
+  NSSTA = "NSSTA",
+  ECSSTA = "ECSSTA",
+  GB_WVTA = "GB WVTA",
+  UKNI_WVTA = "UKNI WVTA",
+  EU_WVTA_Pre_23 = "EU WVTA Pre 23",
+  EU_WVTA_23_on = "EU WVTA 23 on",
+  QNIG = "QNIG",
+  Prov_GB_WVTA = "Prov.GB WVTA",
+  Small_series = "Small series",
+  IVA_VCA = "IVA - VCA",
+  IVA_DVSA_NI = "IVA - DVSA/NI"
 }

--- a/types/v3/tech-record/put/trl/testable/index.d.ts
+++ b/types/v3/tech-record/put/trl/testable/index.d.ts
@@ -324,8 +324,8 @@ export const enum ApprovalType {
   EU_WVTA_Pre_23 = "EU WVTA Pre 23",
   EU_WVTA_23_on = "EU WVTA 23 on",
   QNIG = "QNIG",
-  Prov_GB_WVTA = "Prov.GB WVTA",
-  Small_series = "Small series",
+  PROV_GB_WVTA = "Prov.GB WVTA",
+  SMALL_SERIES = "Small series",
   IVA_VCA = "IVA - VCA",
   IVA_DVSA_NI = "IVA - DVSA/NI"
 }

--- a/types/v3/tech-record/put/trl/testable/index.d.ts
+++ b/types/v3/tech-record/put/trl/testable/index.d.ts
@@ -5,21 +5,6 @@
  * and run json-schema-to-typescript to regenerate this file.
  */
 
-export type ApprovalType =
-  | "NTA"
-  | "ECTA"
-  | "IVA"
-  | "NSSTA"
-  | "ECSSTA"
-  | "GB WVTA"
-  | "UKNI WVTA"
-  | "EU WVTA Pre 23"
-  | "EU WVTA 23 on"
-  | "QNIG"
-  | "Prov.GB WVTA"
-  | "Small series"
-  | "IVA - VCA"
-  | "IVA - DVSA/NI";
 export type TC2Types = "initial";
 export type TC3Types = "intermediate" | "periodic" | "exceptional";
 export type EUVehicleCategory =
@@ -326,4 +311,21 @@ export interface TRLAxles {
   tyres_fitmentCode?: null | FitmentCode;
   tyres_dataTrAxles?: null | number;
   tyres_speedCategorySymbol?: SpeedCategorySymbol | null;
+}
+
+export const enum ApprovalType {
+  NTA = "NTA",
+  ECTA = "ECTA",
+  IVA = "IVA",
+  NSSTA = "NSSTA",
+  ECSSTA = "ECSSTA",
+  GB_WVTA = "GB WVTA",
+  UKNI_WVTA = "UKNI WVTA",
+  EU_WVTA_Pre_23 = "EU WVTA Pre 23",
+  EU_WVTA_23_on = "EU WVTA 23 on",
+  QNIG = "QNIG",
+  Prov_GB_WVTA = "Prov.GB WVTA",
+  Small_series = "Small series",
+  IVA_VCA = "IVA - VCA",
+  IVA_DVSA_NI = "IVA - DVSA/NI"
 }


### PR DESCRIPTION
## Ticket title

Change the types to be enums for front end VTM use.

[CB2-9603](https://dvsa.atlassian.net/browse/CB2-9603)

<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

- update to use enums for approval type type

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
