### PR TITLE
patch(cb2-9602): Enable decimal places for emissionLimit on HGV and PSV

### DIFF
--- a/json-definitions/v3/tech-record/get/hgv/complete/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/complete/index.json
@@ -561,7 +561,7 @@
     "techRecord_emissionsLimit": {
       "type": [
         "null",
-        "integer"
+        "float"
       ],
       "minimum": 0,
       "maximum": 99

--- a/json-definitions/v3/tech-record/get/hgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/skeleton/index.json
@@ -574,7 +574,7 @@
     "techRecord_emissionsLimit": {
       "type": [
         "null",
-        "integer"
+        "float"
       ],
       "minimum": 0,
       "maximum": 99

--- a/json-definitions/v3/tech-record/get/hgv/testable/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/testable/index.json
@@ -578,7 +578,7 @@
     "techRecord_emissionsLimit": {
       "type": [
         "null",
-        "integer"
+        "float"
       ],
       "minimum": 0,
       "maximum": 99

--- a/json-definitions/v3/tech-record/get/psv/complete/index.json
+++ b/json-definitions/v3/tech-record/get/psv/complete/index.json
@@ -397,7 +397,7 @@
     "techRecord_emissionsLimit": {
       "type": [
         "null",
-        "integer"
+        "float"
       ],
       "minimum": 0,
       "maximum": 99

--- a/json-definitions/v3/tech-record/get/psv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/psv/skeleton/index.json
@@ -390,7 +390,7 @@
     "techRecord_emissionsLimit": {
       "type": [
         "null",
-        "integer"
+        "float"
       ],
       "minimum": 0,
       "maximum": 99

--- a/json-definitions/v3/tech-record/get/psv/testable/index.json
+++ b/json-definitions/v3/tech-record/get/psv/testable/index.json
@@ -378,7 +378,7 @@
     "techRecord_emissionsLimit": {
       "type": [
         "null",
-        "integer"
+        "float"
       ],
       "minimum": 0,
       "maximum": 99

--- a/json-definitions/v3/tech-record/put/hgv/complete/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/complete/index.json
@@ -540,7 +540,7 @@
     "techRecord_emissionsLimit": {
       "type": [
         "null",
-        "integer"
+        "float"
       ],
       "minimum": 0,
       "maximum": 99

--- a/json-definitions/v3/tech-record/put/hgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/skeleton/index.json
@@ -551,7 +551,7 @@
     "techRecord_emissionsLimit": {
       "type": [
         "null",
-        "integer"
+        "float"
       ],
       "minimum": 0,
       "maximum": 99

--- a/json-definitions/v3/tech-record/put/hgv/testable/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/testable/index.json
@@ -547,7 +547,7 @@
     "techRecord_emissionsLimit": {
       "type": [
         "null",
-        "integer"
+        "float"
       ],
       "minimum": 0,
       "maximum": 99

--- a/json-definitions/v3/tech-record/put/psv/complete/index.json
+++ b/json-definitions/v3/tech-record/put/psv/complete/index.json
@@ -346,7 +346,7 @@
     "techRecord_emissionsLimit": {
       "type": [
         "null",
-        "integer"
+        "float"
       ],
       "minimum": 0,
       "maximum": 99

--- a/json-definitions/v3/tech-record/put/psv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/psv/skeleton/index.json
@@ -357,7 +357,7 @@
     "techRecord_emissionsLimit": {
       "type": [
         "null",
-        "integer"
+        "float"
       ],
       "minimum": 0,
       "maximum": 99

--- a/json-definitions/v3/tech-record/put/psv/testable/index.json
+++ b/json-definitions/v3/tech-record/put/psv/testable/index.json
@@ -335,7 +335,7 @@
     },
     "techRecord_trainDesignWeight": {
       "type": [
-        "integer",
+        "float",
         "null"
       ],
       "minimum": 0,

--- a/json-schemas/v3/tech-record/get/hgv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/complete/index.json
@@ -576,7 +576,7 @@
 		"techRecord_emissionsLimit": {
 			"type": [
 				"null",
-				"integer"
+				"float"
 			],
 			"minimum": 0,
 			"maximum": 99

--- a/json-schemas/v3/tech-record/get/hgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/skeleton/index.json
@@ -589,7 +589,7 @@
 		"techRecord_emissionsLimit": {
 			"type": [
 				"null",
-				"integer"
+				"float"
 			],
 			"minimum": 0,
 			"maximum": 99

--- a/json-schemas/v3/tech-record/get/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/testable/index.json
@@ -593,7 +593,7 @@
 		"techRecord_emissionsLimit": {
 			"type": [
 				"null",
-				"integer"
+				"float"
 			],
 			"minimum": 0,
 			"maximum": 99

--- a/json-schemas/v3/tech-record/get/psv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/psv/complete/index.json
@@ -512,7 +512,7 @@
 		"techRecord_emissionsLimit": {
 			"type": [
 				"null",
-				"integer"
+				"float"
 			],
 			"minimum": 0,
 			"maximum": 99

--- a/json-schemas/v3/tech-record/get/psv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/psv/skeleton/index.json
@@ -505,7 +505,7 @@
 		"techRecord_emissionsLimit": {
 			"type": [
 				"null",
-				"integer"
+				"float"
 			],
 			"minimum": 0,
 			"maximum": 99

--- a/json-schemas/v3/tech-record/get/psv/testable/index.json
+++ b/json-schemas/v3/tech-record/get/psv/testable/index.json
@@ -493,7 +493,7 @@
 		"techRecord_emissionsLimit": {
 			"type": [
 				"null",
-				"integer"
+				"float"
 			],
 			"minimum": 0,
 			"maximum": 99

--- a/json-schemas/v3/tech-record/put/hgv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/complete/index.json
@@ -555,7 +555,7 @@
 		"techRecord_emissionsLimit": {
 			"type": [
 				"null",
-				"integer"
+				"float"
 			],
 			"minimum": 0,
 			"maximum": 99

--- a/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
@@ -566,7 +566,7 @@
 		"techRecord_emissionsLimit": {
 			"type": [
 				"null",
-				"integer"
+				"float"
 			],
 			"minimum": 0,
 			"maximum": 99

--- a/json-schemas/v3/tech-record/put/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/testable/index.json
@@ -562,7 +562,7 @@
 		"techRecord_emissionsLimit": {
 			"type": [
 				"null",
-				"integer"
+				"float"
 			],
 			"minimum": 0,
 			"maximum": 99

--- a/json-schemas/v3/tech-record/put/psv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/psv/complete/index.json
@@ -461,7 +461,7 @@
 		"techRecord_emissionsLimit": {
 			"type": [
 				"null",
-				"integer"
+				"float"
 			],
 			"minimum": 0,
 			"maximum": 99

--- a/json-schemas/v3/tech-record/put/psv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/psv/skeleton/index.json
@@ -472,7 +472,7 @@
 		"techRecord_emissionsLimit": {
 			"type": [
 				"null",
-				"integer"
+				"float"
 			],
 			"minimum": 0,
 			"maximum": 99

--- a/json-schemas/v3/tech-record/put/psv/testable/index.json
+++ b/json-schemas/v3/tech-record/put/psv/testable/index.json
@@ -443,7 +443,7 @@
 		"techRecord_emissionsLimit": {
 			"type": [
 				"null",
-				"integer"
+				"float"
 			],
 			"minimum": 0,
 			"maximum": 99

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "type definitions for cvs vta and vtm applications",
   "main": "index.js",
   "repository": {

--- a/types/v3/tech-record/get/hgv/complete/index.d.ts
+++ b/types/v3/tech-record/get/hgv/complete/index.d.ts
@@ -155,7 +155,9 @@ export interface TechRecordGETHGVComplete {
   techRecord_dimensions_length: number;
   techRecord_dimensions_width: number;
   techRecord_drawbarCouplingFitted: boolean;
-  techRecord_emissionsLimit?: null | number;
+  techRecord_emissionsLimit?: null | {
+    [k: string]: unknown;
+  };
   techRecord_euroStandard: string;
   techRecord_euVehicleCategory: EUVehicleCategory;
   techRecord_frontAxleToRearAxle: number;

--- a/types/v3/tech-record/get/hgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/hgv/skeleton/index.d.ts
@@ -152,7 +152,9 @@ export interface TechRecordGETHGVSkeleton {
   techRecord_dimensions_length?: number | null;
   techRecord_dimensions_width?: number | null;
   techRecord_drawbarCouplingFitted?: boolean | null;
-  techRecord_emissionsLimit?: null | number;
+  techRecord_emissionsLimit?: null | {
+    [k: string]: unknown;
+  };
   techRecord_euroStandard?: string | null;
   techRecord_euVehicleCategory?: EUVehicleCategory | null;
   techRecord_frontAxleToRearAxle?: number | null;

--- a/types/v3/tech-record/get/hgv/testable/index.d.ts
+++ b/types/v3/tech-record/get/hgv/testable/index.d.ts
@@ -152,7 +152,9 @@ export interface TechRecordGETHGVTestable {
   techRecord_dimensions_length?: number | null;
   techRecord_dimensions_width?: number | null;
   techRecord_drawbarCouplingFitted?: boolean | null;
-  techRecord_emissionsLimit?: null | number;
+  techRecord_emissionsLimit?: null | {
+    [k: string]: unknown;
+  };
   techRecord_euroStandard?: string | null;
   techRecord_euVehicleCategory?: EUVehicleCategory | null;
   techRecord_frontAxleToRearAxle?: number | null;

--- a/types/v3/tech-record/get/psv/complete/index.d.ts
+++ b/types/v3/tech-record/get/psv/complete/index.d.ts
@@ -183,7 +183,9 @@ export interface TechRecordGETPSVComplete {
   techRecord_tachoExemptMrk?: null | boolean;
   techRecord_euroStandard?: null | EuroStandard;
   techRecord_fuelPropulsionSystem?: null | FuelPropulsionSystem;
-  techRecord_emissionsLimit?: null | number;
+  techRecord_emissionsLimit?: null | {
+    [k: string]: unknown;
+  };
   techRecord_trainDesignWeight?: number | null;
   techRecord_numberOfSeatbelts: string;
   techRecord_seatbeltInstallationApprovalDate?: string | null;

--- a/types/v3/tech-record/get/psv/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/psv/skeleton/index.d.ts
@@ -182,7 +182,9 @@ export interface TechRecordGETPSVSkeleton {
   techRecord_tachoExemptMrk?: boolean | null;
   techRecord_euroStandard?: EuroStandard | null;
   techRecord_fuelPropulsionSystem?: FuelPropulsionSystem | null;
-  techRecord_emissionsLimit?: null | number;
+  techRecord_emissionsLimit?: null | {
+    [k: string]: unknown;
+  };
   techRecord_trainDesignWeight?: number | null;
   techRecord_numberOfSeatbelts?: string | null;
   techRecord_seatbeltInstallationApprovalDate?: string | null;

--- a/types/v3/tech-record/get/psv/testable/index.d.ts
+++ b/types/v3/tech-record/get/psv/testable/index.d.ts
@@ -182,7 +182,9 @@ export interface TechRecordGETPSVTestable {
   techRecord_tachoExemptMrk?: boolean | null;
   techRecord_euroStandard?: EuroStandard | null;
   techRecord_fuelPropulsionSystem?: FuelPropulsionSystem | null;
-  techRecord_emissionsLimit?: null | number;
+  techRecord_emissionsLimit?: null | {
+    [k: string]: unknown;
+  };
   techRecord_trainDesignWeight?: number | null;
   techRecord_numberOfSeatbelts?: null | string;
   techRecord_seatbeltInstallationApprovalDate?: string | null;

--- a/types/v3/tech-record/put/hgv/complete/index.d.ts
+++ b/types/v3/tech-record/put/hgv/complete/index.d.ts
@@ -150,7 +150,9 @@ export interface TechRecordPUTHGVComplete {
   techRecord_dimensions_length: number;
   techRecord_dimensions_width: number;
   techRecord_drawbarCouplingFitted: boolean;
-  techRecord_emissionsLimit?: null | number;
+  techRecord_emissionsLimit?: null | {
+    [k: string]: unknown;
+  };
   techRecord_euroStandard: string;
   techRecord_euVehicleCategory: EUVehicleCategory;
   techRecord_frontAxleToRearAxle: number;

--- a/types/v3/tech-record/put/hgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/hgv/skeleton/index.d.ts
@@ -147,7 +147,9 @@ export interface TechRecordPUTHGVSkeleton {
   techRecord_dimensions_length?: number | null;
   techRecord_dimensions_width?: number | null;
   techRecord_drawbarCouplingFitted?: boolean | null;
-  techRecord_emissionsLimit?: null | number;
+  techRecord_emissionsLimit?: null | {
+    [k: string]: unknown;
+  };
   techRecord_euroStandard?: string | null;
   techRecord_euVehicleCategory?: EUVehicleCategory | null;
   techRecord_frontAxleToRearAxle?: number | null;

--- a/types/v3/tech-record/put/hgv/testable/index.d.ts
+++ b/types/v3/tech-record/put/hgv/testable/index.d.ts
@@ -147,7 +147,9 @@ export interface TechRecordPUTHGVTestable {
   techRecord_dimensions_length?: number | null;
   techRecord_dimensions_width?: number | null;
   techRecord_drawbarCouplingFitted?: boolean | null;
-  techRecord_emissionsLimit?: null | number;
+  techRecord_emissionsLimit?: null | {
+    [k: string]: unknown;
+  };
   techRecord_euroStandard?: string | null;
   techRecord_euVehicleCategory?: EUVehicleCategory | null;
   techRecord_frontAxleToRearAxle?: number | null;

--- a/types/v3/tech-record/put/psv/complete/index.d.ts
+++ b/types/v3/tech-record/put/psv/complete/index.d.ts
@@ -173,7 +173,9 @@ export interface TechRecordPUTPSVComplete {
   techRecord_tachoExemptMrk?: null | boolean;
   techRecord_euroStandard?: null | EuroStandard;
   techRecord_fuelPropulsionSystem?: null | FuelPropulsionSystem;
-  techRecord_emissionsLimit?: null | number;
+  techRecord_emissionsLimit?: null | {
+    [k: string]: unknown;
+  };
   techRecord_trainDesignWeight?: number | null;
   techRecord_numberOfSeatbelts: string;
   techRecord_seatbeltInstallationApprovalDate?: string | null;

--- a/types/v3/tech-record/put/psv/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/psv/skeleton/index.d.ts
@@ -173,7 +173,9 @@ export interface TechRecordPUTPSVSkeleton {
   techRecord_tachoExemptMrk?: boolean | null;
   techRecord_euroStandard?: EuroStandard | null;
   techRecord_fuelPropulsionSystem?: FuelPropulsionSystem | null;
-  techRecord_emissionsLimit?: null | number;
+  techRecord_emissionsLimit?: null | {
+    [k: string]: unknown;
+  };
   techRecord_trainDesignWeight?: number | null;
   techRecord_numberOfSeatbelts?: string | null;
   techRecord_seatbeltInstallationApprovalDate?: string | null;

--- a/types/v3/tech-record/put/psv/testable/index.d.ts
+++ b/types/v3/tech-record/put/psv/testable/index.d.ts
@@ -174,7 +174,9 @@ export interface TechRecordPUTPSVTestable {
   techRecord_euroStandard?: EuroStandard | null;
   techRecord_fuelPropulsionSystem?: FuelPropulsionSystem | null;
   techRecord_emissionsLimit?: null | number;
-  techRecord_trainDesignWeight?: number | null;
+  techRecord_trainDesignWeight?: {
+    [k: string]: unknown;
+  } | null;
   techRecord_numberOfSeatbelts?: null | string;
   techRecord_seatbeltInstallationApprovalDate?: string | null;
   techRecord_coifSerialNumber?: string | null;


### PR DESCRIPTION
## Ticket title

Enables decimal places for emissionLimit on HGV and PSV

[CB2-9602](https://dvsa.atlassian.net/browse/CB2-9602)

<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

-

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
