### PR TITLE
patch(cb2-9602): Change emissionsLimit to number for HGV and PSV

### DIFF
--- a/json-definitions/v3/tech-record/get/hgv/complete/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/complete/index.json
@@ -561,7 +561,7 @@
     "techRecord_emissionsLimit": {
       "type": [
         "null",
-        "integer"
+        "number"
       ],
       "minimum": 0,
       "maximum": 99

--- a/json-definitions/v3/tech-record/get/hgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/skeleton/index.json
@@ -574,7 +574,7 @@
     "techRecord_emissionsLimit": {
       "type": [
         "null",
-        "integer"
+        "number"
       ],
       "minimum": 0,
       "maximum": 99

--- a/json-definitions/v3/tech-record/get/hgv/testable/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/testable/index.json
@@ -578,7 +578,7 @@
     "techRecord_emissionsLimit": {
       "type": [
         "null",
-        "integer"
+        "number"
       ],
       "minimum": 0,
       "maximum": 99

--- a/json-definitions/v3/tech-record/get/psv/complete/index.json
+++ b/json-definitions/v3/tech-record/get/psv/complete/index.json
@@ -397,7 +397,7 @@
     "techRecord_emissionsLimit": {
       "type": [
         "null",
-        "integer"
+        "number"
       ],
       "minimum": 0,
       "maximum": 99

--- a/json-definitions/v3/tech-record/get/psv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/psv/skeleton/index.json
@@ -390,7 +390,7 @@
     "techRecord_emissionsLimit": {
       "type": [
         "null",
-        "integer"
+        "number"
       ],
       "minimum": 0,
       "maximum": 99

--- a/json-definitions/v3/tech-record/get/psv/testable/index.json
+++ b/json-definitions/v3/tech-record/get/psv/testable/index.json
@@ -378,7 +378,7 @@
     "techRecord_emissionsLimit": {
       "type": [
         "null",
-        "integer"
+        "number"
       ],
       "minimum": 0,
       "maximum": 99

--- a/json-definitions/v3/tech-record/put/hgv/complete/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/complete/index.json
@@ -540,7 +540,7 @@
     "techRecord_emissionsLimit": {
       "type": [
         "null",
-        "integer"
+        "number"
       ],
       "minimum": 0,
       "maximum": 99

--- a/json-definitions/v3/tech-record/put/hgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/skeleton/index.json
@@ -551,7 +551,7 @@
     "techRecord_emissionsLimit": {
       "type": [
         "null",
-        "integer"
+        "number"
       ],
       "minimum": 0,
       "maximum": 99

--- a/json-definitions/v3/tech-record/put/hgv/testable/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/testable/index.json
@@ -547,7 +547,7 @@
     "techRecord_emissionsLimit": {
       "type": [
         "null",
-        "integer"
+        "number"
       ],
       "minimum": 0,
       "maximum": 99

--- a/json-definitions/v3/tech-record/put/psv/complete/index.json
+++ b/json-definitions/v3/tech-record/put/psv/complete/index.json
@@ -346,7 +346,7 @@
     "techRecord_emissionsLimit": {
       "type": [
         "null",
-        "integer"
+        "number"
       ],
       "minimum": 0,
       "maximum": 99

--- a/json-definitions/v3/tech-record/put/psv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/psv/skeleton/index.json
@@ -357,7 +357,7 @@
     "techRecord_emissionsLimit": {
       "type": [
         "null",
-        "integer"
+        "number"
       ],
       "minimum": 0,
       "maximum": 99

--- a/json-definitions/v3/tech-record/put/psv/testable/index.json
+++ b/json-definitions/v3/tech-record/put/psv/testable/index.json
@@ -328,7 +328,7 @@
     "techRecord_emissionsLimit": {
       "type": [
         "null",
-        "integer"
+        "number"
       ],
       "minimum": 0,
       "maximum": 99

--- a/json-schemas/v3/tech-record/get/hgv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/complete/index.json
@@ -576,7 +576,7 @@
 		"techRecord_emissionsLimit": {
 			"type": [
 				"null",
-				"integer"
+				"number"
 			],
 			"minimum": 0,
 			"maximum": 99

--- a/json-schemas/v3/tech-record/get/hgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/skeleton/index.json
@@ -589,7 +589,7 @@
 		"techRecord_emissionsLimit": {
 			"type": [
 				"null",
-				"integer"
+				"number"
 			],
 			"minimum": 0,
 			"maximum": 99

--- a/json-schemas/v3/tech-record/get/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/testable/index.json
@@ -593,7 +593,7 @@
 		"techRecord_emissionsLimit": {
 			"type": [
 				"null",
-				"integer"
+				"number"
 			],
 			"minimum": 0,
 			"maximum": 99

--- a/json-schemas/v3/tech-record/get/psv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/psv/complete/index.json
@@ -512,7 +512,7 @@
 		"techRecord_emissionsLimit": {
 			"type": [
 				"null",
-				"integer"
+				"number"
 			],
 			"minimum": 0,
 			"maximum": 99

--- a/json-schemas/v3/tech-record/get/psv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/psv/skeleton/index.json
@@ -505,7 +505,7 @@
 		"techRecord_emissionsLimit": {
 			"type": [
 				"null",
-				"integer"
+				"number"
 			],
 			"minimum": 0,
 			"maximum": 99

--- a/json-schemas/v3/tech-record/get/psv/testable/index.json
+++ b/json-schemas/v3/tech-record/get/psv/testable/index.json
@@ -493,7 +493,7 @@
 		"techRecord_emissionsLimit": {
 			"type": [
 				"null",
-				"integer"
+				"number"
 			],
 			"minimum": 0,
 			"maximum": 99

--- a/json-schemas/v3/tech-record/put/hgv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/complete/index.json
@@ -555,7 +555,7 @@
 		"techRecord_emissionsLimit": {
 			"type": [
 				"null",
-				"integer"
+				"number"
 			],
 			"minimum": 0,
 			"maximum": 99

--- a/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
@@ -566,7 +566,7 @@
 		"techRecord_emissionsLimit": {
 			"type": [
 				"null",
-				"integer"
+				"number"
 			],
 			"minimum": 0,
 			"maximum": 99

--- a/json-schemas/v3/tech-record/put/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/testable/index.json
@@ -562,7 +562,7 @@
 		"techRecord_emissionsLimit": {
 			"type": [
 				"null",
-				"integer"
+				"number"
 			],
 			"minimum": 0,
 			"maximum": 99

--- a/json-schemas/v3/tech-record/put/psv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/psv/complete/index.json
@@ -461,7 +461,7 @@
 		"techRecord_emissionsLimit": {
 			"type": [
 				"null",
-				"integer"
+				"number"
 			],
 			"minimum": 0,
 			"maximum": 99

--- a/json-schemas/v3/tech-record/put/psv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/psv/skeleton/index.json
@@ -472,7 +472,7 @@
 		"techRecord_emissionsLimit": {
 			"type": [
 				"null",
-				"integer"
+				"number"
 			],
 			"minimum": 0,
 			"maximum": 99

--- a/json-schemas/v3/tech-record/put/psv/testable/index.json
+++ b/json-schemas/v3/tech-record/put/psv/testable/index.json
@@ -443,7 +443,7 @@
 		"techRecord_emissionsLimit": {
 			"type": [
 				"null",
-				"integer"
+				"number"
 			],
 			"minimum": 0,
 			"maximum": 99

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "3.6.0",
+      "version": "3.6.1",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "type definitions for cvs vta and vtm applications",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
## Ticket title

Change emissionsLimit to number for HGV and PSV

[CB2-9602](https://dvsa.atlassian.net/browse/CB2-9602)

<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

-

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
