### PR TITLE
patch(cb2-9834): add ADR fields for LGV

### DIFF
--- a/json-definitions/v3/tech-record/get/hgv/complete/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/complete/index.json
@@ -67,6 +67,12 @@
     "systemNumber": {
       "type": "string"
     },
+    "techRecord_adrDetails_dangerousGoods": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
     "techRecord_adrDetails_vehicleDetails_type": {
       "type": [
         "string",

--- a/json-definitions/v3/tech-record/get/hgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/skeleton/index.json
@@ -37,6 +37,12 @@
     "systemNumber": {
       "type": "string"
     },
+    "techRecord_adrDetails_dangerousGoods": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
     "techRecord_adrDetails_vehicleDetails_type": {
       "type": [
         "string",

--- a/json-definitions/v3/tech-record/get/hgv/testable/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/testable/index.json
@@ -41,6 +41,12 @@
     "systemNumber": {
       "type": "string"
     },
+    "techRecord_adrDetails_dangerousGoods": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
     "techRecord_adrDetails_vehicleDetails_type": {
       "type": [
         "string",

--- a/json-definitions/v3/tech-record/get/lgv/complete/index.json
+++ b/json-definitions/v3/tech-record/get/lgv/complete/index.json
@@ -72,6 +72,303 @@
       ],
       "maxLength": 255
     },
+    "techRecord_adrDetails_dangerousGoods": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_vehicleDetails_type": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_vehicleDetails_approvalDate": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_permittedDangerousGoods": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "techRecord_adrDetails_compatibilityGroupJ": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_additionalExaminerNotes": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1024
+    },
+    "techRecord_adrDetails_applicantDetails_name": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 150
+    },
+    "techRecord_adrDetails_applicantDetails_street": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 150
+    },
+    "techRecord_adrDetails_applicantDetails_town": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 100
+    },
+    "techRecord_adrDetails_applicantDetails_city": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 100
+    },
+    "techRecord_adrDetails_applicantDetails_postcode": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 25
+    },
+    "techRecord_adrDetails_memosApply": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": [
+          "string"
+        ]
+      }
+    },
+    "techRecord_adrDetails_documents": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": [
+          "string"
+        ]
+      }
+    },
+    "techRecord_adrDetails_listStatementApplicable": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_batteryListNumber": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 8
+    },
+    "techRecord_adrDetails_brakeDeclarationsSeen": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_brakeDeclarationIssuer": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_brakeEndurance": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_weight": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 8
+    },
+    "techRecord_adrDetails_declarationsSeen": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_additionalNotes_guidanceNotes": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "techRecord_adrDetails_additionalNotes_number": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "techRecord_adrDetails_adrTypeApprovalNo": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_adrCertificateNotes": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1500
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 70
+    },
+    "techRecord_adrDetails_tank_tankDetails_yearOfManufacture": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "maximum": 9999
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 50
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankTypeAppNo": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 65
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankCode": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 30
+    },
+    "techRecord_adrDetails_tank_tankDetails_specialProvisions": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1024
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2Type": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "../../../enums/tc2Types.ignore.json"
+        }
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateApprovalNo": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 70
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateExpiryDate": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc3Details_tc3Type": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "../../../enums/tc3Types.ignore.json"
+        }
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicNumber": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 75
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicExpiryDate": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_substancesPermitted": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_statement": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1500
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": [
+          "string"
+        ]
+      }
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_productList": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1500
+    },
     "createdTimestamp": {
       "type": [
         "string"

--- a/json-definitions/v3/tech-record/get/lgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/lgv/skeleton/index.json
@@ -69,6 +69,303 @@
       ],
       "maxLength": 255
     },
+    "techRecord_adrDetails_dangerousGoods": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_vehicleDetails_type": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_vehicleDetails_approvalDate": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_permittedDangerousGoods": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "techRecord_adrDetails_compatibilityGroupJ": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_additionalExaminerNotes": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1024
+    },
+    "techRecord_adrDetails_applicantDetails_name": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 150
+    },
+    "techRecord_adrDetails_applicantDetails_street": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 150
+    },
+    "techRecord_adrDetails_applicantDetails_town": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 100
+    },
+    "techRecord_adrDetails_applicantDetails_city": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 100
+    },
+    "techRecord_adrDetails_applicantDetails_postcode": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 25
+    },
+    "techRecord_adrDetails_memosApply": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": [
+          "string"
+        ]
+      }
+    },
+    "techRecord_adrDetails_documents": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": [
+          "string"
+        ]
+      }
+    },
+    "techRecord_adrDetails_listStatementApplicable": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_batteryListNumber": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 8
+    },
+    "techRecord_adrDetails_brakeDeclarationsSeen": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_brakeDeclarationIssuer": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_brakeEndurance": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_weight": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 8
+    },
+    "techRecord_adrDetails_declarationsSeen": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_additionalNotes_guidanceNotes": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "techRecord_adrDetails_additionalNotes_number": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "techRecord_adrDetails_adrTypeApprovalNo": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_adrCertificateNotes": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1500
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 70
+    },
+    "techRecord_adrDetails_tank_tankDetails_yearOfManufacture": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "maximum": 9999
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 50
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankTypeAppNo": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 65
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankCode": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 30
+    },
+    "techRecord_adrDetails_tank_tankDetails_specialProvisions": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1024
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2Type": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "../../../enums/tc2Types.ignore.json"
+        }
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateApprovalNo": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 70
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateExpiryDate": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc3Details_tc3Type": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "../../../enums/tc3Types.ignore.json"
+        }
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicNumber": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 75
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicExpiryDate": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_substancesPermitted": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_statement": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1500
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": [
+          "string"
+        ]
+      }
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_productList": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1500
+    },
     "createdTimestamp": {
       "type": [
         "string"

--- a/json-definitions/v3/tech-record/get/trl/complete/index.json
+++ b/json-definitions/v3/tech-record/get/trl/complete/index.json
@@ -49,6 +49,12 @@
     "systemNumber": {
       "type": "string"
     },
+    "techRecord_adrDetails_dangerousGoods": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
     "techRecord_adrDetails_vehicleDetails_type": {
       "type": [
         "string",

--- a/json-definitions/v3/tech-record/get/trl/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/trl/skeleton/index.json
@@ -29,6 +29,12 @@
     "systemNumber": {
       "type": "string"
     },
+    "techRecord_adrDetails_dangerousGoods": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
     "techRecord_adrDetails_vehicleDetails_type": {
       "type": [
         "string",

--- a/json-definitions/v3/tech-record/get/trl/testable/index.json
+++ b/json-definitions/v3/tech-record/get/trl/testable/index.json
@@ -31,6 +31,12 @@
     "systemNumber": {
       "type": "string"
     },
+    "techRecord_adrDetails_dangerousGoods": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
     "techRecord_adrDetails_vehicleDetails_type": {
       "type": [
         "string",

--- a/json-definitions/v3/tech-record/put/hgv/complete/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/complete/index.json
@@ -55,6 +55,12 @@
         "null"
       ]
     },
+    "techRecord_adrDetails_dangerousGoods": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
     "techRecord_adrDetails_vehicleDetails_type": {
       "type": [
         "string",

--- a/json-definitions/v3/tech-record/put/hgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/skeleton/index.json
@@ -23,6 +23,12 @@
         "null"
       ]
     },
+    "techRecord_adrDetails_dangerousGoods": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
     "techRecord_adrDetails_vehicleDetails_type": {
       "type": [
         "string",

--- a/json-definitions/v3/tech-record/put/hgv/testable/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/testable/index.json
@@ -25,6 +25,12 @@
         "null"
       ]
     },
+    "techRecord_adrDetails_dangerousGoods": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
     "techRecord_adrDetails_vehicleDetails_type": {
       "type": [
         "string",

--- a/json-definitions/v3/tech-record/put/lgv/complete/index.json
+++ b/json-definitions/v3/tech-record/put/lgv/complete/index.json
@@ -50,6 +50,303 @@
       "type": ["null", "string"],
       "maxLength": 255
     },
+    "techRecord_adrDetails_dangerousGoods": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_vehicleDetails_type": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_vehicleDetails_approvalDate": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_permittedDangerousGoods": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "techRecord_adrDetails_compatibilityGroupJ": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_additionalExaminerNotes": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1024
+    },
+    "techRecord_adrDetails_applicantDetails_name": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 150
+    },
+    "techRecord_adrDetails_applicantDetails_street": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 150
+    },
+    "techRecord_adrDetails_applicantDetails_town": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 100
+    },
+    "techRecord_adrDetails_applicantDetails_city": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 100
+    },
+    "techRecord_adrDetails_applicantDetails_postcode": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 25
+    },
+    "techRecord_adrDetails_memosApply": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": [
+          "string"
+        ]
+      }
+    },
+    "techRecord_adrDetails_documents": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": [
+          "string"
+        ]
+      }
+    },
+    "techRecord_adrDetails_listStatementApplicable": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_batteryListNumber": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 8
+    },
+    "techRecord_adrDetails_brakeDeclarationsSeen": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_brakeDeclarationIssuer": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_brakeEndurance": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_weight": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 8
+    },
+    "techRecord_adrDetails_declarationsSeen": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_additionalNotes_guidanceNotes": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "techRecord_adrDetails_additionalNotes_number": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "techRecord_adrDetails_adrTypeApprovalNo": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_adrCertificateNotes": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1500
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 70
+    },
+    "techRecord_adrDetails_tank_tankDetails_yearOfManufacture": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "maximum": 9999
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 50
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankTypeAppNo": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 65
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankCode": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 30
+    },
+    "techRecord_adrDetails_tank_tankDetails_specialProvisions": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1024
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2Type": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "../../../enums/tc2Types.ignore.json"
+        }
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateApprovalNo": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 70
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateExpiryDate": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc3Details_tc3Type": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "../../../enums/tc3Types.ignore.json"
+        }
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicNumber": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 75
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicExpiryDate": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_substancesPermitted": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_statement": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1500
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": [
+          "string"
+        ]
+      }
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_productList": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1500
+    },
     "techRecord_euVehicleCategory": {
       "anyOf": [
         {

--- a/json-definitions/v3/tech-record/put/lgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/lgv/skeleton/index.json
@@ -71,6 +71,303 @@
       ],
       "maxLength": 255
     },
+    "techRecord_adrDetails_dangerousGoods": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_vehicleDetails_type": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_vehicleDetails_approvalDate": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_permittedDangerousGoods": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "techRecord_adrDetails_compatibilityGroupJ": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_additionalExaminerNotes": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1024
+    },
+    "techRecord_adrDetails_applicantDetails_name": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 150
+    },
+    "techRecord_adrDetails_applicantDetails_street": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 150
+    },
+    "techRecord_adrDetails_applicantDetails_town": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 100
+    },
+    "techRecord_adrDetails_applicantDetails_city": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 100
+    },
+    "techRecord_adrDetails_applicantDetails_postcode": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 25
+    },
+    "techRecord_adrDetails_memosApply": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": [
+          "string"
+        ]
+      }
+    },
+    "techRecord_adrDetails_documents": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": [
+          "string"
+        ]
+      }
+    },
+    "techRecord_adrDetails_listStatementApplicable": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_batteryListNumber": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 8
+    },
+    "techRecord_adrDetails_brakeDeclarationsSeen": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_brakeDeclarationIssuer": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_brakeEndurance": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_weight": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 8
+    },
+    "techRecord_adrDetails_declarationsSeen": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_additionalNotes_guidanceNotes": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "techRecord_adrDetails_additionalNotes_number": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "techRecord_adrDetails_adrTypeApprovalNo": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_adrCertificateNotes": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1500
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 70
+    },
+    "techRecord_adrDetails_tank_tankDetails_yearOfManufacture": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "maximum": 9999
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 50
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankTypeAppNo": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 65
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankCode": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 30
+    },
+    "techRecord_adrDetails_tank_tankDetails_specialProvisions": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1024
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2Type": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "../../../enums/tc2Types.ignore.json"
+        }
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateApprovalNo": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 70
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateExpiryDate": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc3Details_tc3Type": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "../../../enums/tc3Types.ignore.json"
+        }
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicNumber": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 75
+    },
+    "techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicExpiryDate": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_substancesPermitted": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_statement": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1500
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": [
+          "string"
+        ]
+      }
+    },
+    "techRecord_adrDetails_tank_tankDetails_tankStatement_productList": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1500
+    },
     "techRecord_euVehicleCategory": {
       "anyOf": [
         {

--- a/json-definitions/v3/tech-record/put/trl/complete/index.json
+++ b/json-definitions/v3/tech-record/put/trl/complete/index.json
@@ -38,6 +38,12 @@
         "null"
       ]
     },
+    "techRecord_adrDetails_dangerousGoods": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
     "techRecord_adrDetails_vehicleDetails_type": {
       "type": [
         "string",

--- a/json-definitions/v3/tech-record/put/trl/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/trl/skeleton/index.json
@@ -53,6 +53,12 @@
         "string"
       ]
     },
+    "techRecord_adrDetails_dangerousGoods": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
     "techRecord_adrDetails_vehicleDetails_type": {
       "type": [
         "string",

--- a/json-definitions/v3/tech-record/put/trl/testable/index.json
+++ b/json-definitions/v3/tech-record/put/trl/testable/index.json
@@ -55,6 +55,12 @@
         "string"
       ]
     },
+    "techRecord_adrDetails_dangerousGoods": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
     "techRecord_adrDetails_vehicleDetails_type": {
       "type": [
         "string",

--- a/json-schemas/v3/tech-record/get/hgv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/complete/index.json
@@ -67,6 +67,12 @@
 		"systemNumber": {
 			"type": "string"
 		},
+		"techRecord_adrDetails_dangerousGoods": {
+			"type": [
+				"boolean",
+				"null"
+			]
+		},
 		"techRecord_adrDetails_vehicleDetails_type": {
 			"type": [
 				"string",

--- a/json-schemas/v3/tech-record/get/hgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/skeleton/index.json
@@ -37,6 +37,12 @@
 		"systemNumber": {
 			"type": "string"
 		},
+		"techRecord_adrDetails_dangerousGoods": {
+			"type": [
+				"boolean",
+				"null"
+			]
+		},
 		"techRecord_adrDetails_vehicleDetails_type": {
 			"type": [
 				"string",

--- a/json-schemas/v3/tech-record/get/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/testable/index.json
@@ -41,6 +41,12 @@
 		"systemNumber": {
 			"type": "string"
 		},
+		"techRecord_adrDetails_dangerousGoods": {
+			"type": [
+				"boolean",
+				"null"
+			]
+		},
 		"techRecord_adrDetails_vehicleDetails_type": {
 			"type": [
 				"string",

--- a/json-schemas/v3/tech-record/get/lgv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/lgv/complete/index.json
@@ -72,6 +72,313 @@
 			],
 			"maxLength": 255
 		},
+		"techRecord_adrDetails_dangerousGoods": {
+			"type": [
+				"boolean",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_vehicleDetails_type": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_vehicleDetails_approvalDate": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_permittedDangerousGoods": {
+			"type": [
+				"array",
+				"null"
+			],
+			"items": {
+				"type": "string"
+			}
+		},
+		"techRecord_adrDetails_compatibilityGroupJ": {
+			"type": [
+				"boolean",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_additionalExaminerNotes": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 1024
+		},
+		"techRecord_adrDetails_applicantDetails_name": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 150
+		},
+		"techRecord_adrDetails_applicantDetails_street": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 150
+		},
+		"techRecord_adrDetails_applicantDetails_town": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 100
+		},
+		"techRecord_adrDetails_applicantDetails_city": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 100
+		},
+		"techRecord_adrDetails_applicantDetails_postcode": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 25
+		},
+		"techRecord_adrDetails_memosApply": {
+			"type": [
+				"array",
+				"null"
+			],
+			"items": {
+				"type": [
+					"string"
+				]
+			}
+		},
+		"techRecord_adrDetails_documents": {
+			"type": [
+				"array",
+				"null"
+			],
+			"items": {
+				"type": [
+					"string"
+				]
+			}
+		},
+		"techRecord_adrDetails_listStatementApplicable": {
+			"type": [
+				"boolean",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_batteryListNumber": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 8
+		},
+		"techRecord_adrDetails_brakeDeclarationsSeen": {
+			"type": [
+				"boolean",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_brakeDeclarationIssuer": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_brakeEndurance": {
+			"type": [
+				"boolean",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_weight": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 8
+		},
+		"techRecord_adrDetails_declarationsSeen": {
+			"type": [
+				"boolean",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_additionalNotes_guidanceNotes": {
+			"type": [
+				"array",
+				"null"
+			],
+			"items": {
+				"type": "string"
+			}
+		},
+		"techRecord_adrDetails_additionalNotes_number": {
+			"type": [
+				"array",
+				"null"
+			],
+			"items": {
+				"type": "string"
+			}
+		},
+		"techRecord_adrDetails_adrTypeApprovalNo": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_adrCertificateNotes": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 1500
+		},
+		"techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 70
+		},
+		"techRecord_adrDetails_tank_tankDetails_yearOfManufacture": {
+			"type": [
+				"integer",
+				"null"
+			],
+			"maximum": 9999
+		},
+		"techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 50
+		},
+		"techRecord_adrDetails_tank_tankDetails_tankTypeAppNo": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 65
+		},
+		"techRecord_adrDetails_tank_tankDetails_tankCode": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 30
+		},
+		"techRecord_adrDetails_tank_tankDetails_specialProvisions": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 1024
+		},
+		"techRecord_adrDetails_tank_tankDetails_tc2Details_tc2Type": {
+			"anyOf": [
+				{
+					"type": "null"
+				},
+				{
+					"title": "TC2 Types",
+					"type": "string",
+					"enum": [
+						"initial"
+					]
+				}
+			]
+		},
+		"techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateApprovalNo": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 70
+		},
+		"techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateExpiryDate": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_tank_tankDetails_tc3Details_tc3Type": {
+			"anyOf": [
+				{
+					"type": "null"
+				},
+				{
+					"title": "TC3 Types",
+					"type": "string",
+					"enum": [
+						"intermediate",
+						"periodic",
+						"exceptional"
+					]
+				}
+			]
+		},
+		"techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicNumber": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 75
+		},
+		"techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicExpiryDate": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_tank_tankDetails_tankStatement_substancesPermitted": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_tank_tankDetails_tankStatement_statement": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 1500
+		},
+		"techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo": {
+			"type": [
+				"array",
+				"null"
+			],
+			"items": {
+				"type": [
+					"string"
+				]
+			}
+		},
+		"techRecord_adrDetails_tank_tankDetails_tankStatement_productList": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 1500
+		},
 		"createdTimestamp": {
 			"type": [
 				"string"

--- a/json-schemas/v3/tech-record/get/lgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/lgv/skeleton/index.json
@@ -69,6 +69,313 @@
 			],
 			"maxLength": 255
 		},
+		"techRecord_adrDetails_dangerousGoods": {
+			"type": [
+				"boolean",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_vehicleDetails_type": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_vehicleDetails_approvalDate": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_permittedDangerousGoods": {
+			"type": [
+				"array",
+				"null"
+			],
+			"items": {
+				"type": "string"
+			}
+		},
+		"techRecord_adrDetails_compatibilityGroupJ": {
+			"type": [
+				"boolean",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_additionalExaminerNotes": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 1024
+		},
+		"techRecord_adrDetails_applicantDetails_name": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 150
+		},
+		"techRecord_adrDetails_applicantDetails_street": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 150
+		},
+		"techRecord_adrDetails_applicantDetails_town": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 100
+		},
+		"techRecord_adrDetails_applicantDetails_city": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 100
+		},
+		"techRecord_adrDetails_applicantDetails_postcode": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 25
+		},
+		"techRecord_adrDetails_memosApply": {
+			"type": [
+				"array",
+				"null"
+			],
+			"items": {
+				"type": [
+					"string"
+				]
+			}
+		},
+		"techRecord_adrDetails_documents": {
+			"type": [
+				"array",
+				"null"
+			],
+			"items": {
+				"type": [
+					"string"
+				]
+			}
+		},
+		"techRecord_adrDetails_listStatementApplicable": {
+			"type": [
+				"boolean",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_batteryListNumber": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 8
+		},
+		"techRecord_adrDetails_brakeDeclarationsSeen": {
+			"type": [
+				"boolean",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_brakeDeclarationIssuer": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_brakeEndurance": {
+			"type": [
+				"boolean",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_weight": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 8
+		},
+		"techRecord_adrDetails_declarationsSeen": {
+			"type": [
+				"boolean",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_additionalNotes_guidanceNotes": {
+			"type": [
+				"array",
+				"null"
+			],
+			"items": {
+				"type": "string"
+			}
+		},
+		"techRecord_adrDetails_additionalNotes_number": {
+			"type": [
+				"array",
+				"null"
+			],
+			"items": {
+				"type": "string"
+			}
+		},
+		"techRecord_adrDetails_adrTypeApprovalNo": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_adrCertificateNotes": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 1500
+		},
+		"techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 70
+		},
+		"techRecord_adrDetails_tank_tankDetails_yearOfManufacture": {
+			"type": [
+				"integer",
+				"null"
+			],
+			"maximum": 9999
+		},
+		"techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 50
+		},
+		"techRecord_adrDetails_tank_tankDetails_tankTypeAppNo": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 65
+		},
+		"techRecord_adrDetails_tank_tankDetails_tankCode": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 30
+		},
+		"techRecord_adrDetails_tank_tankDetails_specialProvisions": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 1024
+		},
+		"techRecord_adrDetails_tank_tankDetails_tc2Details_tc2Type": {
+			"anyOf": [
+				{
+					"type": "null"
+				},
+				{
+					"title": "TC2 Types",
+					"type": "string",
+					"enum": [
+						"initial"
+					]
+				}
+			]
+		},
+		"techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateApprovalNo": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 70
+		},
+		"techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateExpiryDate": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_tank_tankDetails_tc3Details_tc3Type": {
+			"anyOf": [
+				{
+					"type": "null"
+				},
+				{
+					"title": "TC3 Types",
+					"type": "string",
+					"enum": [
+						"intermediate",
+						"periodic",
+						"exceptional"
+					]
+				}
+			]
+		},
+		"techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicNumber": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 75
+		},
+		"techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicExpiryDate": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_tank_tankDetails_tankStatement_substancesPermitted": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_tank_tankDetails_tankStatement_statement": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 1500
+		},
+		"techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo": {
+			"type": [
+				"array",
+				"null"
+			],
+			"items": {
+				"type": [
+					"string"
+				]
+			}
+		},
+		"techRecord_adrDetails_tank_tankDetails_tankStatement_productList": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 1500
+		},
 		"createdTimestamp": {
 			"type": [
 				"string"

--- a/json-schemas/v3/tech-record/get/trl/complete/index.json
+++ b/json-schemas/v3/tech-record/get/trl/complete/index.json
@@ -49,6 +49,12 @@
 		"systemNumber": {
 			"type": "string"
 		},
+		"techRecord_adrDetails_dangerousGoods": {
+			"type": [
+				"boolean",
+				"null"
+			]
+		},
 		"techRecord_adrDetails_vehicleDetails_type": {
 			"type": [
 				"string",

--- a/json-schemas/v3/tech-record/get/trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/trl/skeleton/index.json
@@ -29,6 +29,12 @@
 		"systemNumber": {
 			"type": "string"
 		},
+		"techRecord_adrDetails_dangerousGoods": {
+			"type": [
+				"boolean",
+				"null"
+			]
+		},
 		"techRecord_adrDetails_vehicleDetails_type": {
 			"type": [
 				"string",

--- a/json-schemas/v3/tech-record/get/trl/testable/index.json
+++ b/json-schemas/v3/tech-record/get/trl/testable/index.json
@@ -31,6 +31,12 @@
 		"systemNumber": {
 			"type": "string"
 		},
+		"techRecord_adrDetails_dangerousGoods": {
+			"type": [
+				"boolean",
+				"null"
+			]
+		},
 		"techRecord_adrDetails_vehicleDetails_type": {
 			"type": [
 				"string",

--- a/json-schemas/v3/tech-record/put/hgv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/complete/index.json
@@ -55,6 +55,12 @@
 				"null"
 			]
 		},
+		"techRecord_adrDetails_dangerousGoods": {
+			"type": [
+				"boolean",
+				"null"
+			]
+		},
 		"techRecord_adrDetails_vehicleDetails_type": {
 			"type": [
 				"string",

--- a/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
@@ -23,6 +23,12 @@
 				"null"
 			]
 		},
+		"techRecord_adrDetails_dangerousGoods": {
+			"type": [
+				"boolean",
+				"null"
+			]
+		},
 		"techRecord_adrDetails_vehicleDetails_type": {
 			"type": [
 				"string",

--- a/json-schemas/v3/tech-record/put/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/testable/index.json
@@ -25,6 +25,12 @@
 				"null"
 			]
 		},
+		"techRecord_adrDetails_dangerousGoods": {
+			"type": [
+				"boolean",
+				"null"
+			]
+		},
 		"techRecord_adrDetails_vehicleDetails_type": {
 			"type": [
 				"string",

--- a/json-schemas/v3/tech-record/put/lgv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/lgv/complete/index.json
@@ -74,6 +74,313 @@
 			],
 			"maxLength": 255
 		},
+		"techRecord_adrDetails_dangerousGoods": {
+			"type": [
+				"boolean",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_vehicleDetails_type": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_vehicleDetails_approvalDate": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_permittedDangerousGoods": {
+			"type": [
+				"array",
+				"null"
+			],
+			"items": {
+				"type": "string"
+			}
+		},
+		"techRecord_adrDetails_compatibilityGroupJ": {
+			"type": [
+				"boolean",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_additionalExaminerNotes": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 1024
+		},
+		"techRecord_adrDetails_applicantDetails_name": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 150
+		},
+		"techRecord_adrDetails_applicantDetails_street": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 150
+		},
+		"techRecord_adrDetails_applicantDetails_town": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 100
+		},
+		"techRecord_adrDetails_applicantDetails_city": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 100
+		},
+		"techRecord_adrDetails_applicantDetails_postcode": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 25
+		},
+		"techRecord_adrDetails_memosApply": {
+			"type": [
+				"array",
+				"null"
+			],
+			"items": {
+				"type": [
+					"string"
+				]
+			}
+		},
+		"techRecord_adrDetails_documents": {
+			"type": [
+				"array",
+				"null"
+			],
+			"items": {
+				"type": [
+					"string"
+				]
+			}
+		},
+		"techRecord_adrDetails_listStatementApplicable": {
+			"type": [
+				"boolean",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_batteryListNumber": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 8
+		},
+		"techRecord_adrDetails_brakeDeclarationsSeen": {
+			"type": [
+				"boolean",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_brakeDeclarationIssuer": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_brakeEndurance": {
+			"type": [
+				"boolean",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_weight": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 8
+		},
+		"techRecord_adrDetails_declarationsSeen": {
+			"type": [
+				"boolean",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_additionalNotes_guidanceNotes": {
+			"type": [
+				"array",
+				"null"
+			],
+			"items": {
+				"type": "string"
+			}
+		},
+		"techRecord_adrDetails_additionalNotes_number": {
+			"type": [
+				"array",
+				"null"
+			],
+			"items": {
+				"type": "string"
+			}
+		},
+		"techRecord_adrDetails_adrTypeApprovalNo": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_adrCertificateNotes": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 1500
+		},
+		"techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 70
+		},
+		"techRecord_adrDetails_tank_tankDetails_yearOfManufacture": {
+			"type": [
+				"integer",
+				"null"
+			],
+			"maximum": 9999
+		},
+		"techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 50
+		},
+		"techRecord_adrDetails_tank_tankDetails_tankTypeAppNo": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 65
+		},
+		"techRecord_adrDetails_tank_tankDetails_tankCode": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 30
+		},
+		"techRecord_adrDetails_tank_tankDetails_specialProvisions": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 1024
+		},
+		"techRecord_adrDetails_tank_tankDetails_tc2Details_tc2Type": {
+			"anyOf": [
+				{
+					"type": "null"
+				},
+				{
+					"title": "TC2 Types",
+					"type": "string",
+					"enum": [
+						"initial"
+					]
+				}
+			]
+		},
+		"techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateApprovalNo": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 70
+		},
+		"techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateExpiryDate": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_tank_tankDetails_tc3Details_tc3Type": {
+			"anyOf": [
+				{
+					"type": "null"
+				},
+				{
+					"title": "TC3 Types",
+					"type": "string",
+					"enum": [
+						"intermediate",
+						"periodic",
+						"exceptional"
+					]
+				}
+			]
+		},
+		"techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicNumber": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 75
+		},
+		"techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicExpiryDate": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_tank_tankDetails_tankStatement_substancesPermitted": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_tank_tankDetails_tankStatement_statement": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 1500
+		},
+		"techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo": {
+			"type": [
+				"array",
+				"null"
+			],
+			"items": {
+				"type": [
+					"string"
+				]
+			}
+		},
+		"techRecord_adrDetails_tank_tankDetails_tankStatement_productList": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 1500
+		},
 		"techRecord_euVehicleCategory": {
 			"anyOf": [
 				{

--- a/json-schemas/v3/tech-record/put/lgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/lgv/skeleton/index.json
@@ -71,6 +71,313 @@
 			],
 			"maxLength": 255
 		},
+		"techRecord_adrDetails_dangerousGoods": {
+			"type": [
+				"boolean",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_vehicleDetails_type": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_vehicleDetails_approvalDate": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_permittedDangerousGoods": {
+			"type": [
+				"array",
+				"null"
+			],
+			"items": {
+				"type": "string"
+			}
+		},
+		"techRecord_adrDetails_compatibilityGroupJ": {
+			"type": [
+				"boolean",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_additionalExaminerNotes": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 1024
+		},
+		"techRecord_adrDetails_applicantDetails_name": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 150
+		},
+		"techRecord_adrDetails_applicantDetails_street": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 150
+		},
+		"techRecord_adrDetails_applicantDetails_town": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 100
+		},
+		"techRecord_adrDetails_applicantDetails_city": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 100
+		},
+		"techRecord_adrDetails_applicantDetails_postcode": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 25
+		},
+		"techRecord_adrDetails_memosApply": {
+			"type": [
+				"array",
+				"null"
+			],
+			"items": {
+				"type": [
+					"string"
+				]
+			}
+		},
+		"techRecord_adrDetails_documents": {
+			"type": [
+				"array",
+				"null"
+			],
+			"items": {
+				"type": [
+					"string"
+				]
+			}
+		},
+		"techRecord_adrDetails_listStatementApplicable": {
+			"type": [
+				"boolean",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_batteryListNumber": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 8
+		},
+		"techRecord_adrDetails_brakeDeclarationsSeen": {
+			"type": [
+				"boolean",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_brakeDeclarationIssuer": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_brakeEndurance": {
+			"type": [
+				"boolean",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_weight": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 8
+		},
+		"techRecord_adrDetails_declarationsSeen": {
+			"type": [
+				"boolean",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_additionalNotes_guidanceNotes": {
+			"type": [
+				"array",
+				"null"
+			],
+			"items": {
+				"type": "string"
+			}
+		},
+		"techRecord_adrDetails_additionalNotes_number": {
+			"type": [
+				"array",
+				"null"
+			],
+			"items": {
+				"type": "string"
+			}
+		},
+		"techRecord_adrDetails_adrTypeApprovalNo": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_adrCertificateNotes": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 1500
+		},
+		"techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 70
+		},
+		"techRecord_adrDetails_tank_tankDetails_yearOfManufacture": {
+			"type": [
+				"integer",
+				"null"
+			],
+			"maximum": 9999
+		},
+		"techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 50
+		},
+		"techRecord_adrDetails_tank_tankDetails_tankTypeAppNo": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 65
+		},
+		"techRecord_adrDetails_tank_tankDetails_tankCode": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 30
+		},
+		"techRecord_adrDetails_tank_tankDetails_specialProvisions": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 1024
+		},
+		"techRecord_adrDetails_tank_tankDetails_tc2Details_tc2Type": {
+			"anyOf": [
+				{
+					"type": "null"
+				},
+				{
+					"title": "TC2 Types",
+					"type": "string",
+					"enum": [
+						"initial"
+					]
+				}
+			]
+		},
+		"techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateApprovalNo": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 70
+		},
+		"techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateExpiryDate": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_tank_tankDetails_tc3Details_tc3Type": {
+			"anyOf": [
+				{
+					"type": "null"
+				},
+				{
+					"title": "TC3 Types",
+					"type": "string",
+					"enum": [
+						"intermediate",
+						"periodic",
+						"exceptional"
+					]
+				}
+			]
+		},
+		"techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicNumber": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 75
+		},
+		"techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicExpiryDate": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_tank_tankDetails_tankStatement_substancesPermitted": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_tank_tankDetails_tankStatement_statement": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 1500
+		},
+		"techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo": {
+			"type": [
+				"array",
+				"null"
+			],
+			"items": {
+				"type": [
+					"string"
+				]
+			}
+		},
+		"techRecord_adrDetails_tank_tankDetails_tankStatement_productList": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 1500
+		},
 		"techRecord_euVehicleCategory": {
 			"anyOf": [
 				{

--- a/json-schemas/v3/tech-record/put/trl/complete/index.json
+++ b/json-schemas/v3/tech-record/put/trl/complete/index.json
@@ -38,6 +38,12 @@
 				"null"
 			]
 		},
+		"techRecord_adrDetails_dangerousGoods": {
+			"type": [
+				"boolean",
+				"null"
+			]
+		},
 		"techRecord_adrDetails_vehicleDetails_type": {
 			"type": [
 				"string",

--- a/json-schemas/v3/tech-record/put/trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/trl/skeleton/index.json
@@ -88,6 +88,12 @@
 				"string"
 			]
 		},
+		"techRecord_adrDetails_dangerousGoods": {
+			"type": [
+				"boolean",
+				"null"
+			]
+		},
 		"techRecord_adrDetails_vehicleDetails_type": {
 			"type": [
 				"string",

--- a/json-schemas/v3/tech-record/put/trl/testable/index.json
+++ b/json-schemas/v3/tech-record/put/trl/testable/index.json
@@ -90,6 +90,12 @@
 				"string"
 			]
 		},
+		"techRecord_adrDetails_dangerousGoods": {
+			"type": [
+				"boolean",
+				"null"
+			]
+		},
 		"techRecord_adrDetails_vehicleDetails_type": {
 			"type": [
 				"string",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "3.6.2",
+      "version": "3.6.3",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "description": "type definitions for cvs vta and vtm applications",
   "main": "index.js",
   "repository": {

--- a/types/v3/tech-record/get/hgv/complete/index.d.ts
+++ b/types/v3/tech-record/get/hgv/complete/index.d.ts
@@ -88,6 +88,7 @@ export interface TechRecordGETHGVComplete {
   createdTimestamp: string;
   partialVin: string;
   systemNumber: string;
+  techRecord_adrDetails_dangerousGoods?: boolean | null;
   techRecord_adrDetails_vehicleDetails_type?: string | null;
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;
   techRecord_adrDetails_permittedDangerousGoods?: string[] | null;

--- a/types/v3/tech-record/get/hgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/hgv/skeleton/index.d.ts
@@ -88,6 +88,7 @@ export interface TechRecordGETHGVSkeleton {
   createdTimestamp: string;
   partialVin: string;
   systemNumber: string;
+  techRecord_adrDetails_dangerousGoods?: boolean | null;
   techRecord_adrDetails_vehicleDetails_type?: string | null;
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;
   techRecord_adrDetails_permittedDangerousGoods?: string[] | null;

--- a/types/v3/tech-record/get/hgv/testable/index.d.ts
+++ b/types/v3/tech-record/get/hgv/testable/index.d.ts
@@ -88,6 +88,7 @@ export interface TechRecordGETHGVTestable {
   createdTimestamp: string;
   partialVin: string;
   systemNumber: string;
+  techRecord_adrDetails_dangerousGoods?: boolean | null;
   techRecord_adrDetails_vehicleDetails_type?: string | null;
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;
   techRecord_adrDetails_permittedDangerousGoods?: string[] | null;

--- a/types/v3/tech-record/get/lgv/complete/index.d.ts
+++ b/types/v3/tech-record/get/lgv/complete/index.d.ts
@@ -5,6 +5,8 @@
  * and run json-schema-to-typescript to regenerate this file.
  */
 
+export type TC2Types = "initial";
+export type TC3Types = "intermediate" | "periodic" | "exceptional";
 export type StatusCode = "provisional" | "current" | "archived";
 export type VehicleSubclass = ("n" | "p" | "a" | "s" | "c" | "l" | "t" | "e" | "m" | "r" | "w")[];
 
@@ -17,6 +19,47 @@ export interface TechRecordGETLGVComplete {
   techRecord_applicantDetails_postCode?: null | string;
   techRecord_applicantDetails_telephoneNumber?: null | string;
   techRecord_applicantDetails_emailAddress?: null | string;
+  techRecord_adrDetails_dangerousGoods?: boolean | null;
+  techRecord_adrDetails_vehicleDetails_type?: string | null;
+  techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;
+  techRecord_adrDetails_permittedDangerousGoods?: string[] | null;
+  techRecord_adrDetails_compatibilityGroupJ?: boolean | null;
+  techRecord_adrDetails_additionalExaminerNotes?: string | null;
+  techRecord_adrDetails_applicantDetails_name?: string | null;
+  techRecord_adrDetails_applicantDetails_street?: string | null;
+  techRecord_adrDetails_applicantDetails_town?: string | null;
+  techRecord_adrDetails_applicantDetails_city?: string | null;
+  techRecord_adrDetails_applicantDetails_postcode?: string | null;
+  techRecord_adrDetails_memosApply?: string[] | null;
+  techRecord_adrDetails_documents?: string[] | null;
+  techRecord_adrDetails_listStatementApplicable?: boolean | null;
+  techRecord_adrDetails_batteryListNumber?: string | null;
+  techRecord_adrDetails_brakeDeclarationsSeen?: boolean | null;
+  techRecord_adrDetails_brakeDeclarationIssuer?: string | null;
+  techRecord_adrDetails_brakeEndurance?: boolean | null;
+  techRecord_adrDetails_weight?: string | null;
+  techRecord_adrDetails_declarationsSeen?: boolean | null;
+  techRecord_adrDetails_additionalNotes_guidanceNotes?: string[] | null;
+  techRecord_adrDetails_additionalNotes_number?: string[] | null;
+  techRecord_adrDetails_adrTypeApprovalNo?: string | null;
+  techRecord_adrDetails_adrCertificateNotes?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tankManufacturer?: string | null;
+  techRecord_adrDetails_tank_tankDetails_yearOfManufacture?: number | null;
+  techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tankTypeAppNo?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tankCode?: string | null;
+  techRecord_adrDetails_tank_tankDetails_specialProvisions?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tc2Details_tc2Type?: null | TC2Types;
+  techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateApprovalNo?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateExpiryDate?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tc3Details_tc3Type?: null | TC3Types;
+  techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicNumber?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicExpiryDate?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tankStatement_substancesPermitted?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tankStatement_statement?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo?: string[] | null;
+  techRecord_adrDetails_tank_tankDetails_tankStatement_productList?: string | null;
   createdTimestamp: string;
   partialVin?: null | string;
   primaryVrm?: null | string;

--- a/types/v3/tech-record/get/lgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/lgv/skeleton/index.d.ts
@@ -5,6 +5,8 @@
  * and run json-schema-to-typescript to regenerate this file.
  */
 
+export type TC2Types = "initial";
+export type TC3Types = "intermediate" | "periodic" | "exceptional";
 export type StatusCode = "provisional" | "current" | "archived";
 export type VehicleSubclass = ("n" | "p" | "a" | "s" | "c" | "l" | "t" | "e" | "m" | "r" | "w")[];
 
@@ -17,6 +19,47 @@ export interface TechRecordGETLGVSkeleton {
   techRecord_applicantDetails_postCode?: null | string;
   techRecord_applicantDetails_telephoneNumber?: null | string;
   techRecord_applicantDetails_emailAddress?: null | string;
+  techRecord_adrDetails_dangerousGoods?: boolean | null;
+  techRecord_adrDetails_vehicleDetails_type?: string | null;
+  techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;
+  techRecord_adrDetails_permittedDangerousGoods?: string[] | null;
+  techRecord_adrDetails_compatibilityGroupJ?: boolean | null;
+  techRecord_adrDetails_additionalExaminerNotes?: string | null;
+  techRecord_adrDetails_applicantDetails_name?: string | null;
+  techRecord_adrDetails_applicantDetails_street?: string | null;
+  techRecord_adrDetails_applicantDetails_town?: string | null;
+  techRecord_adrDetails_applicantDetails_city?: string | null;
+  techRecord_adrDetails_applicantDetails_postcode?: string | null;
+  techRecord_adrDetails_memosApply?: string[] | null;
+  techRecord_adrDetails_documents?: string[] | null;
+  techRecord_adrDetails_listStatementApplicable?: boolean | null;
+  techRecord_adrDetails_batteryListNumber?: string | null;
+  techRecord_adrDetails_brakeDeclarationsSeen?: boolean | null;
+  techRecord_adrDetails_brakeDeclarationIssuer?: string | null;
+  techRecord_adrDetails_brakeEndurance?: boolean | null;
+  techRecord_adrDetails_weight?: string | null;
+  techRecord_adrDetails_declarationsSeen?: boolean | null;
+  techRecord_adrDetails_additionalNotes_guidanceNotes?: string[] | null;
+  techRecord_adrDetails_additionalNotes_number?: string[] | null;
+  techRecord_adrDetails_adrTypeApprovalNo?: string | null;
+  techRecord_adrDetails_adrCertificateNotes?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tankManufacturer?: string | null;
+  techRecord_adrDetails_tank_tankDetails_yearOfManufacture?: number | null;
+  techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tankTypeAppNo?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tankCode?: string | null;
+  techRecord_adrDetails_tank_tankDetails_specialProvisions?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tc2Details_tc2Type?: null | TC2Types;
+  techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateApprovalNo?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateExpiryDate?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tc3Details_tc3Type?: null | TC3Types;
+  techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicNumber?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicExpiryDate?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tankStatement_substancesPermitted?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tankStatement_statement?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo?: string[] | null;
+  techRecord_adrDetails_tank_tankDetails_tankStatement_productList?: string | null;
   createdTimestamp: string;
   partialVin?: null | string;
   primaryVrm?: null | string;

--- a/types/v3/tech-record/get/trl/complete/index.d.ts
+++ b/types/v3/tech-record/get/trl/complete/index.d.ts
@@ -105,6 +105,7 @@ export interface TechRecordGETTRLComplete {
   createdTimestamp: string;
   partialVin: string;
   systemNumber: string;
+  techRecord_adrDetails_dangerousGoods?: boolean | null;
   techRecord_adrDetails_vehicleDetails_type?: string | null;
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;
   techRecord_adrDetails_permittedDangerousGoods?: string[] | null;

--- a/types/v3/tech-record/get/trl/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/trl/skeleton/index.d.ts
@@ -105,6 +105,7 @@ export interface TechRecordGETTRLSkeleton {
   createdTimestamp: string;
   partialVin: string;
   systemNumber: string;
+  techRecord_adrDetails_dangerousGoods?: boolean | null;
   techRecord_adrDetails_vehicleDetails_type?: string | null;
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;
   techRecord_adrDetails_permittedDangerousGoods?: string[] | null;

--- a/types/v3/tech-record/get/trl/testable/index.d.ts
+++ b/types/v3/tech-record/get/trl/testable/index.d.ts
@@ -105,6 +105,7 @@ export interface TechRecordGETTRLTestable {
   createdTimestamp: string;
   partialVin: string;
   systemNumber: string;
+  techRecord_adrDetails_dangerousGoods?: boolean | null;
   techRecord_adrDetails_vehicleDetails_type?: string | null;
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;
   techRecord_adrDetails_permittedDangerousGoods?: string[] | null;

--- a/types/v3/tech-record/put/hgv/complete/index.d.ts
+++ b/types/v3/tech-record/put/hgv/complete/index.d.ts
@@ -86,6 +86,7 @@ export type StatusCode = "provisional" | "current" | "archived";
 export interface TechRecordPUTHGVComplete {
   secondaryVrms?: string[];
   partialVin?: string | null;
+  techRecord_adrDetails_dangerousGoods?: boolean | null;
   techRecord_adrDetails_vehicleDetails_type?: string | null;
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;
   techRecord_adrDetails_permittedDangerousGoods?: string[] | null;

--- a/types/v3/tech-record/put/hgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/hgv/skeleton/index.d.ts
@@ -86,6 +86,7 @@ export type StatusCode = "provisional" | "current" | "archived";
 export interface TechRecordPUTHGVSkeleton {
   secondaryVrms?: string[];
   partialVin?: string | null;
+  techRecord_adrDetails_dangerousGoods?: boolean | null;
   techRecord_adrDetails_vehicleDetails_type?: string | null;
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;
   techRecord_adrDetails_permittedDangerousGoods?: string[] | null;

--- a/types/v3/tech-record/put/hgv/testable/index.d.ts
+++ b/types/v3/tech-record/put/hgv/testable/index.d.ts
@@ -86,6 +86,7 @@ export type StatusCode = "provisional" | "current" | "archived";
 export interface TechRecordPUTHGVTestable {
   secondaryVrms?: string[];
   partialVin?: string | null;
+  techRecord_adrDetails_dangerousGoods?: boolean | null;
   techRecord_adrDetails_vehicleDetails_type?: string | null;
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;
   techRecord_adrDetails_permittedDangerousGoods?: string[] | null;

--- a/types/v3/tech-record/put/lgv/complete/index.d.ts
+++ b/types/v3/tech-record/put/lgv/complete/index.d.ts
@@ -5,6 +5,8 @@
  * and run json-schema-to-typescript to regenerate this file.
  */
 
+export type TC2Types = "initial";
+export type TC3Types = "intermediate" | "periodic" | "exceptional";
 export type StatusCode = "provisional" | "current" | "archived";
 export type VehicleSubclass = ("n" | "p" | "a" | "s" | "c" | "l" | "t" | "e" | "m" | "r" | "w")[];
 
@@ -19,6 +21,47 @@ export interface TechRecordPUTLGVComplete {
   techRecord_applicantDetails_postCode?: null | string;
   techRecord_applicantDetails_telephoneNumber?: null | string;
   techRecord_applicantDetails_emailAddress?: null | string;
+  techRecord_adrDetails_dangerousGoods?: boolean | null;
+  techRecord_adrDetails_vehicleDetails_type?: string | null;
+  techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;
+  techRecord_adrDetails_permittedDangerousGoods?: string[] | null;
+  techRecord_adrDetails_compatibilityGroupJ?: boolean | null;
+  techRecord_adrDetails_additionalExaminerNotes?: string | null;
+  techRecord_adrDetails_applicantDetails_name?: string | null;
+  techRecord_adrDetails_applicantDetails_street?: string | null;
+  techRecord_adrDetails_applicantDetails_town?: string | null;
+  techRecord_adrDetails_applicantDetails_city?: string | null;
+  techRecord_adrDetails_applicantDetails_postcode?: string | null;
+  techRecord_adrDetails_memosApply?: string[] | null;
+  techRecord_adrDetails_documents?: string[] | null;
+  techRecord_adrDetails_listStatementApplicable?: boolean | null;
+  techRecord_adrDetails_batteryListNumber?: string | null;
+  techRecord_adrDetails_brakeDeclarationsSeen?: boolean | null;
+  techRecord_adrDetails_brakeDeclarationIssuer?: string | null;
+  techRecord_adrDetails_brakeEndurance?: boolean | null;
+  techRecord_adrDetails_weight?: string | null;
+  techRecord_adrDetails_declarationsSeen?: boolean | null;
+  techRecord_adrDetails_additionalNotes_guidanceNotes?: string[] | null;
+  techRecord_adrDetails_additionalNotes_number?: string[] | null;
+  techRecord_adrDetails_adrTypeApprovalNo?: string | null;
+  techRecord_adrDetails_adrCertificateNotes?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tankManufacturer?: string | null;
+  techRecord_adrDetails_tank_tankDetails_yearOfManufacture?: number | null;
+  techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tankTypeAppNo?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tankCode?: string | null;
+  techRecord_adrDetails_tank_tankDetails_specialProvisions?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tc2Details_tc2Type?: null | TC2Types;
+  techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateApprovalNo?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateExpiryDate?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tc3Details_tc3Type?: null | TC3Types;
+  techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicNumber?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicExpiryDate?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tankStatement_substancesPermitted?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tankStatement_statement?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo?: string[] | null;
+  techRecord_adrDetails_tank_tankDetails_tankStatement_productList?: string | null;
   techRecord_euVehicleCategory?: EUVehicleCategory | null;
   techRecord_reasonForCreation: string;
   techRecord_vehicleType: "lgv";

--- a/types/v3/tech-record/put/lgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/lgv/skeleton/index.d.ts
@@ -5,6 +5,8 @@
  * and run json-schema-to-typescript to regenerate this file.
  */
 
+export type TC2Types = "initial";
+export type TC3Types = "intermediate" | "periodic" | "exceptional";
 export type StatusCode = "provisional" | "current" | "archived";
 export type VehicleSubclass = ("n" | "p" | "a" | "s" | "c" | "l" | "t" | "e" | "m" | "r" | "w")[];
 
@@ -19,6 +21,47 @@ export interface TechRecordPUTLGVSkeleton {
   techRecord_applicantDetails_postCode?: null | string;
   techRecord_applicantDetails_telephoneNumber?: null | string;
   techRecord_applicantDetails_emailAddress?: null | string;
+  techRecord_adrDetails_dangerousGoods?: boolean | null;
+  techRecord_adrDetails_vehicleDetails_type?: string | null;
+  techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;
+  techRecord_adrDetails_permittedDangerousGoods?: string[] | null;
+  techRecord_adrDetails_compatibilityGroupJ?: boolean | null;
+  techRecord_adrDetails_additionalExaminerNotes?: string | null;
+  techRecord_adrDetails_applicantDetails_name?: string | null;
+  techRecord_adrDetails_applicantDetails_street?: string | null;
+  techRecord_adrDetails_applicantDetails_town?: string | null;
+  techRecord_adrDetails_applicantDetails_city?: string | null;
+  techRecord_adrDetails_applicantDetails_postcode?: string | null;
+  techRecord_adrDetails_memosApply?: string[] | null;
+  techRecord_adrDetails_documents?: string[] | null;
+  techRecord_adrDetails_listStatementApplicable?: boolean | null;
+  techRecord_adrDetails_batteryListNumber?: string | null;
+  techRecord_adrDetails_brakeDeclarationsSeen?: boolean | null;
+  techRecord_adrDetails_brakeDeclarationIssuer?: string | null;
+  techRecord_adrDetails_brakeEndurance?: boolean | null;
+  techRecord_adrDetails_weight?: string | null;
+  techRecord_adrDetails_declarationsSeen?: boolean | null;
+  techRecord_adrDetails_additionalNotes_guidanceNotes?: string[] | null;
+  techRecord_adrDetails_additionalNotes_number?: string[] | null;
+  techRecord_adrDetails_adrTypeApprovalNo?: string | null;
+  techRecord_adrDetails_adrCertificateNotes?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tankManufacturer?: string | null;
+  techRecord_adrDetails_tank_tankDetails_yearOfManufacture?: number | null;
+  techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tankTypeAppNo?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tankCode?: string | null;
+  techRecord_adrDetails_tank_tankDetails_specialProvisions?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tc2Details_tc2Type?: null | TC2Types;
+  techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateApprovalNo?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateExpiryDate?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tc3Details_tc3Type?: null | TC3Types;
+  techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicNumber?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tc3Type_tc3PeriodicExpiryDate?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tankStatement_substancesPermitted?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tankStatement_statement?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo?: string | null;
+  techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo?: string[] | null;
+  techRecord_adrDetails_tank_tankDetails_tankStatement_productList?: string | null;
   techRecord_euVehicleCategory?: EUVehicleCategory | null;
   techRecord_reasonForCreation: string;
   techRecord_vehicleType: "lgv";

--- a/types/v3/tech-record/put/trl/complete/index.d.ts
+++ b/types/v3/tech-record/put/trl/complete/index.d.ts
@@ -103,6 +103,7 @@ export type SpeedCategorySymbol =
 
 export interface TechRecordPUTTRLComplete {
   partialVin?: string | null;
+  techRecord_adrDetails_dangerousGoods?: boolean | null;
   techRecord_adrDetails_vehicleDetails_type?: string | null;
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;
   techRecord_adrDetails_permittedDangerousGoods?: string[] | null;

--- a/types/v3/tech-record/put/trl/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/trl/skeleton/index.d.ts
@@ -108,6 +108,7 @@ export interface TechRecordPUTTRLSkeleton {
   techRecord_ntaNumber?: null | string;
   techRecord_variantNumber?: null | string;
   techRecord_variantVersionNumber?: null | string;
+  techRecord_adrDetails_dangerousGoods?: boolean | null;
   techRecord_adrDetails_vehicleDetails_type?: string | null;
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;
   techRecord_adrDetails_permittedDangerousGoods?: string[] | null;

--- a/types/v3/tech-record/put/trl/testable/index.d.ts
+++ b/types/v3/tech-record/put/trl/testable/index.d.ts
@@ -108,6 +108,7 @@ export interface TechRecordPUTTRLTestable {
   techRecord_ntaNumber?: null | string;
   techRecord_variantNumber?: null | string;
   techRecord_variantVersionNumber?: null | string;
+  techRecord_adrDetails_dangerousGoods?: boolean | null;
   techRecord_adrDetails_vehicleDetails_type?: string | null;
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;
   techRecord_adrDetails_permittedDangerousGoods?: string[] | null;


### PR DESCRIPTION
## Add Applicant/Operator Details to ADR section on a Technical Record


[CB2-9834](https://dvsa.atlassian.net/browse/CB2-9834)

<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

- field techRecord_adrDetails_dangerousGoods added to hgv and trailer
- 43 ADR fields added to LGV get and put model

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
