### PR TITLE
patch(CB2-9874): implements additionalInformation to schema

### DIFF
--- a/json-definitions/iva/defects/get/index.json
+++ b/json-definitions/iva/defects/get/index.json
@@ -73,6 +73,15 @@
           }
         }
       }
+    },
+    "additionalInformation": {
+      "type": "object",
+      "additionalProperties" : false,
+      "properties": {
+        "notes" : {
+          "type" : ["string"]
+        }
+      }
     }
   }
 }

--- a/json-schemas/iva/defects/get/index.json
+++ b/json-schemas/iva/defects/get/index.json
@@ -140,6 +140,17 @@
 					}
 				}
 			}
+		},
+		"additionalInformation": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"notes": {
+					"type": [
+						"string"
+					]
+				}
+			}
 		}
 	}
 }

--- a/types/iva/defects/get/index.d.ts
+++ b/types/iva/defects/get/index.d.ts
@@ -20,6 +20,9 @@ export interface DefectGETIVA {
     additionalInfo: boolean;
     inspectionTypes: InspectionType[];
   }[];
+  additionalInformation?: {
+    notes?: string;
+  };
 }
 
 export enum EUVehicleCategory {


### PR DESCRIPTION
## CB2-9874

_One line description_
Implements AdditionalInformation object to json schema

[CB2-9874](https://dvsa.atlassian.net/browse/CB2-9874)

<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

-Implements AdditionalInformation object to json definitions with 1 property 'notes' of type 'string'. 
- generates object to json schema and index.d.ts

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
