### PR TITLE
major(cb2-9874): Introduce the AdditionalInformation object to IVA defect JSON schema

### DIFF
--- a/json-definitions/iva/defects/get/index.json
+++ b/json-definitions/iva/defects/get/index.json
@@ -16,16 +16,6 @@
     "sectionDescription": {
       "type": ["string"]
     },
-    "vehicleTypes": {
-      "type": "array",
-      "items": {
-        "anyOf": [
-          {
-            "$ref": "../../../v3/tech-record/enums/vehicleType.ignore.json"
-          }
-        ]
-      }
-    },
     "euVehicleCategories": {
       "type": "array",
       "items": {
@@ -45,8 +35,7 @@
           "rsNumber",
           "requiredStandard",
           "refCalculation",
-          "additionalInfo",
-          "inspectionTypes"
+          "additionalInfo"
         ],
         "properties": {
           "rsNumber": {
@@ -71,6 +60,16 @@
               ]
             }
           }
+        }
+      }
+    },
+    "additionalInformation": {
+      "type": "object",
+      "additionalProperties" : false,
+      "required" : ["notes"],
+      "properties": {
+        "notes" : {
+          "type" : ["string"]
         }
       }
     }

--- a/json-schemas/iva/defects/get/index.json
+++ b/json-schemas/iva/defects/get/index.json
@@ -20,25 +20,6 @@
 				"string"
 			]
 		},
-		"vehicleTypes": {
-			"type": "array",
-			"items": {
-				"anyOf": [
-					{
-						"title": "Vehicle Type",
-						"type": "string",
-						"enum": [
-							"psv",
-							"trl",
-							"hgv",
-							"car",
-							"lgv",
-							"motorcycle"
-						]
-					}
-				]
-			}
-		},
 		"euVehicleCategories": {
 			"type": "array",
 			"items": {
@@ -99,8 +80,7 @@
 					"rsNumber",
 					"requiredStandard",
 					"refCalculation",
-					"additionalInfo",
-					"inspectionTypes"
+					"additionalInfo"
 				],
 				"properties": {
 					"rsNumber": {
@@ -138,6 +118,20 @@
 							]
 						}
 					}
+				}
+			}
+		},
+		"additionalInformation": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+				"notes"
+			],
+			"properties": {
+				"notes": {
+					"type": [
+						"string"
+					]
 				}
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "3.7.0",
+  "version": "4.0.0",
   "description": "type definitions for cvs vta and vtm applications",
   "main": "index.js",
   "repository": {

--- a/types/iva/defects/get/index.d.ts
+++ b/types/iva/defects/get/index.d.ts
@@ -5,21 +5,22 @@
  * and run json-schema-to-typescript to regenerate this file.
  */
 
-export type VehicleType = "psv" | "trl" | "hgv" | "car" | "lgv" | "motorcycle";
 export type InspectionType = "basic" | "normal";
 
 export interface DefectGETIVA {
   sectionNumber: string;
   sectionDescription: string;
-  vehicleTypes: VehicleType[];
   euVehicleCategories: EUVehicleCategory[];
   requiredStandards: {
     rsNumber: number;
     requiredStandard: string;
     refCalculation: string;
     additionalInfo: boolean;
-    inspectionTypes: InspectionType[];
+    inspectionTypes?: InspectionType[];
   }[];
+  additionalInformation?: {
+    notes: string;
+  };
 }
 
 export enum EUVehicleCategory {


### PR DESCRIPTION
## Introduce the AdditionalInformation object to IVA defect JSON schema

Introduce the AdditionalInformation object to IVA defect json schema

[CB2-9874](https://dvsa.atlassian.net/browse/CB2-9874)

<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

- Implements AdditionalInformation object to json definitions with 1 property 'notes' of type 'string'. 
- generated object to json schema and index.d.ts

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
