### PR TITLE
patch(cb2-9746): Convert additional examiner notes to object array

### DIFF
--- a/json-definitions/v3/tech-record/get/hgv/complete/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/complete/index.json
@@ -111,10 +111,39 @@
     },
     "techRecord_adrDetails_additionalExaminerNotes": {
       "type": [
-        "string",
+        "array",
         "null"
       ],
-      "maxLength": 1024
+      "items": {
+        "title": "Additional Examiner Notes",
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 1024
+          },
+          "createdAtDate": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "lastUpdatedBy": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      }
     },
     "techRecord_adrDetails_applicantDetails_name": {
       "type": [

--- a/json-definitions/v3/tech-record/get/hgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/skeleton/index.json
@@ -81,10 +81,39 @@
     },
     "techRecord_adrDetails_additionalExaminerNotes": {
       "type": [
-        "string",
+        "array",
         "null"
       ],
-      "maxLength": 1024
+      "items": {
+        "title": "Additional Examiner Notes",
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 1024
+          },
+          "createdAtDate": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "lastUpdatedBy": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      }
     },
     "techRecord_adrDetails_applicantDetails_name": {
       "type": [

--- a/json-definitions/v3/tech-record/get/hgv/testable/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/testable/index.json
@@ -85,10 +85,39 @@
     },
     "techRecord_adrDetails_additionalExaminerNotes": {
       "type": [
-        "string",
+        "array",
         "null"
       ],
-      "maxLength": 1024
+      "items": {
+        "title": "Additional Examiner Notes",
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 1024
+          },
+          "createdAtDate": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "lastUpdatedBy": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      }
     },
     "techRecord_adrDetails_applicantDetails_name": {
       "type": [

--- a/json-definitions/v3/tech-record/get/lgv/complete/index.json
+++ b/json-definitions/v3/tech-record/get/lgv/complete/index.json
@@ -116,10 +116,39 @@
     },
     "techRecord_adrDetails_additionalExaminerNotes": {
       "type": [
-        "string",
+        "array",
         "null"
       ],
-      "maxLength": 1024
+      "items": {
+        "title": "Additional Examiner Notes",
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 1024
+          },
+          "createdAtDate": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "lastUpdatedBy": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      }
     },
     "techRecord_adrDetails_applicantDetails_name": {
       "type": [

--- a/json-definitions/v3/tech-record/get/lgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/lgv/skeleton/index.json
@@ -113,10 +113,39 @@
     },
     "techRecord_adrDetails_additionalExaminerNotes": {
       "type": [
-        "string",
+        "array",
         "null"
       ],
-      "maxLength": 1024
+      "items": {
+        "title": "Additional Examiner Notes",
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 1024
+          },
+          "createdAtDate": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "lastUpdatedBy": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      }
     },
     "techRecord_adrDetails_applicantDetails_name": {
       "type": [

--- a/json-definitions/v3/tech-record/get/trl/complete/index.json
+++ b/json-definitions/v3/tech-record/get/trl/complete/index.json
@@ -93,10 +93,39 @@
     },
     "techRecord_adrDetails_additionalExaminerNotes": {
       "type": [
-        "string",
+        "array",
         "null"
       ],
-      "maxLength": 1024
+      "items": {
+        "title": "Additional Examiner Notes",
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 1024
+          },
+          "createdAtDate": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "lastUpdatedBy": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      }
     },
     "techRecord_adrDetails_applicantDetails_name": {
       "type": [

--- a/json-definitions/v3/tech-record/get/trl/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/trl/skeleton/index.json
@@ -73,10 +73,39 @@
     },
     "techRecord_adrDetails_additionalExaminerNotes": {
       "type": [
-        "string",
+        "array",
         "null"
       ],
-      "maxLength": 1024
+      "items": {
+        "title": "Additional Examiner Notes",
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 1024
+          },
+          "createdAtDate": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "lastUpdatedBy": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      }
     },
     "techRecord_adrDetails_applicantDetails_name": {
       "type": [

--- a/json-definitions/v3/tech-record/get/trl/testable/index.json
+++ b/json-definitions/v3/tech-record/get/trl/testable/index.json
@@ -75,10 +75,39 @@
     },
     "techRecord_adrDetails_additionalExaminerNotes": {
       "type": [
-        "string",
+        "array",
         "null"
       ],
-      "maxLength": 1024
+      "items": {
+        "title": "Additional Examiner Notes",
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 1024
+          },
+          "createdAtDate": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "lastUpdatedBy": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      }
     },
     "techRecord_adrDetails_applicantDetails_name": {
       "type": [

--- a/json-definitions/v3/tech-record/put/hgv/complete/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/complete/index.json
@@ -99,10 +99,39 @@
     },
     "techRecord_adrDetails_additionalExaminerNotes": {
       "type": [
-        "string",
+        "array",
         "null"
       ],
-      "maxLength": 1024
+      "items": {
+        "title": "Additional Examiner Notes",
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 1024
+          },
+          "createdAtDate": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "lastUpdatedBy": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      }
     },
     "techRecord_adrDetails_applicantDetails_name": {
       "type": [

--- a/json-definitions/v3/tech-record/put/hgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/skeleton/index.json
@@ -67,10 +67,39 @@
     },
     "techRecord_adrDetails_additionalExaminerNotes": {
       "type": [
-        "string",
+        "array",
         "null"
       ],
-      "maxLength": 1024
+      "items": {
+        "title": "Additional Examiner Notes",
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 1024
+          },
+          "createdAtDate": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "lastUpdatedBy": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      }
     },
     "techRecord_adrDetails_applicantDetails_name": {
       "type": [

--- a/json-definitions/v3/tech-record/put/hgv/testable/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/testable/index.json
@@ -69,10 +69,39 @@
     },
     "techRecord_adrDetails_additionalExaminerNotes": {
       "type": [
-        "string",
+        "array",
         "null"
       ],
-      "maxLength": 1024
+      "items": {
+        "title": "Additional Examiner Notes",
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 1024
+          },
+          "createdAtDate": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "lastUpdatedBy": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      }
     },
     "techRecord_adrDetails_applicantDetails_name": {
       "type": [

--- a/json-definitions/v3/tech-record/put/lgv/complete/index.json
+++ b/json-definitions/v3/tech-record/put/lgv/complete/index.json
@@ -118,10 +118,39 @@
     },
     "techRecord_adrDetails_additionalExaminerNotes": {
       "type": [
-        "string",
+        "array",
         "null"
       ],
-      "maxLength": 1024
+      "items": {
+        "title": "Additional Examiner Notes",
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 1024
+          },
+          "createdAtDate": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "lastUpdatedBy": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      }
     },
     "techRecord_adrDetails_applicantDetails_name": {
       "type": [

--- a/json-definitions/v3/tech-record/put/lgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/lgv/skeleton/index.json
@@ -115,10 +115,39 @@
     },
     "techRecord_adrDetails_additionalExaminerNotes": {
       "type": [
-        "string",
+        "array",
         "null"
       ],
-      "maxLength": 1024
+      "items": {
+        "title": "Additional Examiner Notes",
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 1024
+          },
+          "createdAtDate": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "lastUpdatedBy": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      }
     },
     "techRecord_adrDetails_applicantDetails_name": {
       "type": [

--- a/json-definitions/v3/tech-record/put/trl/complete/index.json
+++ b/json-definitions/v3/tech-record/put/trl/complete/index.json
@@ -82,10 +82,39 @@
     },
     "techRecord_adrDetails_additionalExaminerNotes": {
       "type": [
-        "string",
+        "array",
         "null"
       ],
-      "maxLength": 1024
+      "items": {
+        "title": "Additional Examiner Notes",
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 1024
+          },
+          "createdAtDate": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "lastUpdatedBy": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      }
     },
     "techRecord_adrDetails_applicantDetails_name": {
       "type": [

--- a/json-definitions/v3/tech-record/put/trl/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/trl/skeleton/index.json
@@ -97,10 +97,39 @@
     },
     "techRecord_adrDetails_additionalExaminerNotes": {
       "type": [
-        "string",
+        "array",
         "null"
       ],
-      "maxLength": 1024
+      "items": {
+        "title": "Additional Examiner Notes",
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 1024
+          },
+          "createdAtDate": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "lastUpdatedBy": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      }
     },
     "techRecord_adrDetails_applicantDetails_name": {
       "type": [

--- a/json-definitions/v3/tech-record/put/trl/testable/index.json
+++ b/json-definitions/v3/tech-record/put/trl/testable/index.json
@@ -99,10 +99,39 @@
     },
     "techRecord_adrDetails_additionalExaminerNotes": {
       "type": [
-        "string",
+        "array",
         "null"
       ],
-      "maxLength": 1024
+      "items": {
+        "title": "Additional Examiner Notes",
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 1024
+          },
+          "createdAtDate": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "lastUpdatedBy": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      }
     },
     "techRecord_adrDetails_applicantDetails_name": {
       "type": [

--- a/json-schemas/v3/tech-record/get/hgv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/complete/index.json
@@ -120,10 +120,39 @@
 		},
 		"techRecord_adrDetails_additionalExaminerNotes": {
 			"type": [
-				"string",
+				"array",
 				"null"
 			],
-			"maxLength": 1024
+			"items": {
+				"title": "Additional Examiner Notes",
+				"additionalProperties": false,
+				"properties": {
+					"note": {
+						"type": [
+							"string",
+							"null"
+						],
+						"maxLength": 1024
+					},
+					"createdAtDate": {
+						"anyOf": [
+							{
+								"type": "string",
+								"pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+							},
+							{
+								"type": "null"
+							}
+						]
+					},
+					"lastUpdatedBy": {
+						"type": [
+							"string",
+							"null"
+						]
+					}
+				}
+			}
 		},
 		"techRecord_adrDetails_applicantDetails_name": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/hgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/skeleton/index.json
@@ -90,10 +90,39 @@
 		},
 		"techRecord_adrDetails_additionalExaminerNotes": {
 			"type": [
-				"string",
+				"array",
 				"null"
 			],
-			"maxLength": 1024
+			"items": {
+				"title": "Additional Examiner Notes",
+				"additionalProperties": false,
+				"properties": {
+					"note": {
+						"type": [
+							"string",
+							"null"
+						],
+						"maxLength": 1024
+					},
+					"createdAtDate": {
+						"anyOf": [
+							{
+								"type": "string",
+								"pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+							},
+							{
+								"type": "null"
+							}
+						]
+					},
+					"lastUpdatedBy": {
+						"type": [
+							"string",
+							"null"
+						]
+					}
+				}
+			}
 		},
 		"techRecord_adrDetails_applicantDetails_name": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/testable/index.json
@@ -94,10 +94,39 @@
 		},
 		"techRecord_adrDetails_additionalExaminerNotes": {
 			"type": [
-				"string",
+				"array",
 				"null"
 			],
-			"maxLength": 1024
+			"items": {
+				"title": "Additional Examiner Notes",
+				"additionalProperties": false,
+				"properties": {
+					"note": {
+						"type": [
+							"string",
+							"null"
+						],
+						"maxLength": 1024
+					},
+					"createdAtDate": {
+						"anyOf": [
+							{
+								"type": "string",
+								"pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+							},
+							{
+								"type": "null"
+							}
+						]
+					},
+					"lastUpdatedBy": {
+						"type": [
+							"string",
+							"null"
+						]
+					}
+				}
+			}
 		},
 		"techRecord_adrDetails_applicantDetails_name": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/lgv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/lgv/complete/index.json
@@ -125,10 +125,39 @@
 		},
 		"techRecord_adrDetails_additionalExaminerNotes": {
 			"type": [
-				"string",
+				"array",
 				"null"
 			],
-			"maxLength": 1024
+			"items": {
+				"title": "Additional Examiner Notes",
+				"additionalProperties": false,
+				"properties": {
+					"note": {
+						"type": [
+							"string",
+							"null"
+						],
+						"maxLength": 1024
+					},
+					"createdAtDate": {
+						"anyOf": [
+							{
+								"type": "string",
+								"pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+							},
+							{
+								"type": "null"
+							}
+						]
+					},
+					"lastUpdatedBy": {
+						"type": [
+							"string",
+							"null"
+						]
+					}
+				}
+			}
 		},
 		"techRecord_adrDetails_applicantDetails_name": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/lgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/lgv/skeleton/index.json
@@ -122,10 +122,39 @@
 		},
 		"techRecord_adrDetails_additionalExaminerNotes": {
 			"type": [
-				"string",
+				"array",
 				"null"
 			],
-			"maxLength": 1024
+			"items": {
+				"title": "Additional Examiner Notes",
+				"additionalProperties": false,
+				"properties": {
+					"note": {
+						"type": [
+							"string",
+							"null"
+						],
+						"maxLength": 1024
+					},
+					"createdAtDate": {
+						"anyOf": [
+							{
+								"type": "string",
+								"pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+							},
+							{
+								"type": "null"
+							}
+						]
+					},
+					"lastUpdatedBy": {
+						"type": [
+							"string",
+							"null"
+						]
+					}
+				}
+			}
 		},
 		"techRecord_adrDetails_applicantDetails_name": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/trl/complete/index.json
+++ b/json-schemas/v3/tech-record/get/trl/complete/index.json
@@ -102,10 +102,39 @@
 		},
 		"techRecord_adrDetails_additionalExaminerNotes": {
 			"type": [
-				"string",
+				"array",
 				"null"
 			],
-			"maxLength": 1024
+			"items": {
+				"title": "Additional Examiner Notes",
+				"additionalProperties": false,
+				"properties": {
+					"note": {
+						"type": [
+							"string",
+							"null"
+						],
+						"maxLength": 1024
+					},
+					"createdAtDate": {
+						"anyOf": [
+							{
+								"type": "string",
+								"pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+							},
+							{
+								"type": "null"
+							}
+						]
+					},
+					"lastUpdatedBy": {
+						"type": [
+							"string",
+							"null"
+						]
+					}
+				}
+			}
 		},
 		"techRecord_adrDetails_applicantDetails_name": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/trl/skeleton/index.json
@@ -82,10 +82,39 @@
 		},
 		"techRecord_adrDetails_additionalExaminerNotes": {
 			"type": [
-				"string",
+				"array",
 				"null"
 			],
-			"maxLength": 1024
+			"items": {
+				"title": "Additional Examiner Notes",
+				"additionalProperties": false,
+				"properties": {
+					"note": {
+						"type": [
+							"string",
+							"null"
+						],
+						"maxLength": 1024
+					},
+					"createdAtDate": {
+						"anyOf": [
+							{
+								"type": "string",
+								"pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+							},
+							{
+								"type": "null"
+							}
+						]
+					},
+					"lastUpdatedBy": {
+						"type": [
+							"string",
+							"null"
+						]
+					}
+				}
+			}
 		},
 		"techRecord_adrDetails_applicantDetails_name": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/trl/testable/index.json
+++ b/json-schemas/v3/tech-record/get/trl/testable/index.json
@@ -84,10 +84,39 @@
 		},
 		"techRecord_adrDetails_additionalExaminerNotes": {
 			"type": [
-				"string",
+				"array",
 				"null"
 			],
-			"maxLength": 1024
+			"items": {
+				"title": "Additional Examiner Notes",
+				"additionalProperties": false,
+				"properties": {
+					"note": {
+						"type": [
+							"string",
+							"null"
+						],
+						"maxLength": 1024
+					},
+					"createdAtDate": {
+						"anyOf": [
+							{
+								"type": "string",
+								"pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+							},
+							{
+								"type": "null"
+							}
+						]
+					},
+					"lastUpdatedBy": {
+						"type": [
+							"string",
+							"null"
+						]
+					}
+				}
+			}
 		},
 		"techRecord_adrDetails_applicantDetails_name": {
 			"type": [

--- a/json-schemas/v3/tech-record/put/hgv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/complete/index.json
@@ -108,10 +108,39 @@
 		},
 		"techRecord_adrDetails_additionalExaminerNotes": {
 			"type": [
-				"string",
+				"array",
 				"null"
 			],
-			"maxLength": 1024
+			"items": {
+				"title": "Additional Examiner Notes",
+				"additionalProperties": false,
+				"properties": {
+					"note": {
+						"type": [
+							"string",
+							"null"
+						],
+						"maxLength": 1024
+					},
+					"createdAtDate": {
+						"anyOf": [
+							{
+								"type": "string",
+								"pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+							},
+							{
+								"type": "null"
+							}
+						]
+					},
+					"lastUpdatedBy": {
+						"type": [
+							"string",
+							"null"
+						]
+					}
+				}
+			}
 		},
 		"techRecord_adrDetails_applicantDetails_name": {
 			"type": [

--- a/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
@@ -76,10 +76,39 @@
 		},
 		"techRecord_adrDetails_additionalExaminerNotes": {
 			"type": [
-				"string",
+				"array",
 				"null"
 			],
-			"maxLength": 1024
+			"items": {
+				"title": "Additional Examiner Notes",
+				"additionalProperties": false,
+				"properties": {
+					"note": {
+						"type": [
+							"string",
+							"null"
+						],
+						"maxLength": 1024
+					},
+					"createdAtDate": {
+						"anyOf": [
+							{
+								"type": "string",
+								"pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+							},
+							{
+								"type": "null"
+							}
+						]
+					},
+					"lastUpdatedBy": {
+						"type": [
+							"string",
+							"null"
+						]
+					}
+				}
+			}
 		},
 		"techRecord_adrDetails_applicantDetails_name": {
 			"type": [

--- a/json-schemas/v3/tech-record/put/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/testable/index.json
@@ -78,10 +78,39 @@
 		},
 		"techRecord_adrDetails_additionalExaminerNotes": {
 			"type": [
-				"string",
+				"array",
 				"null"
 			],
-			"maxLength": 1024
+			"items": {
+				"title": "Additional Examiner Notes",
+				"additionalProperties": false,
+				"properties": {
+					"note": {
+						"type": [
+							"string",
+							"null"
+						],
+						"maxLength": 1024
+					},
+					"createdAtDate": {
+						"anyOf": [
+							{
+								"type": "string",
+								"pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+							},
+							{
+								"type": "null"
+							}
+						]
+					},
+					"lastUpdatedBy": {
+						"type": [
+							"string",
+							"null"
+						]
+					}
+				}
+			}
 		},
 		"techRecord_adrDetails_applicantDetails_name": {
 			"type": [

--- a/json-schemas/v3/tech-record/put/lgv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/lgv/complete/index.json
@@ -127,10 +127,39 @@
 		},
 		"techRecord_adrDetails_additionalExaminerNotes": {
 			"type": [
-				"string",
+				"array",
 				"null"
 			],
-			"maxLength": 1024
+			"items": {
+				"title": "Additional Examiner Notes",
+				"additionalProperties": false,
+				"properties": {
+					"note": {
+						"type": [
+							"string",
+							"null"
+						],
+						"maxLength": 1024
+					},
+					"createdAtDate": {
+						"anyOf": [
+							{
+								"type": "string",
+								"pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+							},
+							{
+								"type": "null"
+							}
+						]
+					},
+					"lastUpdatedBy": {
+						"type": [
+							"string",
+							"null"
+						]
+					}
+				}
+			}
 		},
 		"techRecord_adrDetails_applicantDetails_name": {
 			"type": [

--- a/json-schemas/v3/tech-record/put/lgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/lgv/skeleton/index.json
@@ -124,10 +124,39 @@
 		},
 		"techRecord_adrDetails_additionalExaminerNotes": {
 			"type": [
-				"string",
+				"array",
 				"null"
 			],
-			"maxLength": 1024
+			"items": {
+				"title": "Additional Examiner Notes",
+				"additionalProperties": false,
+				"properties": {
+					"note": {
+						"type": [
+							"string",
+							"null"
+						],
+						"maxLength": 1024
+					},
+					"createdAtDate": {
+						"anyOf": [
+							{
+								"type": "string",
+								"pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+							},
+							{
+								"type": "null"
+							}
+						]
+					},
+					"lastUpdatedBy": {
+						"type": [
+							"string",
+							"null"
+						]
+					}
+				}
+			}
 		},
 		"techRecord_adrDetails_applicantDetails_name": {
 			"type": [

--- a/json-schemas/v3/tech-record/put/trl/complete/index.json
+++ b/json-schemas/v3/tech-record/put/trl/complete/index.json
@@ -91,10 +91,39 @@
 		},
 		"techRecord_adrDetails_additionalExaminerNotes": {
 			"type": [
-				"string",
+				"array",
 				"null"
 			],
-			"maxLength": 1024
+			"items": {
+				"title": "Additional Examiner Notes",
+				"additionalProperties": false,
+				"properties": {
+					"note": {
+						"type": [
+							"string",
+							"null"
+						],
+						"maxLength": 1024
+					},
+					"createdAtDate": {
+						"anyOf": [
+							{
+								"type": "string",
+								"pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+							},
+							{
+								"type": "null"
+							}
+						]
+					},
+					"lastUpdatedBy": {
+						"type": [
+							"string",
+							"null"
+						]
+					}
+				}
+			}
 		},
 		"techRecord_adrDetails_applicantDetails_name": {
 			"type": [

--- a/json-schemas/v3/tech-record/put/trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/trl/skeleton/index.json
@@ -141,10 +141,39 @@
 		},
 		"techRecord_adrDetails_additionalExaminerNotes": {
 			"type": [
-				"string",
+				"array",
 				"null"
 			],
-			"maxLength": 1024
+			"items": {
+				"title": "Additional Examiner Notes",
+				"additionalProperties": false,
+				"properties": {
+					"note": {
+						"type": [
+							"string",
+							"null"
+						],
+						"maxLength": 1024
+					},
+					"createdAtDate": {
+						"anyOf": [
+							{
+								"type": "string",
+								"pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+							},
+							{
+								"type": "null"
+							}
+						]
+					},
+					"lastUpdatedBy": {
+						"type": [
+							"string",
+							"null"
+						]
+					}
+				}
+			}
 		},
 		"techRecord_adrDetails_applicantDetails_name": {
 			"type": [

--- a/json-schemas/v3/tech-record/put/trl/testable/index.json
+++ b/json-schemas/v3/tech-record/put/trl/testable/index.json
@@ -143,10 +143,39 @@
 		},
 		"techRecord_adrDetails_additionalExaminerNotes": {
 			"type": [
-				"string",
+				"array",
 				"null"
 			],
-			"maxLength": 1024
+			"items": {
+				"title": "Additional Examiner Notes",
+				"additionalProperties": false,
+				"properties": {
+					"note": {
+						"type": [
+							"string",
+							"null"
+						],
+						"maxLength": 1024
+					},
+					"createdAtDate": {
+						"anyOf": [
+							{
+								"type": "string",
+								"pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+							},
+							{
+								"type": "null"
+							}
+						]
+					},
+					"lastUpdatedBy": {
+						"type": [
+							"string",
+							"null"
+						]
+					}
+				}
+			}
 		},
 		"techRecord_adrDetails_applicantDetails_name": {
 			"type": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "type definitions for cvs vta and vtm applications",
   "main": "index.js",
   "repository": {

--- a/types/v3/tech-record/get/hgv/complete/index.d.ts
+++ b/types/v3/tech-record/get/hgv/complete/index.d.ts
@@ -92,7 +92,7 @@ export interface TechRecordGETHGVComplete {
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;
   techRecord_adrDetails_permittedDangerousGoods?: string[] | null;
   techRecord_adrDetails_compatibilityGroupJ?: null | ADRCompatibilityGroupJ;
-  techRecord_adrDetails_additionalExaminerNotes?: string | null;
+  techRecord_adrDetails_additionalExaminerNotes?: AdditionalExaminerNotes[] | null;
   techRecord_adrDetails_applicantDetails_name?: string | null;
   techRecord_adrDetails_applicantDetails_street?: string | null;
   techRecord_adrDetails_applicantDetails_town?: string | null;
@@ -208,6 +208,11 @@ export interface TechRecordGETHGVComplete {
   vin: string;
   techRecord_hiddenInVta?: null | boolean;
   techRecord_updateType?: null | string;
+}
+export interface AdditionalExaminerNotes {
+  note?: string | null;
+  createdAtDate?: string | null;
+  lastUpdatedBy?: string | null;
 }
 export interface TC3Details {
   tc3Type?: null | TC3Types;

--- a/types/v3/tech-record/get/hgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/hgv/skeleton/index.d.ts
@@ -92,7 +92,7 @@ export interface TechRecordGETHGVSkeleton {
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;
   techRecord_adrDetails_permittedDangerousGoods?: string[] | null;
   techRecord_adrDetails_compatibilityGroupJ?: null | ADRCompatibilityGroupJ;
-  techRecord_adrDetails_additionalExaminerNotes?: string | null;
+  techRecord_adrDetails_additionalExaminerNotes?: AdditionalExaminerNotes[] | null;
   techRecord_adrDetails_applicantDetails_name?: string | null;
   techRecord_adrDetails_applicantDetails_street?: string | null;
   techRecord_adrDetails_applicantDetails_town?: string | null;
@@ -205,6 +205,11 @@ export interface TechRecordGETHGVSkeleton {
   vin: string;
   techRecord_hiddenInVta?: null | boolean;
   techRecord_updateType?: null | string;
+}
+export interface AdditionalExaminerNotes {
+  note?: string | null;
+  createdAtDate?: string | null;
+  lastUpdatedBy?: string | null;
 }
 export interface TC3Details {
   tc3Type?: null | TC3Types;

--- a/types/v3/tech-record/get/hgv/testable/index.d.ts
+++ b/types/v3/tech-record/get/hgv/testable/index.d.ts
@@ -92,7 +92,7 @@ export interface TechRecordGETHGVTestable {
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;
   techRecord_adrDetails_permittedDangerousGoods?: string[] | null;
   techRecord_adrDetails_compatibilityGroupJ?: null | ADRCompatibilityGroupJ;
-  techRecord_adrDetails_additionalExaminerNotes?: string | null;
+  techRecord_adrDetails_additionalExaminerNotes?: AdditionalExaminerNotes[] | null;
   techRecord_adrDetails_applicantDetails_name?: string | null;
   techRecord_adrDetails_applicantDetails_street?: string | null;
   techRecord_adrDetails_applicantDetails_town?: string | null;
@@ -205,6 +205,11 @@ export interface TechRecordGETHGVTestable {
   vin: string;
   techRecord_hiddenInVta?: null | boolean;
   techRecord_updateType?: null | string;
+}
+export interface AdditionalExaminerNotes {
+  note?: string | null;
+  createdAtDate?: string | null;
+  lastUpdatedBy?: string | null;
 }
 export interface TC3Details {
   tc3Type?: null | TC3Types;

--- a/types/v3/tech-record/get/lgv/complete/index.d.ts
+++ b/types/v3/tech-record/get/lgv/complete/index.d.ts
@@ -23,7 +23,7 @@ export interface TechRecordGETLGVComplete {
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;
   techRecord_adrDetails_permittedDangerousGoods?: string[] | null;
   techRecord_adrDetails_compatibilityGroupJ?: null | ADRCompatibilityGroupJ;
-  techRecord_adrDetails_additionalExaminerNotes?: string | null;
+  techRecord_adrDetails_additionalExaminerNotes?: AdditionalExaminerNotes[] | null;
   techRecord_adrDetails_applicantDetails_name?: string | null;
   techRecord_adrDetails_applicantDetails_street?: string | null;
   techRecord_adrDetails_applicantDetails_town?: string | null;
@@ -82,6 +82,11 @@ export interface TechRecordGETLGVComplete {
   techRecord_hiddenInVta?: null | boolean;
   techRecord_updateType?: null | string;
   secondaryVrms?: null | string[];
+}
+export interface AdditionalExaminerNotes {
+  note?: string | null;
+  createdAtDate?: string | null;
+  lastUpdatedBy?: string | null;
 }
 export interface TC3Details {
   tc3Type?: null | TC3Types;

--- a/types/v3/tech-record/get/lgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/lgv/skeleton/index.d.ts
@@ -23,7 +23,7 @@ export interface TechRecordGETLGVSkeleton {
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;
   techRecord_adrDetails_permittedDangerousGoods?: string[] | null;
   techRecord_adrDetails_compatibilityGroupJ?: null | ADRCompatibilityGroupJ;
-  techRecord_adrDetails_additionalExaminerNotes?: string | null;
+  techRecord_adrDetails_additionalExaminerNotes?: AdditionalExaminerNotes[] | null;
   techRecord_adrDetails_applicantDetails_name?: string | null;
   techRecord_adrDetails_applicantDetails_street?: string | null;
   techRecord_adrDetails_applicantDetails_town?: string | null;
@@ -82,6 +82,11 @@ export interface TechRecordGETLGVSkeleton {
   techRecord_updateType?: null | string;
   secondaryVrms?: null | string[];
   techRecord_vehicleSubclass?: VehicleSubclass;
+}
+export interface AdditionalExaminerNotes {
+  note?: string | null;
+  createdAtDate?: string | null;
+  lastUpdatedBy?: string | null;
 }
 export interface TC3Details {
   tc3Type?: null | TC3Types;

--- a/types/v3/tech-record/get/trl/complete/index.d.ts
+++ b/types/v3/tech-record/get/trl/complete/index.d.ts
@@ -109,7 +109,7 @@ export interface TechRecordGETTRLComplete {
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;
   techRecord_adrDetails_permittedDangerousGoods?: string[] | null;
   techRecord_adrDetails_compatibilityGroupJ?: null | ADRCompatibilityGroupJ;
-  techRecord_adrDetails_additionalExaminerNotes?: string | null;
+  techRecord_adrDetails_additionalExaminerNotes?: AdditionalExaminerNotes[] | null;
   techRecord_adrDetails_applicantDetails_name?: string | null;
   techRecord_adrDetails_applicantDetails_street?: string | null;
   techRecord_adrDetails_applicantDetails_town?: string | null;
@@ -251,6 +251,11 @@ export interface TechRecordGETTRLComplete {
   techRecord_authIntoService_dateAuthorised?: string | null;
   techRecord_authIntoService_dateRejected?: string | null;
   techRecord_dimensions_axleSpacing?: AxleSpacing[];
+}
+export interface AdditionalExaminerNotes {
+  note?: string | null;
+  createdAtDate?: string | null;
+  lastUpdatedBy?: string | null;
 }
 export interface TC3Details {
   tc3Type?: null | TC3Types;

--- a/types/v3/tech-record/get/trl/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/trl/skeleton/index.d.ts
@@ -109,7 +109,7 @@ export interface TechRecordGETTRLSkeleton {
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;
   techRecord_adrDetails_permittedDangerousGoods?: string[] | null;
   techRecord_adrDetails_compatibilityGroupJ?: null | ADRCompatibilityGroupJ;
-  techRecord_adrDetails_additionalExaminerNotes?: string | null;
+  techRecord_adrDetails_additionalExaminerNotes?: AdditionalExaminerNotes[] | null;
   techRecord_adrDetails_applicantDetails_name?: string | null;
   techRecord_adrDetails_applicantDetails_street?: string | null;
   techRecord_adrDetails_applicantDetails_town?: string | null;
@@ -248,6 +248,11 @@ export interface TechRecordGETTRLSkeleton {
   techRecord_authIntoService_dateRejected?: string | null;
   techRecord_notes?: string | null;
   techRecord_dimensions_axleSpacing?: AxleSpacing[];
+}
+export interface AdditionalExaminerNotes {
+  note?: string | null;
+  createdAtDate?: string | null;
+  lastUpdatedBy?: string | null;
 }
 export interface TC3Details {
   tc3Type?: null | TC3Types;

--- a/types/v3/tech-record/get/trl/testable/index.d.ts
+++ b/types/v3/tech-record/get/trl/testable/index.d.ts
@@ -109,7 +109,7 @@ export interface TechRecordGETTRLTestable {
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;
   techRecord_adrDetails_permittedDangerousGoods?: string[] | null;
   techRecord_adrDetails_compatibilityGroupJ?: null | ADRCompatibilityGroupJ;
-  techRecord_adrDetails_additionalExaminerNotes?: string | null;
+  techRecord_adrDetails_additionalExaminerNotes?: AdditionalExaminerNotes[] | null;
   techRecord_adrDetails_applicantDetails_name?: string | null;
   techRecord_adrDetails_applicantDetails_street?: string | null;
   techRecord_adrDetails_applicantDetails_town?: string | null;
@@ -248,6 +248,11 @@ export interface TechRecordGETTRLTestable {
   techRecord_authIntoService_dateRejected?: string | null;
   techRecord_notes?: string | null;
   techRecord_dimensions_axleSpacing?: AxleSpacing[];
+}
+export interface AdditionalExaminerNotes {
+  note?: string | null;
+  createdAtDate?: string | null;
+  lastUpdatedBy?: string | null;
 }
 export interface TC3Details {
   tc3Type?: null | TC3Types;

--- a/types/v3/tech-record/put/hgv/complete/index.d.ts
+++ b/types/v3/tech-record/put/hgv/complete/index.d.ts
@@ -90,7 +90,7 @@ export interface TechRecordPUTHGVComplete {
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;
   techRecord_adrDetails_permittedDangerousGoods?: string[] | null;
   techRecord_adrDetails_compatibilityGroupJ?: null | ADRCompatibilityGroupJ;
-  techRecord_adrDetails_additionalExaminerNotes?: string | null;
+  techRecord_adrDetails_additionalExaminerNotes?: AdditionalExaminerNotes[] | null;
   techRecord_adrDetails_applicantDetails_name?: string | null;
   techRecord_adrDetails_applicantDetails_street?: string | null;
   techRecord_adrDetails_applicantDetails_town?: string | null;
@@ -196,6 +196,11 @@ export interface TechRecordPUTHGVComplete {
   vin: string;
   techRecord_hiddenInVta?: null | boolean;
   techRecord_updateType?: null | string;
+}
+export interface AdditionalExaminerNotes {
+  note?: string | null;
+  createdAtDate?: string | null;
+  lastUpdatedBy?: string | null;
 }
 export interface TC3Details {
   tc3Type?: null | TC3Types;

--- a/types/v3/tech-record/put/hgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/hgv/skeleton/index.d.ts
@@ -90,7 +90,7 @@ export interface TechRecordPUTHGVSkeleton {
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;
   techRecord_adrDetails_permittedDangerousGoods?: string[] | null;
   techRecord_adrDetails_compatibilityGroupJ?: null | ADRCompatibilityGroupJ;
-  techRecord_adrDetails_additionalExaminerNotes?: string | null;
+  techRecord_adrDetails_additionalExaminerNotes?: AdditionalExaminerNotes[] | null;
   techRecord_adrDetails_applicantDetails_name?: string | null;
   techRecord_adrDetails_applicantDetails_street?: string | null;
   techRecord_adrDetails_applicantDetails_town?: string | null;
@@ -193,6 +193,11 @@ export interface TechRecordPUTHGVSkeleton {
   vin: string;
   techRecord_hiddenInVta?: null | boolean;
   techRecord_updateType?: null | string;
+}
+export interface AdditionalExaminerNotes {
+  note?: string | null;
+  createdAtDate?: string | null;
+  lastUpdatedBy?: string | null;
 }
 export interface TC3Details {
   tc3Type?: null | TC3Types;

--- a/types/v3/tech-record/put/hgv/testable/index.d.ts
+++ b/types/v3/tech-record/put/hgv/testable/index.d.ts
@@ -90,7 +90,7 @@ export interface TechRecordPUTHGVTestable {
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;
   techRecord_adrDetails_permittedDangerousGoods?: string[] | null;
   techRecord_adrDetails_compatibilityGroupJ?: null | ADRCompatibilityGroupJ;
-  techRecord_adrDetails_additionalExaminerNotes?: string | null;
+  techRecord_adrDetails_additionalExaminerNotes?: AdditionalExaminerNotes[] | null;
   techRecord_adrDetails_applicantDetails_name?: string | null;
   techRecord_adrDetails_applicantDetails_street?: string | null;
   techRecord_adrDetails_applicantDetails_town?: string | null;
@@ -193,6 +193,11 @@ export interface TechRecordPUTHGVTestable {
   vin: string;
   techRecord_hiddenInVta?: null | boolean;
   techRecord_updateType?: null | string;
+}
+export interface AdditionalExaminerNotes {
+  note?: string | null;
+  createdAtDate?: string | null;
+  lastUpdatedBy?: string | null;
 }
 export interface TC3Details {
   tc3Type?: null | TC3Types;

--- a/types/v3/tech-record/put/lgv/complete/index.d.ts
+++ b/types/v3/tech-record/put/lgv/complete/index.d.ts
@@ -25,7 +25,7 @@ export interface TechRecordPUTLGVComplete {
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;
   techRecord_adrDetails_permittedDangerousGoods?: string[] | null;
   techRecord_adrDetails_compatibilityGroupJ?: null | ADRCompatibilityGroupJ;
-  techRecord_adrDetails_additionalExaminerNotes?: string | null;
+  techRecord_adrDetails_additionalExaminerNotes?: AdditionalExaminerNotes[] | null;
   techRecord_adrDetails_applicantDetails_name?: string | null;
   techRecord_adrDetails_applicantDetails_street?: string | null;
   techRecord_adrDetails_applicantDetails_town?: string | null;
@@ -72,6 +72,11 @@ export interface TechRecordPUTLGVComplete {
   techRecord_updateType?: string;
   secondaryVrms?: string[];
   techRecord_vehicleConfiguration: VehicleConfiguration;
+}
+export interface AdditionalExaminerNotes {
+  note?: string | null;
+  createdAtDate?: string | null;
+  lastUpdatedBy?: string | null;
 }
 export interface TC3Details {
   tc3Type?: null | TC3Types;

--- a/types/v3/tech-record/put/lgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/lgv/skeleton/index.d.ts
@@ -25,7 +25,7 @@ export interface TechRecordPUTLGVSkeleton {
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;
   techRecord_adrDetails_permittedDangerousGoods?: string[] | null;
   techRecord_adrDetails_compatibilityGroupJ?: null | ADRCompatibilityGroupJ;
-  techRecord_adrDetails_additionalExaminerNotes?: string | null;
+  techRecord_adrDetails_additionalExaminerNotes?: AdditionalExaminerNotes[] | null;
   techRecord_adrDetails_applicantDetails_name?: string | null;
   techRecord_adrDetails_applicantDetails_street?: string | null;
   techRecord_adrDetails_applicantDetails_town?: string | null;
@@ -72,6 +72,11 @@ export interface TechRecordPUTLGVSkeleton {
   secondaryVrms?: string[];
   techRecord_vehicleSubclass?: VehicleSubclass;
   techRecord_vehicleConfiguration?: null | VehicleConfiguration;
+}
+export interface AdditionalExaminerNotes {
+  note?: string | null;
+  createdAtDate?: string | null;
+  lastUpdatedBy?: string | null;
 }
 export interface TC3Details {
   tc3Type?: null | TC3Types;

--- a/types/v3/tech-record/put/trl/complete/index.d.ts
+++ b/types/v3/tech-record/put/trl/complete/index.d.ts
@@ -107,7 +107,7 @@ export interface TechRecordPUTTRLComplete {
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;
   techRecord_adrDetails_permittedDangerousGoods?: string[] | null;
   techRecord_adrDetails_compatibilityGroupJ?: null | ADRCompatibilityGroupJ;
-  techRecord_adrDetails_additionalExaminerNotes?: string | null;
+  techRecord_adrDetails_additionalExaminerNotes?: AdditionalExaminerNotes[] | null;
   techRecord_adrDetails_applicantDetails_name?: string | null;
   techRecord_adrDetails_applicantDetails_street?: string | null;
   techRecord_adrDetails_applicantDetails_town?: string | null;
@@ -240,6 +240,11 @@ export interface TechRecordPUTTRLComplete {
   techRecord_authIntoService_dateAuthorised?: string | null;
   techRecord_authIntoService_dateRejected?: string | null;
   techRecord_dimensions_axleSpacing?: AxleSpacing[];
+}
+export interface AdditionalExaminerNotes {
+  note?: string | null;
+  createdAtDate?: string | null;
+  lastUpdatedBy?: string | null;
 }
 export interface TC3Details {
   tc3Type?: null | TC3Types;

--- a/types/v3/tech-record/put/trl/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/trl/skeleton/index.d.ts
@@ -112,7 +112,7 @@ export interface TechRecordPUTTRLSkeleton {
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;
   techRecord_adrDetails_permittedDangerousGoods?: string[] | null;
   techRecord_adrDetails_compatibilityGroupJ?: null | ADRCompatibilityGroupJ;
-  techRecord_adrDetails_additionalExaminerNotes?: string | null;
+  techRecord_adrDetails_additionalExaminerNotes?: AdditionalExaminerNotes[] | null;
   techRecord_adrDetails_applicantDetails_name?: string | null;
   techRecord_adrDetails_applicantDetails_street?: string | null;
   techRecord_adrDetails_applicantDetails_town?: string | null;
@@ -237,6 +237,11 @@ export interface TechRecordPUTTRLSkeleton {
   techRecord_authIntoService_dateAuthorised?: string | null;
   techRecord_authIntoService_dateRejected?: string | null;
   techRecord_axles?: null | TRLAxles[];
+}
+export interface AdditionalExaminerNotes {
+  note?: string | null;
+  createdAtDate?: string | null;
+  lastUpdatedBy?: string | null;
 }
 export interface TC3Details {
   tc3Type?: null | TC3Types;

--- a/types/v3/tech-record/put/trl/testable/index.d.ts
+++ b/types/v3/tech-record/put/trl/testable/index.d.ts
@@ -112,7 +112,7 @@ export interface TechRecordPUTTRLTestable {
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;
   techRecord_adrDetails_permittedDangerousGoods?: string[] | null;
   techRecord_adrDetails_compatibilityGroupJ?: null | ADRCompatibilityGroupJ;
-  techRecord_adrDetails_additionalExaminerNotes?: string | null;
+  techRecord_adrDetails_additionalExaminerNotes?: AdditionalExaminerNotes[] | null;
   techRecord_adrDetails_applicantDetails_name?: string | null;
   techRecord_adrDetails_applicantDetails_street?: string | null;
   techRecord_adrDetails_applicantDetails_town?: string | null;
@@ -237,6 +237,11 @@ export interface TechRecordPUTTRLTestable {
   techRecord_authIntoService_datePending?: string | null;
   techRecord_authIntoService_dateAuthorised?: string | null;
   techRecord_authIntoService_dateRejected?: string | null;
+}
+export interface AdditionalExaminerNotes {
+  note?: string | null;
+  createdAtDate?: string | null;
+  lastUpdatedBy?: string | null;
 }
 export interface TC3Details {
   tc3Type?: null | TC3Types;


### PR DESCRIPTION
## Ticket title
Converts the additional examiner notes to object array to capture examiner note history on the tech record itself.

[CB2-9746](https://dvsa.atlassian.net/browse/CB2-9746)

<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

-

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
