### PR TITLE
minor(cb2-10521): change adr brake endurance weight unit of measurement to tonnes on a technical record

### DIFF
--- a/json-definitions/v3/tech-record/get/hgv/complete/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/complete/index.json
@@ -236,10 +236,10 @@
     },
     "techRecord_adrDetails_weight": {
       "type": [
-        "string",
+        "number",
         "null"
       ],
-      "maxLength": 8
+      "maximum": 99999999
     },
     "techRecord_adrDetails_declarationsSeen": {
       "type": [

--- a/json-definitions/v3/tech-record/get/hgv/complete/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/complete/index.json
@@ -239,7 +239,7 @@
         "number",
         "null"
       ],
-      "maximum": 99999999
+      "maximum": 99999999.99
     },
     "techRecord_adrDetails_declarationsSeen": {
       "type": [

--- a/json-definitions/v3/tech-record/get/hgv/complete/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/complete/index.json
@@ -239,7 +239,7 @@
         "number",
         "null"
       ],
-      "maximum": 99999999.99
+      "maximum": 99999999
     },
     "techRecord_adrDetails_declarationsSeen": {
       "type": [

--- a/json-definitions/v3/tech-record/get/hgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/skeleton/index.json
@@ -209,7 +209,7 @@
         "number",
         "null"
       ],
-      "maximum": 99999999.99
+      "maximum": 99999999
     },
     "techRecord_adrDetails_declarationsSeen": {
       "type": [

--- a/json-definitions/v3/tech-record/get/hgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/skeleton/index.json
@@ -209,7 +209,7 @@
         "number",
         "null"
       ],
-      "maximum": 99999999
+      "maximum": 99999999.99
     },
     "techRecord_adrDetails_declarationsSeen": {
       "type": [

--- a/json-definitions/v3/tech-record/get/hgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/skeleton/index.json
@@ -206,10 +206,10 @@
     },
     "techRecord_adrDetails_weight": {
       "type": [
-        "string",
+        "number",
         "null"
       ],
-      "maxLength": 8
+      "maximum": 99999999
     },
     "techRecord_adrDetails_declarationsSeen": {
       "type": [

--- a/json-definitions/v3/tech-record/get/hgv/testable/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/testable/index.json
@@ -210,10 +210,10 @@
     },
     "techRecord_adrDetails_weight": {
       "type": [
-        "string",
+        "number",
         "null"
       ],
-      "maxLength": 8
+      "maximum": 99999999
     },
     "techRecord_adrDetails_declarationsSeen": {
       "type": [

--- a/json-definitions/v3/tech-record/get/hgv/testable/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/testable/index.json
@@ -213,7 +213,7 @@
         "number",
         "null"
       ],
-      "maximum": 99999999.99
+      "maximum": 99999999
     },
     "techRecord_adrDetails_declarationsSeen": {
       "type": [

--- a/json-definitions/v3/tech-record/get/hgv/testable/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/testable/index.json
@@ -213,7 +213,7 @@
         "number",
         "null"
       ],
-      "maximum": 99999999
+      "maximum": 99999999.99
     },
     "techRecord_adrDetails_declarationsSeen": {
       "type": [

--- a/json-definitions/v3/tech-record/get/lgv/complete/index.json
+++ b/json-definitions/v3/tech-record/get/lgv/complete/index.json
@@ -244,7 +244,7 @@
         "number",
         "null"
       ],
-      "maximum": 99999999.99
+      "maximum": 99999999
     },
     "techRecord_adrDetails_declarationsSeen": {
       "type": [

--- a/json-definitions/v3/tech-record/get/lgv/complete/index.json
+++ b/json-definitions/v3/tech-record/get/lgv/complete/index.json
@@ -244,7 +244,7 @@
         "number",
         "null"
       ],
-      "maximum": 99999999
+      "maximum": 99999999.99
     },
     "techRecord_adrDetails_declarationsSeen": {
       "type": [

--- a/json-definitions/v3/tech-record/get/lgv/complete/index.json
+++ b/json-definitions/v3/tech-record/get/lgv/complete/index.json
@@ -241,10 +241,10 @@
     },
     "techRecord_adrDetails_weight": {
       "type": [
-        "string",
+        "number",
         "null"
       ],
-      "maxLength": 8
+      "maximum": 99999999
     },
     "techRecord_adrDetails_declarationsSeen": {
       "type": [

--- a/json-definitions/v3/tech-record/get/lgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/lgv/skeleton/index.json
@@ -241,7 +241,7 @@
         "number",
         "null"
       ],
-      "maximum": 99999999
+      "maximum": 99999999.99
     },
     "techRecord_adrDetails_declarationsSeen": {
       "type": [

--- a/json-definitions/v3/tech-record/get/lgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/lgv/skeleton/index.json
@@ -238,10 +238,10 @@
     },
     "techRecord_adrDetails_weight": {
       "type": [
-        "string",
+        "number",
         "null"
       ],
-      "maxLength": 8
+      "maximum": 99999999
     },
     "techRecord_adrDetails_declarationsSeen": {
       "type": [

--- a/json-definitions/v3/tech-record/get/lgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/lgv/skeleton/index.json
@@ -241,7 +241,7 @@
         "number",
         "null"
       ],
-      "maximum": 99999999.99
+      "maximum": 99999999
     },
     "techRecord_adrDetails_declarationsSeen": {
       "type": [

--- a/json-definitions/v3/tech-record/get/trl/complete/index.json
+++ b/json-definitions/v3/tech-record/get/trl/complete/index.json
@@ -218,10 +218,10 @@
     },
     "techRecord_adrDetails_weight": {
       "type": [
-        "string",
+        "number",
         "null"
       ],
-      "maxLength": 8
+      "maximum": 99999999
     },
     "techRecord_adrDetails_declarationsSeen": {
       "type": [

--- a/json-definitions/v3/tech-record/get/trl/complete/index.json
+++ b/json-definitions/v3/tech-record/get/trl/complete/index.json
@@ -221,7 +221,7 @@
         "number",
         "null"
       ],
-      "maximum": 99999999.99
+      "maximum": 99999999
     },
     "techRecord_adrDetails_declarationsSeen": {
       "type": [

--- a/json-definitions/v3/tech-record/get/trl/complete/index.json
+++ b/json-definitions/v3/tech-record/get/trl/complete/index.json
@@ -221,7 +221,7 @@
         "number",
         "null"
       ],
-      "maximum": 99999999
+      "maximum": 99999999.99
     },
     "techRecord_adrDetails_declarationsSeen": {
       "type": [

--- a/json-definitions/v3/tech-record/get/trl/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/trl/skeleton/index.json
@@ -198,10 +198,10 @@
     },
     "techRecord_adrDetails_weight": {
       "type": [
-        "string",
+        "number",
         "null"
       ],
-      "maxLength": 8
+      "maximum": 99999999
     },
     "techRecord_adrDetails_declarationsSeen": {
       "type": [

--- a/json-definitions/v3/tech-record/get/trl/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/trl/skeleton/index.json
@@ -201,7 +201,7 @@
         "number",
         "null"
       ],
-      "maximum": 99999999.99
+      "maximum": 99999999
     },
     "techRecord_adrDetails_declarationsSeen": {
       "type": [

--- a/json-definitions/v3/tech-record/get/trl/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/trl/skeleton/index.json
@@ -201,7 +201,7 @@
         "number",
         "null"
       ],
-      "maximum": 99999999
+      "maximum": 99999999.99
     },
     "techRecord_adrDetails_declarationsSeen": {
       "type": [

--- a/json-definitions/v3/tech-record/get/trl/testable/index.json
+++ b/json-definitions/v3/tech-record/get/trl/testable/index.json
@@ -203,7 +203,7 @@
         "number",
         "null"
       ],
-      "maximum": 99999999.99
+      "maximum": 99999999
     },
     "techRecord_adrDetails_declarationsSeen": {
       "type": [

--- a/json-definitions/v3/tech-record/get/trl/testable/index.json
+++ b/json-definitions/v3/tech-record/get/trl/testable/index.json
@@ -200,10 +200,10 @@
     },
     "techRecord_adrDetails_weight": {
       "type": [
-        "string",
+        "number",
         "null"
       ],
-      "maxLength": 8
+      "maximum": 99999999
     },
     "techRecord_adrDetails_declarationsSeen": {
       "type": [

--- a/json-definitions/v3/tech-record/get/trl/testable/index.json
+++ b/json-definitions/v3/tech-record/get/trl/testable/index.json
@@ -203,7 +203,7 @@
         "number",
         "null"
       ],
-      "maximum": 99999999
+      "maximum": 99999999.99
     },
     "techRecord_adrDetails_declarationsSeen": {
       "type": [

--- a/json-schemas/v3/tech-record/get/hgv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/complete/index.json
@@ -245,10 +245,10 @@
 		},
 		"techRecord_adrDetails_weight": {
 			"type": [
-				"string",
+				"number",
 				"null"
 			],
-			"maxLength": 8
+			"maximum": 99999999
 		},
 		"techRecord_adrDetails_declarationsSeen": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/hgv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/complete/index.json
@@ -248,7 +248,7 @@
 				"number",
 				"null"
 			],
-			"maximum": 99999999
+			"maximum": 99999999.99
 		},
 		"techRecord_adrDetails_declarationsSeen": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/hgv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/complete/index.json
@@ -248,7 +248,7 @@
 				"number",
 				"null"
 			],
-			"maximum": 99999999.99
+			"maximum": 99999999
 		},
 		"techRecord_adrDetails_declarationsSeen": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/hgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/skeleton/index.json
@@ -218,7 +218,7 @@
 				"number",
 				"null"
 			],
-			"maximum": 99999999
+			"maximum": 99999999.99
 		},
 		"techRecord_adrDetails_declarationsSeen": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/hgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/skeleton/index.json
@@ -215,10 +215,10 @@
 		},
 		"techRecord_adrDetails_weight": {
 			"type": [
-				"string",
+				"number",
 				"null"
 			],
-			"maxLength": 8
+			"maximum": 99999999
 		},
 		"techRecord_adrDetails_declarationsSeen": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/hgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/skeleton/index.json
@@ -218,7 +218,7 @@
 				"number",
 				"null"
 			],
-			"maximum": 99999999.99
+			"maximum": 99999999
 		},
 		"techRecord_adrDetails_declarationsSeen": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/testable/index.json
@@ -222,7 +222,7 @@
 				"number",
 				"null"
 			],
-			"maximum": 99999999
+			"maximum": 99999999.99
 		},
 		"techRecord_adrDetails_declarationsSeen": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/testable/index.json
@@ -219,10 +219,10 @@
 		},
 		"techRecord_adrDetails_weight": {
 			"type": [
-				"string",
+				"number",
 				"null"
 			],
-			"maxLength": 8
+			"maximum": 99999999
 		},
 		"techRecord_adrDetails_declarationsSeen": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/testable/index.json
@@ -222,7 +222,7 @@
 				"number",
 				"null"
 			],
-			"maximum": 99999999.99
+			"maximum": 99999999
 		},
 		"techRecord_adrDetails_declarationsSeen": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/lgv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/lgv/complete/index.json
@@ -250,10 +250,10 @@
 		},
 		"techRecord_adrDetails_weight": {
 			"type": [
-				"string",
+				"number",
 				"null"
 			],
-			"maxLength": 8
+			"maximum": 99999999
 		},
 		"techRecord_adrDetails_declarationsSeen": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/lgv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/lgv/complete/index.json
@@ -253,7 +253,7 @@
 				"number",
 				"null"
 			],
-			"maximum": 99999999
+			"maximum": 99999999.99
 		},
 		"techRecord_adrDetails_declarationsSeen": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/lgv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/lgv/complete/index.json
@@ -253,7 +253,7 @@
 				"number",
 				"null"
 			],
-			"maximum": 99999999.99
+			"maximum": 99999999
 		},
 		"techRecord_adrDetails_declarationsSeen": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/lgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/lgv/skeleton/index.json
@@ -247,10 +247,10 @@
 		},
 		"techRecord_adrDetails_weight": {
 			"type": [
-				"string",
+				"number",
 				"null"
 			],
-			"maxLength": 8
+			"maximum": 99999999
 		},
 		"techRecord_adrDetails_declarationsSeen": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/lgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/lgv/skeleton/index.json
@@ -250,7 +250,7 @@
 				"number",
 				"null"
 			],
-			"maximum": 99999999
+			"maximum": 99999999.99
 		},
 		"techRecord_adrDetails_declarationsSeen": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/lgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/lgv/skeleton/index.json
@@ -250,7 +250,7 @@
 				"number",
 				"null"
 			],
-			"maximum": 99999999.99
+			"maximum": 99999999
 		},
 		"techRecord_adrDetails_declarationsSeen": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/trl/complete/index.json
+++ b/json-schemas/v3/tech-record/get/trl/complete/index.json
@@ -227,10 +227,10 @@
 		},
 		"techRecord_adrDetails_weight": {
 			"type": [
-				"string",
+				"number",
 				"null"
 			],
-			"maxLength": 8
+			"maximum": 99999999
 		},
 		"techRecord_adrDetails_declarationsSeen": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/trl/complete/index.json
+++ b/json-schemas/v3/tech-record/get/trl/complete/index.json
@@ -230,7 +230,7 @@
 				"number",
 				"null"
 			],
-			"maximum": 99999999.99
+			"maximum": 99999999
 		},
 		"techRecord_adrDetails_declarationsSeen": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/trl/complete/index.json
+++ b/json-schemas/v3/tech-record/get/trl/complete/index.json
@@ -230,7 +230,7 @@
 				"number",
 				"null"
 			],
-			"maximum": 99999999
+			"maximum": 99999999.99
 		},
 		"techRecord_adrDetails_declarationsSeen": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/trl/skeleton/index.json
@@ -210,7 +210,7 @@
 				"number",
 				"null"
 			],
-			"maximum": 99999999
+			"maximum": 99999999.99
 		},
 		"techRecord_adrDetails_declarationsSeen": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/trl/skeleton/index.json
@@ -207,10 +207,10 @@
 		},
 		"techRecord_adrDetails_weight": {
 			"type": [
-				"string",
+				"number",
 				"null"
 			],
-			"maxLength": 8
+			"maximum": 99999999
 		},
 		"techRecord_adrDetails_declarationsSeen": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/trl/skeleton/index.json
@@ -210,7 +210,7 @@
 				"number",
 				"null"
 			],
-			"maximum": 99999999.99
+			"maximum": 99999999
 		},
 		"techRecord_adrDetails_declarationsSeen": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/trl/testable/index.json
+++ b/json-schemas/v3/tech-record/get/trl/testable/index.json
@@ -212,7 +212,7 @@
 				"number",
 				"null"
 			],
-			"maximum": 99999999.99
+			"maximum": 99999999
 		},
 		"techRecord_adrDetails_declarationsSeen": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/trl/testable/index.json
+++ b/json-schemas/v3/tech-record/get/trl/testable/index.json
@@ -212,7 +212,7 @@
 				"number",
 				"null"
 			],
-			"maximum": 99999999
+			"maximum": 99999999.99
 		},
 		"techRecord_adrDetails_declarationsSeen": {
 			"type": [

--- a/json-schemas/v3/tech-record/get/trl/testable/index.json
+++ b/json-schemas/v3/tech-record/get/trl/testable/index.json
@@ -209,10 +209,10 @@
 		},
 		"techRecord_adrDetails_weight": {
 			"type": [
-				"string",
+				"number",
 				"null"
 			],
-			"maxLength": 8
+			"maximum": 99999999
 		},
 		"techRecord_adrDetails_declarationsSeen": {
 			"type": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "5.0.0",
+      "version": "5.1.0",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "type definitions for cvs vta and vtm applications",
   "main": "index.js",
   "repository": {

--- a/tests/hgv/skeleton.test.ts
+++ b/tests/hgv/skeleton.test.ts
@@ -96,7 +96,7 @@ describe("validate ADR hgv schema", () => {
   it("should pass if techRecord_adrDetails_brakeEndurance is true and weight is present", () => {
     const data = hgvData[7];
     (data as any).techRecord_adrDetails_brakeEndurance = true;
-    (data as any).techRecord_adrDetails_weight = "123";
+    (data as any).techRecord_adrDetails_weight = 123;
     const res = isValidObject(schemaName, data);
     expect(res).toEqual(true);
   });

--- a/types/v3/tech-record/get/hgv/complete/index.d.ts
+++ b/types/v3/tech-record/get/hgv/complete/index.d.ts
@@ -105,7 +105,7 @@ export interface TechRecordGETHGVComplete {
   techRecord_adrDetails_brakeDeclarationsSeen?: boolean | null;
   techRecord_adrDetails_brakeDeclarationIssuer?: string | null;
   techRecord_adrDetails_brakeEndurance?: boolean | null;
-  techRecord_adrDetails_weight?: string | null;
+  techRecord_adrDetails_weight?: number | null;
   techRecord_adrDetails_declarationsSeen?: boolean | null;
   techRecord_adrDetails_additionalNotes_guidanceNotes?: string[] | null;
   techRecord_adrDetails_additionalNotes_number?: string[] | null;

--- a/types/v3/tech-record/get/hgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/hgv/skeleton/index.d.ts
@@ -105,7 +105,7 @@ export interface TechRecordGETHGVSkeleton {
   techRecord_adrDetails_brakeDeclarationsSeen?: boolean | null;
   techRecord_adrDetails_brakeDeclarationIssuer?: string | null;
   techRecord_adrDetails_brakeEndurance?: boolean | null;
-  techRecord_adrDetails_weight?: string | null;
+  techRecord_adrDetails_weight?: number | null;
   techRecord_adrDetails_declarationsSeen?: boolean | null;
   techRecord_adrDetails_additionalNotes_guidanceNotes?: string[] | null;
   techRecord_adrDetails_additionalNotes_number?: string[] | null;

--- a/types/v3/tech-record/get/hgv/testable/index.d.ts
+++ b/types/v3/tech-record/get/hgv/testable/index.d.ts
@@ -105,7 +105,7 @@ export interface TechRecordGETHGVTestable {
   techRecord_adrDetails_brakeDeclarationsSeen?: boolean | null;
   techRecord_adrDetails_brakeDeclarationIssuer?: string | null;
   techRecord_adrDetails_brakeEndurance?: boolean | null;
-  techRecord_adrDetails_weight?: string | null;
+  techRecord_adrDetails_weight?: number | null;
   techRecord_adrDetails_declarationsSeen?: boolean | null;
   techRecord_adrDetails_additionalNotes_guidanceNotes?: string[] | null;
   techRecord_adrDetails_additionalNotes_number?: string[] | null;

--- a/types/v3/tech-record/get/lgv/complete/index.d.ts
+++ b/types/v3/tech-record/get/lgv/complete/index.d.ts
@@ -36,7 +36,7 @@ export interface TechRecordGETLGVComplete {
   techRecord_adrDetails_brakeDeclarationsSeen?: boolean | null;
   techRecord_adrDetails_brakeDeclarationIssuer?: string | null;
   techRecord_adrDetails_brakeEndurance?: boolean | null;
-  techRecord_adrDetails_weight?: string | null;
+  techRecord_adrDetails_weight?: number | null;
   techRecord_adrDetails_declarationsSeen?: boolean | null;
   techRecord_adrDetails_additionalNotes_guidanceNotes?: string[] | null;
   techRecord_adrDetails_additionalNotes_number?: string[] | null;

--- a/types/v3/tech-record/get/lgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/lgv/skeleton/index.d.ts
@@ -36,7 +36,7 @@ export interface TechRecordGETLGVSkeleton {
   techRecord_adrDetails_brakeDeclarationsSeen?: boolean | null;
   techRecord_adrDetails_brakeDeclarationIssuer?: string | null;
   techRecord_adrDetails_brakeEndurance?: boolean | null;
-  techRecord_adrDetails_weight?: string | null;
+  techRecord_adrDetails_weight?: number | null;
   techRecord_adrDetails_declarationsSeen?: boolean | null;
   techRecord_adrDetails_additionalNotes_guidanceNotes?: string[] | null;
   techRecord_adrDetails_additionalNotes_number?: string[] | null;

--- a/types/v3/tech-record/get/trl/complete/index.d.ts
+++ b/types/v3/tech-record/get/trl/complete/index.d.ts
@@ -122,7 +122,7 @@ export interface TechRecordGETTRLComplete {
   techRecord_adrDetails_brakeDeclarationsSeen?: boolean | null;
   techRecord_adrDetails_brakeDeclarationIssuer?: string | null;
   techRecord_adrDetails_brakeEndurance?: boolean | null;
-  techRecord_adrDetails_weight?: string | null;
+  techRecord_adrDetails_weight?: number | null;
   techRecord_adrDetails_declarationsSeen?: boolean | null;
   techRecord_adrDetails_additionalNotes_guidanceNotes?: string[] | null;
   techRecord_adrDetails_additionalNotes_number?: string[] | null;

--- a/types/v3/tech-record/get/trl/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/trl/skeleton/index.d.ts
@@ -122,7 +122,7 @@ export interface TechRecordGETTRLSkeleton {
   techRecord_adrDetails_brakeDeclarationsSeen?: boolean | null;
   techRecord_adrDetails_brakeDeclarationIssuer?: string | null;
   techRecord_adrDetails_brakeEndurance?: boolean | null;
-  techRecord_adrDetails_weight?: string | null;
+  techRecord_adrDetails_weight?: number | null;
   techRecord_adrDetails_declarationsSeen?: boolean | null;
   techRecord_adrDetails_additionalNotes_guidanceNotes?: string[] | null;
   techRecord_adrDetails_additionalNotes_number?: string[] | null;

--- a/types/v3/tech-record/get/trl/testable/index.d.ts
+++ b/types/v3/tech-record/get/trl/testable/index.d.ts
@@ -122,7 +122,7 @@ export interface TechRecordGETTRLTestable {
   techRecord_adrDetails_brakeDeclarationsSeen?: boolean | null;
   techRecord_adrDetails_brakeDeclarationIssuer?: string | null;
   techRecord_adrDetails_brakeEndurance?: boolean | null;
-  techRecord_adrDetails_weight?: string | null;
+  techRecord_adrDetails_weight?: number | null;
   techRecord_adrDetails_declarationsSeen?: boolean | null;
   techRecord_adrDetails_additionalNotes_guidanceNotes?: string[] | null;
   techRecord_adrDetails_additionalNotes_number?: string[] | null;


### PR DESCRIPTION
## Ticket title

change of data type to number to reflect front end changes, allows max of 99999999 to reflect old string length
_One line description_

[CB2-XXXX](https://dvsa.atlassian.net/browse/CB2-XXXX)

<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

-

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
