### PR TITLE
minor(cb2-11293): added documentId to adrDetails

### DIFF
--- a/json-definitions/v3/tech-record/get/hgv/complete/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/complete/index.json
@@ -67,6 +67,9 @@
     "systemNumber": {
       "type": "string"
     },
+    "techRecord_adrDetails_documentId": {
+			"type": "string"
+		},
     "techRecord_adrDetails_dangerousGoods": {
       "type": [
         "boolean",

--- a/json-definitions/v3/tech-record/get/hgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/skeleton/index.json
@@ -37,6 +37,9 @@
     "systemNumber": {
       "type": "string"
     },
+    "techRecord_adrDetails_documentId": {
+			"type": "string"
+		},
     "techRecord_adrDetails_dangerousGoods": {
       "type": [
         "boolean",

--- a/json-definitions/v3/tech-record/get/hgv/testable/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/testable/index.json
@@ -41,6 +41,9 @@
     "systemNumber": {
       "type": "string"
     },
+    "techRecord_adrDetails_documentId": {
+			"type": "string"
+		},
     "techRecord_adrDetails_dangerousGoods": {
       "type": [
         "boolean",

--- a/json-definitions/v3/tech-record/get/lgv/complete/index.json
+++ b/json-definitions/v3/tech-record/get/lgv/complete/index.json
@@ -73,7 +73,7 @@
       "maxLength": 255
     },
     "techRecord_adrDetails_documentId": {
-			"type": "string"
+			"type": "string" 
 		},
     "techRecord_adrDetails_dangerousGoods": {
       "type": [

--- a/json-definitions/v3/tech-record/get/lgv/complete/index.json
+++ b/json-definitions/v3/tech-record/get/lgv/complete/index.json
@@ -72,6 +72,9 @@
       ],
       "maxLength": 255
     },
+    "techRecord_adrDetails_documentId": {
+			"type": "string"
+		},
     "techRecord_adrDetails_dangerousGoods": {
       "type": [
         "boolean",

--- a/json-definitions/v3/tech-record/get/lgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/lgv/skeleton/index.json
@@ -69,6 +69,9 @@
       ],
       "maxLength": 255
     },
+    "techRecord_adrDetails_documentId": {
+			"type": "string"
+		},
     "techRecord_adrDetails_dangerousGoods": {
       "type": [
         "boolean",

--- a/json-definitions/v3/tech-record/get/trl/complete/index.json
+++ b/json-definitions/v3/tech-record/get/trl/complete/index.json
@@ -49,6 +49,9 @@
     "systemNumber": {
       "type": "string"
     },
+    "techRecord_adrDetails_documentId": {
+			"type": "string"
+		},
     "techRecord_adrDetails_dangerousGoods": {
       "type": [
         "boolean",

--- a/json-definitions/v3/tech-record/get/trl/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/trl/skeleton/index.json
@@ -29,6 +29,9 @@
     "systemNumber": {
       "type": "string"
     },
+    "techRecord_adrDetails_documentId": {
+			"type": "string"
+		},
     "techRecord_adrDetails_dangerousGoods": {
       "type": [
         "boolean",

--- a/json-definitions/v3/tech-record/get/trl/testable/index.json
+++ b/json-definitions/v3/tech-record/get/trl/testable/index.json
@@ -31,6 +31,9 @@
     "systemNumber": {
       "type": "string"
     },
+    "techRecord_adrDetails_documentId": {
+			"type": "string"
+		},
     "techRecord_adrDetails_dangerousGoods": {
       "type": [
         "boolean",

--- a/json-definitions/v3/tech-record/put/hgv/complete/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/complete/index.json
@@ -55,6 +55,9 @@
         "null"
       ]
     },
+    "techRecord_adrDetails_documentId": {
+			"type": "string"
+		},
     "techRecord_adrDetails_dangerousGoods": {
       "type": [
         "boolean",

--- a/json-definitions/v3/tech-record/put/hgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/skeleton/index.json
@@ -23,6 +23,9 @@
         "null"
       ]
     },
+    "techRecord_adrDetails_documentId": {
+			"type": "string"
+		},
     "techRecord_adrDetails_dangerousGoods": {
       "type": [
         "boolean",

--- a/json-definitions/v3/tech-record/put/hgv/testable/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/testable/index.json
@@ -25,6 +25,9 @@
         "null"
       ]
     },
+    "techRecord_adrDetails_documentId": {
+			"type": "string"
+		},
     "techRecord_adrDetails_dangerousGoods": {
       "type": [
         "boolean",

--- a/json-definitions/v3/tech-record/put/lgv/complete/index.json
+++ b/json-definitions/v3/tech-record/put/lgv/complete/index.json
@@ -74,6 +74,9 @@
       ],
       "maxLength": 255
     },
+    "techRecord_adrDetails_documentId": {
+			"type": "string"
+		},
     "techRecord_adrDetails_dangerousGoods": {
       "type": [
         "boolean",

--- a/json-definitions/v3/tech-record/put/lgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/lgv/skeleton/index.json
@@ -71,6 +71,9 @@
       ],
       "maxLength": 255
     },
+    "techRecord_adrDetails_documentId": {
+			"type": "string"
+		},
     "techRecord_adrDetails_dangerousGoods": {
       "type": [
         "boolean",

--- a/json-definitions/v3/tech-record/put/trl/complete/index.json
+++ b/json-definitions/v3/tech-record/put/trl/complete/index.json
@@ -38,6 +38,9 @@
         "null"
       ]
     },
+    "techRecord_adrDetails_documentId": {
+			"type": "string"
+		},
     "techRecord_adrDetails_dangerousGoods": {
       "type": [
         "boolean",

--- a/json-definitions/v3/tech-record/put/trl/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/trl/skeleton/index.json
@@ -53,6 +53,9 @@
         "string"
       ]
     },
+    "techRecord_adrDetails_documentId": {
+			"type": "string"
+		},
     "techRecord_adrDetails_dangerousGoods": {
       "type": [
         "boolean",

--- a/json-definitions/v3/tech-record/put/trl/testable/index.json
+++ b/json-definitions/v3/tech-record/put/trl/testable/index.json
@@ -55,6 +55,9 @@
         "string"
       ]
     },
+    "techRecord_adrDetails_documentId": {
+			"type": "string"
+		},
     "techRecord_adrDetails_dangerousGoods": {
       "type": [
         "boolean",

--- a/json-schemas/v3/tech-record/get/hgv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/complete/index.json
@@ -67,6 +67,9 @@
 		"systemNumber": {
 			"type": "string"
 		},
+		"techRecord_adrDetails_documentId": {
+			"type": "string"
+		},
 		"techRecord_adrDetails_dangerousGoods": {
 			"type": [
 				"boolean",

--- a/json-schemas/v3/tech-record/get/hgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/skeleton/index.json
@@ -37,6 +37,9 @@
 		"systemNumber": {
 			"type": "string"
 		},
+		"techRecord_adrDetails_documentId": {
+			"type": "string"
+		},
 		"techRecord_adrDetails_dangerousGoods": {
 			"type": [
 				"boolean",

--- a/json-schemas/v3/tech-record/get/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/testable/index.json
@@ -41,6 +41,9 @@
 		"systemNumber": {
 			"type": "string"
 		},
+		"techRecord_adrDetails_documentId": {
+			"type": "string"
+		},
 		"techRecord_adrDetails_dangerousGoods": {
 			"type": [
 				"boolean",

--- a/json-schemas/v3/tech-record/get/lgv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/lgv/complete/index.json
@@ -72,6 +72,9 @@
 			],
 			"maxLength": 255
 		},
+		"techRecord_adrDetails_documentId": {
+			"type": "string"
+		},
 		"techRecord_adrDetails_dangerousGoods": {
 			"type": [
 				"boolean",

--- a/json-schemas/v3/tech-record/get/lgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/lgv/skeleton/index.json
@@ -69,6 +69,9 @@
 			],
 			"maxLength": 255
 		},
+		"techRecord_adrDetails_documentId": {
+			"type": "string"
+		},
 		"techRecord_adrDetails_dangerousGoods": {
 			"type": [
 				"boolean",

--- a/json-schemas/v3/tech-record/get/trl/complete/index.json
+++ b/json-schemas/v3/tech-record/get/trl/complete/index.json
@@ -49,6 +49,9 @@
 		"systemNumber": {
 			"type": "string"
 		},
+		"techRecord_adrDetails_documentId": {
+			"type": "string"
+		},
 		"techRecord_adrDetails_dangerousGoods": {
 			"type": [
 				"boolean",

--- a/json-schemas/v3/tech-record/get/trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/trl/skeleton/index.json
@@ -29,6 +29,9 @@
 		"systemNumber": {
 			"type": "string"
 		},
+		"techRecord_adrDetails_documentId": {
+			"type": "string"
+		},
 		"techRecord_adrDetails_dangerousGoods": {
 			"type": [
 				"boolean",

--- a/json-schemas/v3/tech-record/get/trl/testable/index.json
+++ b/json-schemas/v3/tech-record/get/trl/testable/index.json
@@ -31,6 +31,9 @@
 		"systemNumber": {
 			"type": "string"
 		},
+		"techRecord_adrDetails_documentId": {
+			"type": "string"
+		},
 		"techRecord_adrDetails_dangerousGoods": {
 			"type": [
 				"boolean",

--- a/json-schemas/v3/tech-record/put/hgv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/complete/index.json
@@ -55,6 +55,9 @@
 				"null"
 			]
 		},
+		"techRecord_adrDetails_documentId": {
+			"type": "string"
+		},
 		"techRecord_adrDetails_dangerousGoods": {
 			"type": [
 				"boolean",

--- a/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
@@ -23,6 +23,9 @@
 				"null"
 			]
 		},
+		"techRecord_adrDetails_documentId": {
+			"type": "string"
+		},
 		"techRecord_adrDetails_dangerousGoods": {
 			"type": [
 				"boolean",

--- a/json-schemas/v3/tech-record/put/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/testable/index.json
@@ -25,6 +25,9 @@
 				"null"
 			]
 		},
+		"techRecord_adrDetails_documentId": {
+			"type": "string"
+		},
 		"techRecord_adrDetails_dangerousGoods": {
 			"type": [
 				"boolean",

--- a/json-schemas/v3/tech-record/put/lgv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/lgv/complete/index.json
@@ -74,6 +74,9 @@
 			],
 			"maxLength": 255
 		},
+		"techRecord_adrDetails_documentId": {
+			"type": "string"
+		},
 		"techRecord_adrDetails_dangerousGoods": {
 			"type": [
 				"boolean",

--- a/json-schemas/v3/tech-record/put/lgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/lgv/skeleton/index.json
@@ -71,6 +71,9 @@
 			],
 			"maxLength": 255
 		},
+		"techRecord_adrDetails_documentId": {
+			"type": "string"
+		},
 		"techRecord_adrDetails_dangerousGoods": {
 			"type": [
 				"boolean",

--- a/json-schemas/v3/tech-record/put/trl/complete/index.json
+++ b/json-schemas/v3/tech-record/put/trl/complete/index.json
@@ -38,6 +38,9 @@
 				"null"
 			]
 		},
+		"techRecord_adrDetails_documentId": {
+			"type": "string"
+		},
 		"techRecord_adrDetails_dangerousGoods": {
 			"type": [
 				"boolean",

--- a/json-schemas/v3/tech-record/put/trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/trl/skeleton/index.json
@@ -88,6 +88,9 @@
 				"string"
 			]
 		},
+		"techRecord_adrDetails_documentId": {
+			"type": "string"
+		},
 		"techRecord_adrDetails_dangerousGoods": {
 			"type": [
 				"boolean",

--- a/json-schemas/v3/tech-record/put/trl/testable/index.json
+++ b/json-schemas/v3/tech-record/put/trl/testable/index.json
@@ -90,6 +90,9 @@
 				"string"
 			]
 		},
+		"techRecord_adrDetails_documentId": {
+			"type": "string"
+		},
 		"techRecord_adrDetails_dangerousGoods": {
 			"type": [
 				"boolean",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "6.0.1",
+      "version": "6.1.0",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "6.0.0",
+      "version": "6.0.1",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "description": "type definitions for cvs vta and vtm applications",
   "main": "index.js",
   "repository": {

--- a/types/v3/tech-record/get/hgv/complete/index.d.ts
+++ b/types/v3/tech-record/get/hgv/complete/index.d.ts
@@ -87,6 +87,7 @@ export interface TechRecordGETHGVComplete {
   createdTimestamp: string;
   partialVin: string;
   systemNumber: string;
+  techRecord_adrDetails_documentId?: string;
   techRecord_adrDetails_dangerousGoods?: boolean | null;
   techRecord_adrDetails_vehicleDetails_type?: string | null;
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;

--- a/types/v3/tech-record/get/hgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/hgv/skeleton/index.d.ts
@@ -87,6 +87,7 @@ export interface TechRecordGETHGVSkeleton {
   createdTimestamp: string;
   partialVin: string;
   systemNumber: string;
+  techRecord_adrDetails_documentId?: string;
   techRecord_adrDetails_dangerousGoods?: boolean | null;
   techRecord_adrDetails_vehicleDetails_type?: string | null;
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;

--- a/types/v3/tech-record/get/hgv/testable/index.d.ts
+++ b/types/v3/tech-record/get/hgv/testable/index.d.ts
@@ -87,6 +87,7 @@ export interface TechRecordGETHGVTestable {
   createdTimestamp: string;
   partialVin: string;
   systemNumber: string;
+  techRecord_adrDetails_documentId?: string;
   techRecord_adrDetails_dangerousGoods?: boolean | null;
   techRecord_adrDetails_vehicleDetails_type?: string | null;
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;

--- a/types/v3/tech-record/get/lgv/complete/index.d.ts
+++ b/types/v3/tech-record/get/lgv/complete/index.d.ts
@@ -18,6 +18,7 @@ export interface TechRecordGETLGVComplete {
   techRecord_applicantDetails_postCode?: null | string;
   techRecord_applicantDetails_telephoneNumber?: null | string;
   techRecord_applicantDetails_emailAddress?: null | string;
+  techRecord_adrDetails_documentId?: string;
   techRecord_adrDetails_dangerousGoods?: boolean | null;
   techRecord_adrDetails_vehicleDetails_type?: string | null;
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;

--- a/types/v3/tech-record/get/lgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/lgv/skeleton/index.d.ts
@@ -18,6 +18,7 @@ export interface TechRecordGETLGVSkeleton {
   techRecord_applicantDetails_postCode?: null | string;
   techRecord_applicantDetails_telephoneNumber?: null | string;
   techRecord_applicantDetails_emailAddress?: null | string;
+  techRecord_adrDetails_documentId?: string;
   techRecord_adrDetails_dangerousGoods?: boolean | null;
   techRecord_adrDetails_vehicleDetails_type?: string | null;
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;

--- a/types/v3/tech-record/get/trl/complete/index.d.ts
+++ b/types/v3/tech-record/get/trl/complete/index.d.ts
@@ -104,6 +104,7 @@ export interface TechRecordGETTRLComplete {
   createdTimestamp: string;
   partialVin: string;
   systemNumber: string;
+  techRecord_adrDetails_documentId?: string;
   techRecord_adrDetails_dangerousGoods?: boolean | null;
   techRecord_adrDetails_vehicleDetails_type?: string | null;
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;

--- a/types/v3/tech-record/get/trl/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/trl/skeleton/index.d.ts
@@ -104,6 +104,7 @@ export interface TechRecordGETTRLSkeleton {
   createdTimestamp: string;
   partialVin: string;
   systemNumber: string;
+  techRecord_adrDetails_documentId?: string;
   techRecord_adrDetails_dangerousGoods?: boolean | null;
   techRecord_adrDetails_vehicleDetails_type?: string | null;
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;

--- a/types/v3/tech-record/get/trl/testable/index.d.ts
+++ b/types/v3/tech-record/get/trl/testable/index.d.ts
@@ -104,6 +104,7 @@ export interface TechRecordGETTRLTestable {
   createdTimestamp: string;
   partialVin: string;
   systemNumber: string;
+  techRecord_adrDetails_documentId?: string;
   techRecord_adrDetails_dangerousGoods?: boolean | null;
   techRecord_adrDetails_vehicleDetails_type?: string | null;
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;

--- a/types/v3/tech-record/put/hgv/complete/index.d.ts
+++ b/types/v3/tech-record/put/hgv/complete/index.d.ts
@@ -85,6 +85,7 @@ export type StatusCode = "provisional" | "current" | "archived";
 export interface TechRecordPUTHGVComplete {
   secondaryVrms?: string[];
   partialVin?: string | null;
+  techRecord_adrDetails_documentId?: string;
   techRecord_adrDetails_dangerousGoods?: boolean | null;
   techRecord_adrDetails_vehicleDetails_type?: string | null;
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;

--- a/types/v3/tech-record/put/hgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/hgv/skeleton/index.d.ts
@@ -85,6 +85,7 @@ export type StatusCode = "provisional" | "current" | "archived";
 export interface TechRecordPUTHGVSkeleton {
   secondaryVrms?: string[];
   partialVin?: string | null;
+  techRecord_adrDetails_documentId?: string;
   techRecord_adrDetails_dangerousGoods?: boolean | null;
   techRecord_adrDetails_vehicleDetails_type?: string | null;
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;

--- a/types/v3/tech-record/put/hgv/testable/index.d.ts
+++ b/types/v3/tech-record/put/hgv/testable/index.d.ts
@@ -85,6 +85,7 @@ export type StatusCode = "provisional" | "current" | "archived";
 export interface TechRecordPUTHGVTestable {
   secondaryVrms?: string[];
   partialVin?: string | null;
+  techRecord_adrDetails_documentId?: string;
   techRecord_adrDetails_dangerousGoods?: boolean | null;
   techRecord_adrDetails_vehicleDetails_type?: string | null;
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;

--- a/types/v3/tech-record/put/lgv/complete/index.d.ts
+++ b/types/v3/tech-record/put/lgv/complete/index.d.ts
@@ -20,6 +20,7 @@ export interface TechRecordPUTLGVComplete {
   techRecord_applicantDetails_postCode?: null | string;
   techRecord_applicantDetails_telephoneNumber?: null | string;
   techRecord_applicantDetails_emailAddress?: null | string;
+  techRecord_adrDetails_documentId?: string;
   techRecord_adrDetails_dangerousGoods?: boolean | null;
   techRecord_adrDetails_vehicleDetails_type?: string | null;
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;

--- a/types/v3/tech-record/put/lgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/lgv/skeleton/index.d.ts
@@ -20,6 +20,7 @@ export interface TechRecordPUTLGVSkeleton {
   techRecord_applicantDetails_postCode?: null | string;
   techRecord_applicantDetails_telephoneNumber?: null | string;
   techRecord_applicantDetails_emailAddress?: null | string;
+  techRecord_adrDetails_documentId?: string;
   techRecord_adrDetails_dangerousGoods?: boolean | null;
   techRecord_adrDetails_vehicleDetails_type?: string | null;
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;

--- a/types/v3/tech-record/put/trl/complete/index.d.ts
+++ b/types/v3/tech-record/put/trl/complete/index.d.ts
@@ -102,6 +102,7 @@ export type SpeedCategorySymbol =
 
 export interface TechRecordPUTTRLComplete {
   partialVin?: string | null;
+  techRecord_adrDetails_documentId?: string;
   techRecord_adrDetails_dangerousGoods?: boolean | null;
   techRecord_adrDetails_vehicleDetails_type?: string | null;
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;

--- a/types/v3/tech-record/put/trl/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/trl/skeleton/index.d.ts
@@ -107,6 +107,7 @@ export interface TechRecordPUTTRLSkeleton {
   techRecord_ntaNumber?: null | string;
   techRecord_variantNumber?: null | string;
   techRecord_variantVersionNumber?: null | string;
+  techRecord_adrDetails_documentId?: string;
   techRecord_adrDetails_dangerousGoods?: boolean | null;
   techRecord_adrDetails_vehicleDetails_type?: string | null;
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;

--- a/types/v3/tech-record/put/trl/testable/index.d.ts
+++ b/types/v3/tech-record/put/trl/testable/index.d.ts
@@ -107,6 +107,7 @@ export interface TechRecordPUTTRLTestable {
   techRecord_ntaNumber?: null | string;
   techRecord_variantNumber?: null | string;
   techRecord_variantVersionNumber?: null | string;
+  techRecord_adrDetails_documentId?: string;
   techRecord_adrDetails_dangerousGoods?: boolean | null;
   techRecord_adrDetails_vehicleDetails_type?: string | null;
   techRecord_adrDetails_vehicleDetails_approvalDate?: string | null;


### PR DESCRIPTION
## Added documentId to ADR Details

The documentId field has been added as a string type to the ADR details object on tech record GET and PUT objects.

[CB2-11293](https://dvsa.atlassian.net/browse/CB2-11293)

<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

-

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
