### PR TITLE
minor(cb2-11103): allow createdatdate to be an iso string

### DIFF
--- a/json-definitions/v3/tech-record/get/hgv/complete/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/complete/index.json
@@ -130,14 +130,9 @@
             "maxLength": 1024
           },
           "createdAtDate": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-              },
-              {
-                "type": "null"
-              }
+            "type": [
+              "string",
+              "null"
             ]
           },
           "lastUpdatedBy": {

--- a/json-definitions/v3/tech-record/get/hgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/skeleton/index.json
@@ -100,14 +100,9 @@
             "maxLength": 1024
           },
           "createdAtDate": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-              },
-              {
-                "type": "null"
-              }
+            "type": [
+              "string",
+              "null"
             ]
           },
           "lastUpdatedBy": {

--- a/json-definitions/v3/tech-record/get/hgv/testable/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/testable/index.json
@@ -104,14 +104,9 @@
             "maxLength": 1024
           },
           "createdAtDate": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-              },
-              {
-                "type": "null"
-              }
+            "type": [
+              "string",
+              "null"
             ]
           },
           "lastUpdatedBy": {

--- a/json-definitions/v3/tech-record/get/lgv/complete/index.json
+++ b/json-definitions/v3/tech-record/get/lgv/complete/index.json
@@ -73,7 +73,7 @@
       "maxLength": 255
     },
     "techRecord_adrDetails_documentId": {
-			"type": "string" 
+			"type": "string"
 		},
     "techRecord_adrDetails_dangerousGoods": {
       "type": [
@@ -135,14 +135,9 @@
             "maxLength": 1024
           },
           "createdAtDate": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-              },
-              {
-                "type": "null"
-              }
+            "type": [
+              "string",
+              "null"
             ]
           },
           "lastUpdatedBy": {

--- a/json-definitions/v3/tech-record/get/lgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/lgv/skeleton/index.json
@@ -132,14 +132,9 @@
             "maxLength": 1024
           },
           "createdAtDate": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-              },
-              {
-                "type": "null"
-              }
+            "type": [
+              "string",
+              "null"
             ]
           },
           "lastUpdatedBy": {

--- a/json-definitions/v3/tech-record/get/trl/complete/index.json
+++ b/json-definitions/v3/tech-record/get/trl/complete/index.json
@@ -112,14 +112,9 @@
             "maxLength": 1024
           },
           "createdAtDate": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-              },
-              {
-                "type": "null"
-              }
+            "type": [
+              "string",
+              "null"
             ]
           },
           "lastUpdatedBy": {

--- a/json-definitions/v3/tech-record/get/trl/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/trl/skeleton/index.json
@@ -92,14 +92,9 @@
             "maxLength": 1024
           },
           "createdAtDate": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-              },
-              {
-                "type": "null"
-              }
+            "type": [
+              "string",
+              "null"
             ]
           },
           "lastUpdatedBy": {

--- a/json-definitions/v3/tech-record/get/trl/testable/index.json
+++ b/json-definitions/v3/tech-record/get/trl/testable/index.json
@@ -94,14 +94,9 @@
             "maxLength": 1024
           },
           "createdAtDate": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-              },
-              {
-                "type": "null"
-              }
+            "type": [
+              "string",
+              "null"
             ]
           },
           "lastUpdatedBy": {

--- a/json-definitions/v3/tech-record/put/hgv/complete/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/complete/index.json
@@ -118,14 +118,9 @@
             "maxLength": 1024
           },
           "createdAtDate": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-              },
-              {
-                "type": "null"
-              }
+            "type": [
+              "string",
+              "null"
             ]
           },
           "lastUpdatedBy": {

--- a/json-definitions/v3/tech-record/put/hgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/skeleton/index.json
@@ -86,14 +86,9 @@
             "maxLength": 1024
           },
           "createdAtDate": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-              },
-              {
-                "type": "null"
-              }
+            "type": [
+              "string",
+              "null"
             ]
           },
           "lastUpdatedBy": {

--- a/json-definitions/v3/tech-record/put/hgv/testable/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/testable/index.json
@@ -88,14 +88,9 @@
             "maxLength": 1024
           },
           "createdAtDate": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-              },
-              {
-                "type": "null"
-              }
+            "type": [
+              "string",
+              "null"
             ]
           },
           "lastUpdatedBy": {

--- a/json-definitions/v3/tech-record/put/lgv/complete/index.json
+++ b/json-definitions/v3/tech-record/put/lgv/complete/index.json
@@ -137,14 +137,9 @@
             "maxLength": 1024
           },
           "createdAtDate": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-              },
-              {
-                "type": "null"
-              }
+            "type": [
+              "string",
+              "null"
             ]
           },
           "lastUpdatedBy": {

--- a/json-definitions/v3/tech-record/put/lgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/lgv/skeleton/index.json
@@ -134,14 +134,9 @@
             "maxLength": 1024
           },
           "createdAtDate": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-              },
-              {
-                "type": "null"
-              }
+            "type": [
+              "string",
+              "null"
             ]
           },
           "lastUpdatedBy": {

--- a/json-definitions/v3/tech-record/put/trl/complete/index.json
+++ b/json-definitions/v3/tech-record/put/trl/complete/index.json
@@ -101,14 +101,9 @@
             "maxLength": 1024
           },
           "createdAtDate": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-              },
-              {
-                "type": "null"
-              }
+            "type": [
+              "string",
+              "null"
             ]
           },
           "lastUpdatedBy": {

--- a/json-definitions/v3/tech-record/put/trl/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/trl/skeleton/index.json
@@ -116,14 +116,9 @@
             "maxLength": 1024
           },
           "createdAtDate": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-              },
-              {
-                "type": "null"
-              }
+            "type": [
+              "string",
+              "null"
             ]
           },
           "lastUpdatedBy": {

--- a/json-definitions/v3/tech-record/put/trl/testable/index.json
+++ b/json-definitions/v3/tech-record/put/trl/testable/index.json
@@ -118,14 +118,9 @@
             "maxLength": 1024
           },
           "createdAtDate": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-              },
-              {
-                "type": "null"
-              }
+            "type": [
+              "string",
+              "null"
             ]
           },
           "lastUpdatedBy": {

--- a/json-schemas/v3/tech-record/get/hgv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/complete/index.json
@@ -139,14 +139,9 @@
 						"maxLength": 1024
 					},
 					"createdAtDate": {
-						"anyOf": [
-							{
-								"type": "string",
-								"pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-							},
-							{
-								"type": "null"
-							}
+						"type": [
+							"string",
+							"null"
 						]
 					},
 					"lastUpdatedBy": {

--- a/json-schemas/v3/tech-record/get/hgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/skeleton/index.json
@@ -109,14 +109,9 @@
 						"maxLength": 1024
 					},
 					"createdAtDate": {
-						"anyOf": [
-							{
-								"type": "string",
-								"pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-							},
-							{
-								"type": "null"
-							}
+						"type": [
+							"string",
+							"null"
 						]
 					},
 					"lastUpdatedBy": {

--- a/json-schemas/v3/tech-record/get/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/testable/index.json
@@ -113,14 +113,9 @@
 						"maxLength": 1024
 					},
 					"createdAtDate": {
-						"anyOf": [
-							{
-								"type": "string",
-								"pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-							},
-							{
-								"type": "null"
-							}
+						"type": [
+							"string",
+							"null"
 						]
 					},
 					"lastUpdatedBy": {

--- a/json-schemas/v3/tech-record/get/lgv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/lgv/complete/index.json
@@ -144,14 +144,9 @@
 						"maxLength": 1024
 					},
 					"createdAtDate": {
-						"anyOf": [
-							{
-								"type": "string",
-								"pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-							},
-							{
-								"type": "null"
-							}
+						"type": [
+							"string",
+							"null"
 						]
 					},
 					"lastUpdatedBy": {

--- a/json-schemas/v3/tech-record/get/lgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/lgv/skeleton/index.json
@@ -141,14 +141,9 @@
 						"maxLength": 1024
 					},
 					"createdAtDate": {
-						"anyOf": [
-							{
-								"type": "string",
-								"pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-							},
-							{
-								"type": "null"
-							}
+						"type": [
+							"string",
+							"null"
 						]
 					},
 					"lastUpdatedBy": {

--- a/json-schemas/v3/tech-record/get/trl/complete/index.json
+++ b/json-schemas/v3/tech-record/get/trl/complete/index.json
@@ -121,14 +121,9 @@
 						"maxLength": 1024
 					},
 					"createdAtDate": {
-						"anyOf": [
-							{
-								"type": "string",
-								"pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-							},
-							{
-								"type": "null"
-							}
+						"type": [
+							"string",
+							"null"
 						]
 					},
 					"lastUpdatedBy": {

--- a/json-schemas/v3/tech-record/get/trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/trl/skeleton/index.json
@@ -101,14 +101,9 @@
 						"maxLength": 1024
 					},
 					"createdAtDate": {
-						"anyOf": [
-							{
-								"type": "string",
-								"pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-							},
-							{
-								"type": "null"
-							}
+						"type": [
+							"string",
+							"null"
 						]
 					},
 					"lastUpdatedBy": {

--- a/json-schemas/v3/tech-record/get/trl/testable/index.json
+++ b/json-schemas/v3/tech-record/get/trl/testable/index.json
@@ -103,14 +103,9 @@
 						"maxLength": 1024
 					},
 					"createdAtDate": {
-						"anyOf": [
-							{
-								"type": "string",
-								"pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-							},
-							{
-								"type": "null"
-							}
+						"type": [
+							"string",
+							"null"
 						]
 					},
 					"lastUpdatedBy": {

--- a/json-schemas/v3/tech-record/put/hgv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/complete/index.json
@@ -127,14 +127,9 @@
 						"maxLength": 1024
 					},
 					"createdAtDate": {
-						"anyOf": [
-							{
-								"type": "string",
-								"pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-							},
-							{
-								"type": "null"
-							}
+						"type": [
+							"string",
+							"null"
 						]
 					},
 					"lastUpdatedBy": {

--- a/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
@@ -95,14 +95,9 @@
 						"maxLength": 1024
 					},
 					"createdAtDate": {
-						"anyOf": [
-							{
-								"type": "string",
-								"pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-							},
-							{
-								"type": "null"
-							}
+						"type": [
+							"string",
+							"null"
 						]
 					},
 					"lastUpdatedBy": {

--- a/json-schemas/v3/tech-record/put/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/testable/index.json
@@ -97,14 +97,9 @@
 						"maxLength": 1024
 					},
 					"createdAtDate": {
-						"anyOf": [
-							{
-								"type": "string",
-								"pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-							},
-							{
-								"type": "null"
-							}
+						"type": [
+							"string",
+							"null"
 						]
 					},
 					"lastUpdatedBy": {

--- a/json-schemas/v3/tech-record/put/lgv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/lgv/complete/index.json
@@ -146,14 +146,9 @@
 						"maxLength": 1024
 					},
 					"createdAtDate": {
-						"anyOf": [
-							{
-								"type": "string",
-								"pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-							},
-							{
-								"type": "null"
-							}
+						"type": [
+							"string",
+							"null"
 						]
 					},
 					"lastUpdatedBy": {

--- a/json-schemas/v3/tech-record/put/lgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/lgv/skeleton/index.json
@@ -143,14 +143,9 @@
 						"maxLength": 1024
 					},
 					"createdAtDate": {
-						"anyOf": [
-							{
-								"type": "string",
-								"pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-							},
-							{
-								"type": "null"
-							}
+						"type": [
+							"string",
+							"null"
 						]
 					},
 					"lastUpdatedBy": {

--- a/json-schemas/v3/tech-record/put/trl/complete/index.json
+++ b/json-schemas/v3/tech-record/put/trl/complete/index.json
@@ -110,14 +110,9 @@
 						"maxLength": 1024
 					},
 					"createdAtDate": {
-						"anyOf": [
-							{
-								"type": "string",
-								"pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-							},
-							{
-								"type": "null"
-							}
+						"type": [
+							"string",
+							"null"
 						]
 					},
 					"lastUpdatedBy": {

--- a/json-schemas/v3/tech-record/put/trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/trl/skeleton/index.json
@@ -160,14 +160,9 @@
 						"maxLength": 1024
 					},
 					"createdAtDate": {
-						"anyOf": [
-							{
-								"type": "string",
-								"pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-							},
-							{
-								"type": "null"
-							}
+						"type": [
+							"string",
+							"null"
 						]
 					},
 					"lastUpdatedBy": {

--- a/json-schemas/v3/tech-record/put/trl/testable/index.json
+++ b/json-schemas/v3/tech-record/put/trl/testable/index.json
@@ -162,14 +162,9 @@
 						"maxLength": 1024
 					},
 					"createdAtDate": {
-						"anyOf": [
-							{
-								"type": "string",
-								"pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-							},
-							{
-								"type": "null"
-							}
+						"type": [
+							"string",
+							"null"
 						]
 					},
 					"lastUpdatedBy": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "6.1.0",
+      "version": "6.2.0",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "type definitions for cvs vta and vtm applications",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
## Ticket title

Allow createdAtDate to be an iso string

[CB2-11103](https://dvsa.atlassian.net/browse/CB2-11103)

<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

- removed regex from createdAtDate allowing a full iso string to be used for the createdAtDate value.

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
