### PR TITLE
minor(cb-12996): Added test code to test types

### DIFF
--- a/json-definitions/v1/test-result/index.json
+++ b/json-definitions/v1/test-result/index.json
@@ -260,6 +260,11 @@
         }
       },
       "additionalProperties": false
+    },
+    "vehicleId": {
+      "type": [
+        "string", "null"
+      ]
     }
   },
   "additionalProperties": false,

--- a/json-definitions/v1/test-type/index.json
+++ b/json-definitions/v1/test-type/index.json
@@ -204,6 +204,32 @@
         "string",
         "null"
       ]
+    },
+    "lastUpdatedAt": {
+      "type": [
+        "string",
+        "date",
+        "null"
+      ]
+    },
+    "createdAt": {
+      "type": [
+        "string",
+        "date",
+        "null"
+      ]
+    },
+    "testTypeClassification": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "deletionFlag": {
+      "type": [
+        "string",
+        "null"
+      ]
     }
   },
   "required": [

--- a/json-definitions/v1/test-type/index.json
+++ b/json-definitions/v1/test-type/index.json
@@ -198,6 +198,12 @@
         "string",
         "null"
       ]
+    },
+    "testCode": {
+      "type": [
+        "string",
+        "null"
+      ]
     }
   },
   "required": [

--- a/json-schemas/v1/test-result/index.json
+++ b/json-schemas/v1/test-result/index.json
@@ -871,6 +871,12 @@
 							"string",
 							"null"
 						]
+					},
+					"testCode": {
+						"type": [
+							"string",
+							"null"
+						]
 					}
 				},
 				"required": [

--- a/json-schemas/v1/test-result/index.json
+++ b/json-schemas/v1/test-result/index.json
@@ -877,6 +877,32 @@
 							"string",
 							"null"
 						]
+					},
+					"lastUpdatedAt": {
+						"type": [
+							"string",
+							"date",
+							"null"
+						]
+					},
+					"createdAt": {
+						"type": [
+							"string",
+							"date",
+							"null"
+						]
+					},
+					"testTypeClassification": {
+						"type": [
+							"string",
+							"null"
+						]
+					},
+					"deletionFlag": {
+						"type": [
+							"string",
+							"null"
+						]
 					}
 				},
 				"required": [

--- a/json-schemas/v1/test-result/index.json
+++ b/json-schemas/v1/test-result/index.json
@@ -1032,6 +1032,12 @@
 				}
 			},
 			"additionalProperties": false
+		},
+		"vehicleId": {
+			"type": [
+				"string",
+				"null"
+			]
 		}
 	},
 	"additionalProperties": false,

--- a/json-schemas/v1/test-type/index.json
+++ b/json-schemas/v1/test-type/index.json
@@ -607,6 +607,12 @@
 				"string",
 				"null"
 			]
+		},
+		"testCode": {
+			"type": [
+				"string",
+				"null"
+			]
 		}
 	},
 	"required": [

--- a/json-schemas/v1/test-type/index.json
+++ b/json-schemas/v1/test-type/index.json
@@ -613,6 +613,32 @@
 				"string",
 				"null"
 			]
+		},
+		"lastUpdatedAt": {
+			"type": [
+				"string",
+				"date",
+				"null"
+			]
+		},
+		"createdAt": {
+			"type": [
+				"string",
+				"date",
+				"null"
+			]
+		},
+		"testTypeClassification": {
+			"type": [
+				"string",
+				"null"
+			]
+		},
+		"deletionFlag": {
+			"type": [
+				"string",
+				"null"
+			]
 		}
 	},
 	"required": [

--- a/json-schemas/v1/test/index.json
+++ b/json-schemas/v1/test/index.json
@@ -1553,6 +1553,12 @@
 													"string",
 													"null"
 												]
+											},
+											"testCode": {
+												"type": [
+													"string",
+													"null"
+												]
 											}
 										},
 										"required": [
@@ -2337,6 +2343,12 @@
 									]
 								},
 								"reapplicationDate": {
+									"type": [
+										"string",
+										"null"
+									]
+								},
+								"testCode": {
 									"type": [
 										"string",
 										"null"

--- a/json-schemas/v1/test/index.json
+++ b/json-schemas/v1/test/index.json
@@ -1714,6 +1714,12 @@
 										}
 									},
 									"additionalProperties": false
+								},
+								"vehicleId": {
+									"type": [
+										"string",
+										"null"
+									]
 								}
 							},
 							"additionalProperties": false,

--- a/json-schemas/v1/test/index.json
+++ b/json-schemas/v1/test/index.json
@@ -1559,6 +1559,32 @@
 													"string",
 													"null"
 												]
+											},
+											"lastUpdatedAt": {
+												"type": [
+													"string",
+													"date",
+													"null"
+												]
+											},
+											"createdAt": {
+												"type": [
+													"string",
+													"date",
+													"null"
+												]
+											},
+											"testTypeClassification": {
+												"type": [
+													"string",
+													"null"
+												]
+											},
+											"deletionFlag": {
+												"type": [
+													"string",
+													"null"
+												]
 											}
 										},
 										"required": [
@@ -2349,6 +2375,32 @@
 									]
 								},
 								"testCode": {
+									"type": [
+										"string",
+										"null"
+									]
+								},
+								"lastUpdatedAt": {
+									"type": [
+										"string",
+										"date",
+										"null"
+									]
+								},
+								"createdAt": {
+									"type": [
+										"string",
+										"date",
+										"null"
+									]
+								},
+								"testTypeClassification": {
+									"type": [
+										"string",
+										"null"
+									]
+								},
+								"deletionFlag": {
 									"type": [
 										"string",
 										"null"

--- a/json-schemas/v1/vehicle/index.json
+++ b/json-schemas/v1/vehicle/index.json
@@ -1531,6 +1531,32 @@
 										"string",
 										"null"
 									]
+								},
+								"lastUpdatedAt": {
+									"type": [
+										"string",
+										"date",
+										"null"
+									]
+								},
+								"createdAt": {
+									"type": [
+										"string",
+										"date",
+										"null"
+									]
+								},
+								"testTypeClassification": {
+									"type": [
+										"string",
+										"null"
+									]
+								},
+								"deletionFlag": {
+									"type": [
+										"string",
+										"null"
+									]
 								}
 							},
 							"required": [
@@ -2321,6 +2347,32 @@
 						]
 					},
 					"testCode": {
+						"type": [
+							"string",
+							"null"
+						]
+					},
+					"lastUpdatedAt": {
+						"type": [
+							"string",
+							"date",
+							"null"
+						]
+					},
+					"createdAt": {
+						"type": [
+							"string",
+							"date",
+							"null"
+						]
+					},
+					"testTypeClassification": {
+						"type": [
+							"string",
+							"null"
+						]
+					},
+					"deletionFlag": {
 						"type": [
 							"string",
 							"null"

--- a/json-schemas/v1/vehicle/index.json
+++ b/json-schemas/v1/vehicle/index.json
@@ -1525,6 +1525,12 @@
 										"string",
 										"null"
 									]
+								},
+								"testCode": {
+									"type": [
+										"string",
+										"null"
+									]
 								}
 							},
 							"required": [
@@ -2309,6 +2315,12 @@
 						]
 					},
 					"reapplicationDate": {
+						"type": [
+							"string",
+							"null"
+						]
+					},
+					"testCode": {
 						"type": [
 							"string",
 							"null"

--- a/json-schemas/v1/vehicle/index.json
+++ b/json-schemas/v1/vehicle/index.json
@@ -1686,6 +1686,12 @@
 							}
 						},
 						"additionalProperties": false
+					},
+					"vehicleId": {
+						"type": [
+							"string",
+							"null"
+						]
 					}
 				},
 				"additionalProperties": false,

--- a/json-schemas/v1/visit/index.json
+++ b/json-schemas/v1/visit/index.json
@@ -1592,6 +1592,32 @@
 																"string",
 																"null"
 															]
+														},
+														"lastUpdatedAt": {
+															"type": [
+																"string",
+																"date",
+																"null"
+															]
+														},
+														"createdAt": {
+															"type": [
+																"string",
+																"date",
+																"null"
+															]
+														},
+														"testTypeClassification": {
+															"type": [
+																"string",
+																"null"
+															]
+														},
+														"deletionFlag": {
+															"type": [
+																"string",
+																"null"
+															]
 														}
 													},
 													"required": [
@@ -2382,6 +2408,32 @@
 												]
 											},
 											"testCode": {
+												"type": [
+													"string",
+													"null"
+												]
+											},
+											"lastUpdatedAt": {
+												"type": [
+													"string",
+													"date",
+													"null"
+												]
+											},
+											"createdAt": {
+												"type": [
+													"string",
+													"date",
+													"null"
+												]
+											},
+											"testTypeClassification": {
+												"type": [
+													"string",
+													"null"
+												]
+											},
+											"deletionFlag": {
 												"type": [
 													"string",
 													"null"

--- a/json-schemas/v1/visit/index.json
+++ b/json-schemas/v1/visit/index.json
@@ -1747,6 +1747,12 @@
 													}
 												},
 												"additionalProperties": false
+											},
+											"vehicleId": {
+												"type": [
+													"string",
+													"null"
+												]
 											}
 										},
 										"additionalProperties": false,

--- a/json-schemas/v1/visit/index.json
+++ b/json-schemas/v1/visit/index.json
@@ -1586,6 +1586,12 @@
 																"string",
 																"null"
 															]
+														},
+														"testCode": {
+															"type": [
+																"string",
+																"null"
+															]
 														}
 													},
 													"required": [
@@ -2370,6 +2376,12 @@
 												]
 											},
 											"reapplicationDate": {
+												"type": [
+													"string",
+													"null"
+												]
+											},
+											"testCode": {
 												"type": [
 													"string",
 													"null"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "7.1.1",
+  "version": "7.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "7.1.0",
+      "version": "7.2.0",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "7.1.1",
+  "version": "7.2.0",
   "description": "type definitions for cvs vta and vtm applications",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "7.1.2",
+  "version": "7.1.1",
   "description": "type definitions for cvs vta and vtm applications",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "7.1.0",
+  "version": "7.1.2",
   "description": "type definitions for cvs vta and vtm applications",
   "main": "index.js",
   "repository": {

--- a/types/v1/test-result/index.d.ts
+++ b/types/v1/test-result/index.d.ts
@@ -105,6 +105,20 @@ export interface TestTypeSchema {
   testNumber?: string | null;
   reapplicationDate?: string | null;
   testCode?: string | null;
+  lastUpdatedAt?:
+    | string
+    | {
+        [k: string]: unknown;
+      }
+    | null;
+  createdAt?:
+    | string
+    | {
+        [k: string]: unknown;
+      }
+    | null;
+  testTypeClassification?: string | null;
+  deletionFlag?: string | null;
 }
 export interface ModTypeSchema {
   code: string;

--- a/types/v1/test-result/index.d.ts
+++ b/types/v1/test-result/index.d.ts
@@ -57,6 +57,7 @@ export interface TestResultSchema {
   make?: string | null;
   model?: string | null;
   bodyType?: BodyTypeSchema;
+  vehicleId?: string | null;
 }
 export interface VehicleClassSchema {
   code: string;

--- a/types/v1/test-result/index.d.ts
+++ b/types/v1/test-result/index.d.ts
@@ -104,6 +104,7 @@ export interface TestTypeSchema {
   requiredStandards?: SpecialistCustomDefectsSchemaPut[];
   testNumber?: string | null;
   reapplicationDate?: string | null;
+  testCode?: string | null;
 }
 export interface ModTypeSchema {
   code: string;

--- a/types/v1/test-type/index.d.ts
+++ b/types/v1/test-type/index.d.ts
@@ -50,6 +50,20 @@ export interface TestTypeSchema {
   testNumber?: string | null;
   reapplicationDate?: string | null;
   testCode?: string | null;
+  lastUpdatedAt?:
+    | string
+    | {
+        [k: string]: unknown;
+      }
+    | null;
+  createdAt?:
+    | string
+    | {
+        [k: string]: unknown;
+      }
+    | null;
+  testTypeClassification?: string | null;
+  deletionFlag?: string | null;
 }
 export interface ModTypeSchema {
   code: string;

--- a/types/v1/test-type/index.d.ts
+++ b/types/v1/test-type/index.d.ts
@@ -49,6 +49,7 @@ export interface TestTypeSchema {
   requiredStandards?: SpecialistCustomDefectsSchemaPut[];
   testNumber?: string | null;
   reapplicationDate?: string | null;
+  testCode?: string | null;
 }
 export interface ModTypeSchema {
   code: string;

--- a/types/v1/test/index.d.ts
+++ b/types/v1/test/index.d.ts
@@ -322,6 +322,20 @@ export interface TestTypeSchema {
   testNumber?: string | null;
   reapplicationDate?: string | null;
   testCode?: string | null;
+  lastUpdatedAt?:
+    | string
+    | {
+        [k: string]: unknown;
+      }
+    | null;
+  createdAt?:
+    | string
+    | {
+        [k: string]: unknown;
+      }
+    | null;
+  testTypeClassification?: string | null;
+  deletionFlag?: string | null;
 }
 export interface ModTypeSchema {
   code: string;

--- a/types/v1/test/index.d.ts
+++ b/types/v1/test/index.d.ts
@@ -321,6 +321,7 @@ export interface TestTypeSchema {
   requiredStandards?: SpecialistCustomDefectsSchemaPut[];
   testNumber?: string | null;
   reapplicationDate?: string | null;
+  testCode?: string | null;
 }
 export interface ModTypeSchema {
   code: string;

--- a/types/v1/test/index.d.ts
+++ b/types/v1/test/index.d.ts
@@ -278,6 +278,7 @@ export interface TestResultSchema {
   make?: string | null;
   model?: string | null;
   bodyType?: BodyTypeSchema;
+  vehicleId?: string | null;
 }
 export interface TestTypeSchema {
   testTypeName: string | null;

--- a/types/v1/vehicle/index.d.ts
+++ b/types/v1/vehicle/index.d.ts
@@ -314,6 +314,20 @@ export interface TestTypeSchema {
   testNumber?: string | null;
   reapplicationDate?: string | null;
   testCode?: string | null;
+  lastUpdatedAt?:
+    | string
+    | {
+        [k: string]: unknown;
+      }
+    | null;
+  createdAt?:
+    | string
+    | {
+        [k: string]: unknown;
+      }
+    | null;
+  testTypeClassification?: string | null;
+  deletionFlag?: string | null;
 }
 export interface ModTypeSchema {
   code: string;

--- a/types/v1/vehicle/index.d.ts
+++ b/types/v1/vehicle/index.d.ts
@@ -313,6 +313,7 @@ export interface TestTypeSchema {
   requiredStandards?: SpecialistCustomDefectsSchemaPut[];
   testNumber?: string | null;
   reapplicationDate?: string | null;
+  testCode?: string | null;
 }
 export interface ModTypeSchema {
   code: string;

--- a/types/v1/vehicle/index.d.ts
+++ b/types/v1/vehicle/index.d.ts
@@ -270,6 +270,7 @@ export interface TestResultSchema {
   make?: string | null;
   model?: string | null;
   bodyType?: BodyTypeSchema;
+  vehicleId?: string | null;
 }
 export interface TestTypeSchema {
   testTypeName: string | null;

--- a/types/v1/visit/index.d.ts
+++ b/types/v1/visit/index.d.ts
@@ -291,6 +291,7 @@ export interface TestResultSchema {
   make?: string | null;
   model?: string | null;
   bodyType?: BodyTypeSchema;
+  vehicleId?: string | null;
 }
 export interface TestTypeSchema {
   testTypeName: string | null;

--- a/types/v1/visit/index.d.ts
+++ b/types/v1/visit/index.d.ts
@@ -334,6 +334,7 @@ export interface TestTypeSchema {
   requiredStandards?: SpecialistCustomDefectsSchemaPut[];
   testNumber?: string | null;
   reapplicationDate?: string | null;
+  testCode?: string | null;
 }
 export interface ModTypeSchema {
   code: string;

--- a/types/v1/visit/index.d.ts
+++ b/types/v1/visit/index.d.ts
@@ -335,6 +335,20 @@ export interface TestTypeSchema {
   testNumber?: string | null;
   reapplicationDate?: string | null;
   testCode?: string | null;
+  lastUpdatedAt?:
+    | string
+    | {
+        [k: string]: unknown;
+      }
+    | null;
+  createdAt?:
+    | string
+    | {
+        [k: string]: unknown;
+      }
+    | null;
+  testTypeClassification?: string | null;
+  deletionFlag?: string | null;
 }
 export interface ModTypeSchema {
   code: string;


### PR DESCRIPTION
## Update test type definition inside of the types definition repository, to include testCode

This change is to add in test code into the test types fields as well as the following additional fields: 

- lastUpdatedAt
- createdAt
- testTypeClassification
- deleltionFlag

[CB2-12996](https://dvsa.atlassian.net/browse/CB2-12996)

<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->