### PR TITLE
minor(cb2-13178): Added central docs to test type

### DIFF
--- a/json-definitions/v1/enums/testStationType.enum.json
+++ b/json-definitions/v1/enums/testStationType.enum.json
@@ -5,12 +5,14 @@
         "ATF",
         "GVTS",
         "HQ",
-        "POTF"
+        "POTF",
+        "VEF"
     ],
     "enum": [
         "atf",
         "gvts",
         "hq",
-        "potf"
+        "potf",
+        "vef"
     ]
 }

--- a/json-schemas/v1/activity/index.json
+++ b/json-schemas/v1/activity/index.json
@@ -38,13 +38,15 @@
 				"ATF",
 				"GVTS",
 				"HQ",
-				"POTF"
+				"POTF",
+				"VEF"
 			],
 			"enum": [
 				"atf",
 				"gvts",
 				"hq",
-				"potf"
+				"potf",
+				"vef"
 			]
 		},
 		"testerName": {

--- a/json-schemas/v1/enums/testStationType.enum.json
+++ b/json-schemas/v1/enums/testStationType.enum.json
@@ -5,12 +5,14 @@
 		"ATF",
 		"GVTS",
 		"HQ",
-		"POTF"
+		"POTF",
+		"VEF"
 	],
 	"enum": [
 		"atf",
 		"gvts",
 		"hq",
-		"potf"
+		"potf",
+		"vef"
 	]
 }

--- a/json-schemas/v1/test-result/index.json
+++ b/json-schemas/v1/test-result/index.json
@@ -28,13 +28,15 @@
 						"ATF",
 						"GVTS",
 						"HQ",
-						"POTF"
+						"POTF",
+						"VEF"
 					],
 					"enum": [
 						"atf",
 						"gvts",
 						"hq",
-						"potf"
+						"potf",
+						"vef"
 					]
 				}
 			]

--- a/json-schemas/v1/test/index.json
+++ b/json-schemas/v1/test/index.json
@@ -710,13 +710,15 @@
 												"ATF",
 												"GVTS",
 												"HQ",
-												"POTF"
+												"POTF",
+												"VEF"
 											],
 											"enum": [
 												"atf",
 												"gvts",
 												"hq",
-												"potf"
+												"potf",
+												"vef"
 											]
 										}
 									]

--- a/json-schemas/v1/vehicle/index.json
+++ b/json-schemas/v1/vehicle/index.json
@@ -682,13 +682,15 @@
 									"ATF",
 									"GVTS",
 									"HQ",
-									"POTF"
+									"POTF",
+									"VEF"
 								],
 								"enum": [
 									"atf",
 									"gvts",
 									"hq",
-									"potf"
+									"potf",
+									"vef"
 								]
 							}
 						]

--- a/json-schemas/v1/visit/index.json
+++ b/json-schemas/v1/visit/index.json
@@ -743,13 +743,15 @@
 															"ATF",
 															"GVTS",
 															"HQ",
-															"POTF"
+															"POTF",
+															"VEF"
 														],
 														"enum": [
 															"atf",
 															"gvts",
 															"hq",
-															"potf"
+															"potf",
+															"vef"
 														]
 													}
 												]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "7.3.0",
+      "version": "7.4.0",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "description": "type definitions for cvs vta and vtm applications",
   "main": "index.js",
   "repository": {

--- a/types/v1/activity/index.d.ts
+++ b/types/v1/activity/index.d.ts
@@ -32,7 +32,8 @@ export enum TestStationTypes {
   ATF = "atf",
   GVTS = "gvts",
   HQ = "hq",
-  POTF = "potf"
+  POTF = "potf",
+  VEF = "vef"
 }
 export enum WaitReason {
   WAITING_FOR_VEHICLE = "Waiting for vehicle",

--- a/types/v1/enums/testStationType.enum.ts
+++ b/types/v1/enums/testStationType.enum.ts
@@ -9,5 +9,6 @@ export enum TestStationTypes {
   ATF = "atf",
   GVTS = "gvts",
   HQ = "hq",
-  POTF = "potf"
+  POTF = "potf",
+  VEF = "vef"
 }

--- a/types/v1/test-result/index.d.ts
+++ b/types/v1/test-result/index.d.ts
@@ -205,7 +205,8 @@ export enum TestStationTypes {
   ATF = "atf",
   GVTS = "gvts",
   HQ = "hq",
-  POTF = "potf"
+  POTF = "potf",
+  VEF = "vef"
 }
 export enum TestStatus {
   SUBMITTED = "submitted",

--- a/types/v1/test/index.d.ts
+++ b/types/v1/test/index.d.ts
@@ -422,7 +422,8 @@ export enum TestStationTypes {
   ATF = "atf",
   GVTS = "gvts",
   HQ = "hq",
-  POTF = "potf"
+  POTF = "potf",
+  VEF = "vef"
 }
 export enum TestStatus {
   SUBMITTED = "submitted",

--- a/types/v1/vehicle/index.d.ts
+++ b/types/v1/vehicle/index.d.ts
@@ -414,7 +414,8 @@ export enum TestStationTypes {
   ATF = "atf",
   GVTS = "gvts",
   HQ = "hq",
-  POTF = "potf"
+  POTF = "potf",
+  VEF = "vef"
 }
 export enum TestStatus {
   SUBMITTED = "submitted",

--- a/types/v1/visit/index.d.ts
+++ b/types/v1/visit/index.d.ts
@@ -435,7 +435,8 @@ export enum TestStationTypes {
   ATF = "atf",
   GVTS = "gvts",
   HQ = "hq",
-  POTF = "potf"
+  POTF = "potf",
+  VEF = "vef"
 }
 export enum TestStatus {
   SUBMITTED = "submitted",


### PR DESCRIPTION
## Update Test Station Types to include VEF

_Adds the VEF option to test station type enums_

[CB2-13178](https://dvsa.atlassian.net/browse/CB2-13178)

<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

- added vef to TestStationTypes

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
