### PR TITLE
minor(cb2-13894): add month of manufacture to TRLs

### DIFF
--- a/json-definitions/v3/tech-record/enums/manufactureMonth.ignore.json
+++ b/json-definitions/v3/tech-record/enums/manufactureMonth.ignore.json
@@ -1,0 +1,18 @@
+{
+    "title": "Paragraph Ids",
+    "type": "string",
+    "enum": [
+        "January",
+        "February",
+        "March",
+        "April",
+        "May",
+        "June",
+        "July",
+        "August",
+        "September",
+        "October",
+        "November",
+        "December"
+    ]
+}

--- a/json-definitions/v3/tech-record/enums/manufactureMonth.ignore.json
+++ b/json-definitions/v3/tech-record/enums/manufactureMonth.ignore.json
@@ -1,5 +1,5 @@
 {
-    "title": "Paragraph Ids",
+    "title": "Months",
     "type": "string",
     "enum": [
         "January",

--- a/json-definitions/v3/tech-record/get/trl/complete/index.json
+++ b/json-definitions/v3/tech-record/get/trl/complete/index.json
@@ -743,6 +743,16 @@
       "type": "string",
       "maxLength": 50
     },
+    "techRecord_manufactureMonth": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/manufactureMonth.ignore.json"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "techRecord_manufactureYear": {
       "anyOf": [
         {

--- a/json-definitions/v3/tech-record/get/trl/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/trl/skeleton/index.json
@@ -784,6 +784,16 @@
       ],
       "maxLength": 50
     },
+    "techRecord_manufactureMonth": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/manufactureMonth.ignore.json"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "techRecord_manufactureYear": {
       "anyOf": [
         {

--- a/json-definitions/v3/tech-record/get/trl/testable/index.json
+++ b/json-definitions/v3/tech-record/get/trl/testable/index.json
@@ -780,6 +780,16 @@
       ],
       "maxLength": 50
     },
+    "techRecord_manufactureMonth": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/manufactureMonth.ignore.json"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "techRecord_manufactureYear": {
       "anyOf": [
         {

--- a/json-definitions/v3/tech-record/put/trl/complete/index.json
+++ b/json-definitions/v3/tech-record/put/trl/complete/index.json
@@ -723,6 +723,16 @@
       "type": "string",
       "maxLength": 50
     },
+    "techRecord_manufactureMonth": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/manufactureMonth.ignore.json"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "techRecord_manufactureYear": {
       "anyOf": [
         {

--- a/json-definitions/v3/tech-record/put/trl/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/trl/skeleton/index.json
@@ -758,6 +758,16 @@
       ],
       "maxLength": 50
     },
+    "techRecord_manufactureMonth": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/manufactureMonth.ignore.json"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "techRecord_manufactureYear": {
       "anyOf": [
         {

--- a/json-definitions/v3/tech-record/put/trl/testable/index.json
+++ b/json-definitions/v3/tech-record/put/trl/testable/index.json
@@ -760,6 +760,16 @@
       ],
       "maxLength": 50
     },
+    "techRecord_manufactureMonth": {
+      "anyOf": [
+        {
+          "$ref": "../../../enums/manufactureMonth.ignore.json"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "techRecord_manufactureYear": {
       "anyOf": [
         {

--- a/json-schemas/v3/tech-record/get/trl/complete/index.json
+++ b/json-schemas/v3/tech-record/get/trl/complete/index.json
@@ -911,7 +911,7 @@
 		"techRecord_manufactureMonth": {
 			"anyOf": [
 				{
-					"title": "Paragraph Ids",
+					"title": "Months",
 					"type": "string",
 					"enum": [
 						"January",

--- a/json-schemas/v3/tech-record/get/trl/complete/index.json
+++ b/json-schemas/v3/tech-record/get/trl/complete/index.json
@@ -908,6 +908,31 @@
 			"type": "string",
 			"maxLength": 50
 		},
+		"techRecord_manufactureMonth": {
+			"anyOf": [
+				{
+					"title": "Paragraph Ids",
+					"type": "string",
+					"enum": [
+						"January",
+						"February",
+						"March",
+						"April",
+						"May",
+						"June",
+						"July",
+						"August",
+						"September",
+						"October",
+						"November",
+						"December"
+					]
+				},
+				{
+					"type": "null"
+				}
+			]
+		},
 		"techRecord_manufactureYear": {
 			"anyOf": [
 				{

--- a/json-schemas/v3/tech-record/get/trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/trl/skeleton/index.json
@@ -949,6 +949,31 @@
 			],
 			"maxLength": 50
 		},
+		"techRecord_manufactureMonth": {
+			"anyOf": [
+				{
+					"title": "Paragraph Ids",
+					"type": "string",
+					"enum": [
+						"January",
+						"February",
+						"March",
+						"April",
+						"May",
+						"June",
+						"July",
+						"August",
+						"September",
+						"October",
+						"November",
+						"December"
+					]
+				},
+				{
+					"type": "null"
+				}
+			]
+		},
 		"techRecord_manufactureYear": {
 			"anyOf": [
 				{

--- a/json-schemas/v3/tech-record/get/trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/trl/skeleton/index.json
@@ -952,7 +952,7 @@
 		"techRecord_manufactureMonth": {
 			"anyOf": [
 				{
-					"title": "Paragraph Ids",
+					"title": "Months",
 					"type": "string",
 					"enum": [
 						"January",

--- a/json-schemas/v3/tech-record/get/trl/testable/index.json
+++ b/json-schemas/v3/tech-record/get/trl/testable/index.json
@@ -945,6 +945,31 @@
 			],
 			"maxLength": 50
 		},
+		"techRecord_manufactureMonth": {
+			"anyOf": [
+				{
+					"title": "Paragraph Ids",
+					"type": "string",
+					"enum": [
+						"January",
+						"February",
+						"March",
+						"April",
+						"May",
+						"June",
+						"July",
+						"August",
+						"September",
+						"October",
+						"November",
+						"December"
+					]
+				},
+				{
+					"type": "null"
+				}
+			]
+		},
 		"techRecord_manufactureYear": {
 			"anyOf": [
 				{

--- a/json-schemas/v3/tech-record/get/trl/testable/index.json
+++ b/json-schemas/v3/tech-record/get/trl/testable/index.json
@@ -948,7 +948,7 @@
 		"techRecord_manufactureMonth": {
 			"anyOf": [
 				{
-					"title": "Paragraph Ids",
+					"title": "Months",
 					"type": "string",
 					"enum": [
 						"January",

--- a/json-schemas/v3/tech-record/put/trl/complete/index.json
+++ b/json-schemas/v3/tech-record/put/trl/complete/index.json
@@ -888,6 +888,31 @@
 			"type": "string",
 			"maxLength": 50
 		},
+		"techRecord_manufactureMonth": {
+			"anyOf": [
+				{
+					"title": "Paragraph Ids",
+					"type": "string",
+					"enum": [
+						"January",
+						"February",
+						"March",
+						"April",
+						"May",
+						"June",
+						"July",
+						"August",
+						"September",
+						"October",
+						"November",
+						"December"
+					]
+				},
+				{
+					"type": "null"
+				}
+			]
+		},
 		"techRecord_manufactureYear": {
 			"anyOf": [
 				{

--- a/json-schemas/v3/tech-record/put/trl/complete/index.json
+++ b/json-schemas/v3/tech-record/put/trl/complete/index.json
@@ -891,7 +891,7 @@
 		"techRecord_manufactureMonth": {
 			"anyOf": [
 				{
-					"title": "Paragraph Ids",
+					"title": "Months",
 					"type": "string",
 					"enum": [
 						"January",

--- a/json-schemas/v3/tech-record/put/trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/trl/skeleton/index.json
@@ -926,7 +926,7 @@
 		"techRecord_manufactureMonth": {
 			"anyOf": [
 				{
-					"title": "Paragraph Ids",
+					"title": "Months",
 					"type": "string",
 					"enum": [
 						"January",

--- a/json-schemas/v3/tech-record/put/trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/trl/skeleton/index.json
@@ -923,6 +923,31 @@
 			],
 			"maxLength": 50
 		},
+		"techRecord_manufactureMonth": {
+			"anyOf": [
+				{
+					"title": "Paragraph Ids",
+					"type": "string",
+					"enum": [
+						"January",
+						"February",
+						"March",
+						"April",
+						"May",
+						"June",
+						"July",
+						"August",
+						"September",
+						"October",
+						"November",
+						"December"
+					]
+				},
+				{
+					"type": "null"
+				}
+			]
+		},
 		"techRecord_manufactureYear": {
 			"anyOf": [
 				{

--- a/json-schemas/v3/tech-record/put/trl/testable/index.json
+++ b/json-schemas/v3/tech-record/put/trl/testable/index.json
@@ -928,7 +928,7 @@
 		"techRecord_manufactureMonth": {
 			"anyOf": [
 				{
-					"title": "Paragraph Ids",
+					"title": "Months",
 					"type": "string",
 					"enum": [
 						"January",

--- a/json-schemas/v3/tech-record/put/trl/testable/index.json
+++ b/json-schemas/v3/tech-record/put/trl/testable/index.json
@@ -925,6 +925,31 @@
 			],
 			"maxLength": 50
 		},
+		"techRecord_manufactureMonth": {
+			"anyOf": [
+				{
+					"title": "Paragraph Ids",
+					"type": "string",
+					"enum": [
+						"January",
+						"February",
+						"March",
+						"April",
+						"May",
+						"June",
+						"July",
+						"August",
+						"September",
+						"October",
+						"November",
+						"December"
+					]
+				},
+				{
+					"type": "null"
+				}
+			]
+		},
 		"techRecord_manufactureYear": {
 			"anyOf": [
 				{

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "7.5.1",
+  "version": "7.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "7.5.1",
+      "version": "7.6.0",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "7.5.1",
+  "version": "7.6.0",
   "description": "type definitions for cvs vta and vtm applications",
   "main": "index.js",
   "repository": {

--- a/tests/resources/data/trlComplete.json
+++ b/tests/resources/data/trlComplete.json
@@ -46,6 +46,7 @@
     "techRecord_loadSensingValve": false,
     "techRecord_make": "Isuzu",
     "techRecord_manufactureYear": 2018,
+    "techRecord_manufactureMonth": "January",
     "techRecord_maxLoadOnCoupling": 7000,
     "techRecord_model": "F06",
     "techRecord_noOfAxles": 2,

--- a/tests/resources/data/trlSkeleton.json
+++ b/tests/resources/data/trlSkeleton.json
@@ -44,6 +44,7 @@
     "techRecord_letterOfAuth": null,
     "techRecord_make": "A PL",
     "techRecord_manufactureYear": null,
+    "techRecord_manufactureMonth": null,
     "techRecord_manufacturerDetails": null,
     "techRecord_maxLoadOnCoupling": null,
     "techRecord_microfilm_microfilmDocumentType": "Tempo 100 Sp Ord",

--- a/tests/resources/data/trlTestable.json
+++ b/tests/resources/data/trlTestable.json
@@ -34,6 +34,7 @@
     "techRecord_lastUpdatedAt": null,
     "techRecord_make": null,
     "techRecord_manufactureYear": 2021,
+    "techRecord_manufactureMonth": "April",
     "techRecord_maxTrainDesignWeight": 0,
     "techRecord_maxTrainGbWeight": 0,
     "techRecord_model": "model1",

--- a/types/v3/tech-record/get/trl/complete/index.d.ts
+++ b/types/v3/tech-record/get/trl/complete/index.d.ts
@@ -18,6 +18,19 @@ export type FrameDescription =
   | "U section";
 export type LetterTypes = "trailer acceptance" | "trailer rejection";
 export type ParagraphIds = 3 | 4 | 5 | 6 | 7;
+export type ParagraphIds1 =
+  | "January"
+  | "February"
+  | "March"
+  | "April"
+  | "May"
+  | "June"
+  | "July"
+  | "August"
+  | "September"
+  | "October"
+  | "November"
+  | "December";
 export type MicrofilmDocumentType =
   | "PSV Miscellaneous"
   | "AAT - Trailer Annual Test"
@@ -194,6 +207,7 @@ export interface TechRecordGETTRLComplete {
   techRecord_letterOfAuth_paragraphId?: null | ParagraphIds;
   techRecord_letterOfAuth_letterIssuer?: string | null;
   techRecord_make: string;
+  techRecord_manufactureMonth?: ParagraphIds1 | null;
   techRecord_manufactureYear?: number | null;
   techRecord_manufacturerDetails?: string | null;
   techRecord_maxLoadOnCoupling: number;

--- a/types/v3/tech-record/get/trl/complete/index.d.ts
+++ b/types/v3/tech-record/get/trl/complete/index.d.ts
@@ -18,7 +18,7 @@ export type FrameDescription =
   | "U section";
 export type LetterTypes = "trailer acceptance" | "trailer rejection";
 export type ParagraphIds = 3 | 4 | 5 | 6 | 7;
-export type ParagraphIds1 =
+export type Months =
   | "January"
   | "February"
   | "March"
@@ -207,7 +207,7 @@ export interface TechRecordGETTRLComplete {
   techRecord_letterOfAuth_paragraphId?: null | ParagraphIds;
   techRecord_letterOfAuth_letterIssuer?: string | null;
   techRecord_make: string;
-  techRecord_manufactureMonth?: ParagraphIds1 | null;
+  techRecord_manufactureMonth?: Months | null;
   techRecord_manufactureYear?: number | null;
   techRecord_manufacturerDetails?: string | null;
   techRecord_maxLoadOnCoupling: number;

--- a/types/v3/tech-record/get/trl/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/trl/skeleton/index.d.ts
@@ -18,7 +18,7 @@ export type FrameDescription =
   | "U section";
 export type LetterTypes = "trailer acceptance" | "trailer rejection";
 export type ParagraphIds = 3 | 4 | 5 | 6 | 7;
-export type ParagraphIds1 =
+export type Months =
   | "January"
   | "February"
   | "March"
@@ -210,7 +210,7 @@ export interface TechRecordGETTRLSkeleton {
   techRecord_letterOfAuth_paragraphId?: null | ParagraphIds;
   techRecord_letterOfAuth_letterIssuer?: string | null;
   techRecord_make?: string | null;
-  techRecord_manufactureMonth?: ParagraphIds1 | null;
+  techRecord_manufactureMonth?: Months | null;
   techRecord_manufactureYear?: number | null;
   techRecord_manufacturerDetails?: string | null;
   techRecord_maxLoadOnCoupling?: number | null;

--- a/types/v3/tech-record/get/trl/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/trl/skeleton/index.d.ts
@@ -18,6 +18,19 @@ export type FrameDescription =
   | "U section";
 export type LetterTypes = "trailer acceptance" | "trailer rejection";
 export type ParagraphIds = 3 | 4 | 5 | 6 | 7;
+export type ParagraphIds1 =
+  | "January"
+  | "February"
+  | "March"
+  | "April"
+  | "May"
+  | "June"
+  | "July"
+  | "August"
+  | "September"
+  | "October"
+  | "November"
+  | "December";
 export type MicrofilmDocumentType =
   | "PSV Miscellaneous"
   | "AAT - Trailer Annual Test"
@@ -197,6 +210,7 @@ export interface TechRecordGETTRLSkeleton {
   techRecord_letterOfAuth_paragraphId?: null | ParagraphIds;
   techRecord_letterOfAuth_letterIssuer?: string | null;
   techRecord_make?: string | null;
+  techRecord_manufactureMonth?: ParagraphIds1 | null;
   techRecord_manufactureYear?: number | null;
   techRecord_manufacturerDetails?: string | null;
   techRecord_maxLoadOnCoupling?: number | null;

--- a/types/v3/tech-record/get/trl/testable/index.d.ts
+++ b/types/v3/tech-record/get/trl/testable/index.d.ts
@@ -18,7 +18,7 @@ export type FrameDescription =
   | "U section";
 export type LetterTypes = "trailer acceptance" | "trailer rejection";
 export type ParagraphIds = 3 | 4 | 5 | 6 | 7;
-export type ParagraphIds1 =
+export type Months =
   | "January"
   | "February"
   | "March"
@@ -210,7 +210,7 @@ export interface TechRecordGETTRLTestable {
   techRecord_letterOfAuth_paragraphId?: null | ParagraphIds;
   techRecord_letterOfAuth_letterIssuer?: string | null;
   techRecord_make?: string | null;
-  techRecord_manufactureMonth?: ParagraphIds1 | null;
+  techRecord_manufactureMonth?: Months | null;
   techRecord_manufactureYear?: number | null;
   techRecord_manufacturerDetails?: string | null;
   techRecord_maxLoadOnCoupling?: number | null;

--- a/types/v3/tech-record/get/trl/testable/index.d.ts
+++ b/types/v3/tech-record/get/trl/testable/index.d.ts
@@ -18,6 +18,19 @@ export type FrameDescription =
   | "U section";
 export type LetterTypes = "trailer acceptance" | "trailer rejection";
 export type ParagraphIds = 3 | 4 | 5 | 6 | 7;
+export type ParagraphIds1 =
+  | "January"
+  | "February"
+  | "March"
+  | "April"
+  | "May"
+  | "June"
+  | "July"
+  | "August"
+  | "September"
+  | "October"
+  | "November"
+  | "December";
 export type MicrofilmDocumentType =
   | "PSV Miscellaneous"
   | "AAT - Trailer Annual Test"
@@ -197,6 +210,7 @@ export interface TechRecordGETTRLTestable {
   techRecord_letterOfAuth_paragraphId?: null | ParagraphIds;
   techRecord_letterOfAuth_letterIssuer?: string | null;
   techRecord_make?: string | null;
+  techRecord_manufactureMonth?: ParagraphIds1 | null;
   techRecord_manufactureYear?: number | null;
   techRecord_manufacturerDetails?: string | null;
   techRecord_maxLoadOnCoupling?: number | null;

--- a/types/v3/tech-record/put/trl/complete/index.d.ts
+++ b/types/v3/tech-record/put/trl/complete/index.d.ts
@@ -18,6 +18,19 @@ export type FrameDescription =
   | "U section";
 export type LetterTypes = "trailer acceptance" | "trailer rejection";
 export type ParagraphIds = 3 | 4 | 5 | 6 | 7;
+export type ParagraphIds1 =
+  | "January"
+  | "February"
+  | "March"
+  | "April"
+  | "May"
+  | "June"
+  | "July"
+  | "August"
+  | "September"
+  | "October"
+  | "November"
+  | "December";
 export type MicrofilmDocumentType =
   | "PSV Miscellaneous"
   | "AAT - Trailer Annual Test"
@@ -189,6 +202,7 @@ export interface TechRecordPUTTRLComplete {
   techRecord_letterOfAuth_paragraphId?: null | ParagraphIds;
   techRecord_letterOfAuth_letterIssuer?: string | null;
   techRecord_make: string;
+  techRecord_manufactureMonth?: ParagraphIds1 | null;
   techRecord_manufactureYear?: number | null;
   techRecord_manufacturerDetails?: string | null;
   techRecord_maxLoadOnCoupling: number;

--- a/types/v3/tech-record/put/trl/complete/index.d.ts
+++ b/types/v3/tech-record/put/trl/complete/index.d.ts
@@ -18,7 +18,7 @@ export type FrameDescription =
   | "U section";
 export type LetterTypes = "trailer acceptance" | "trailer rejection";
 export type ParagraphIds = 3 | 4 | 5 | 6 | 7;
-export type ParagraphIds1 =
+export type Months =
   | "January"
   | "February"
   | "March"
@@ -202,7 +202,7 @@ export interface TechRecordPUTTRLComplete {
   techRecord_letterOfAuth_paragraphId?: null | ParagraphIds;
   techRecord_letterOfAuth_letterIssuer?: string | null;
   techRecord_make: string;
-  techRecord_manufactureMonth?: ParagraphIds1 | null;
+  techRecord_manufactureMonth?: Months | null;
   techRecord_manufactureYear?: number | null;
   techRecord_manufacturerDetails?: string | null;
   techRecord_maxLoadOnCoupling: number;

--- a/types/v3/tech-record/put/trl/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/trl/skeleton/index.d.ts
@@ -18,6 +18,19 @@ export type FrameDescription =
   | "U section";
 export type LetterTypes = "trailer acceptance" | "trailer rejection";
 export type ParagraphIds = 3 | 4 | 5 | 6 | 7;
+export type ParagraphIds1 =
+  | "January"
+  | "February"
+  | "March"
+  | "April"
+  | "May"
+  | "June"
+  | "July"
+  | "August"
+  | "September"
+  | "October"
+  | "November"
+  | "December";
 export type MicrofilmDocumentType =
   | "PSV Miscellaneous"
   | "AAT - Trailer Annual Test"
@@ -192,6 +205,7 @@ export interface TechRecordPUTTRLSkeleton {
   techRecord_letterOfAuth_paragraphId?: null | ParagraphIds;
   techRecord_letterOfAuth_letterIssuer?: string | null;
   techRecord_make?: string | null;
+  techRecord_manufactureMonth?: ParagraphIds1 | null;
   techRecord_manufactureYear?: number | null;
   techRecord_manufacturerDetails?: string | null;
   techRecord_maxLoadOnCoupling?: number | null;

--- a/types/v3/tech-record/put/trl/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/trl/skeleton/index.d.ts
@@ -18,7 +18,7 @@ export type FrameDescription =
   | "U section";
 export type LetterTypes = "trailer acceptance" | "trailer rejection";
 export type ParagraphIds = 3 | 4 | 5 | 6 | 7;
-export type ParagraphIds1 =
+export type Months =
   | "January"
   | "February"
   | "March"
@@ -205,7 +205,7 @@ export interface TechRecordPUTTRLSkeleton {
   techRecord_letterOfAuth_paragraphId?: null | ParagraphIds;
   techRecord_letterOfAuth_letterIssuer?: string | null;
   techRecord_make?: string | null;
-  techRecord_manufactureMonth?: ParagraphIds1 | null;
+  techRecord_manufactureMonth?: Months | null;
   techRecord_manufactureYear?: number | null;
   techRecord_manufacturerDetails?: string | null;
   techRecord_maxLoadOnCoupling?: number | null;

--- a/types/v3/tech-record/put/trl/testable/index.d.ts
+++ b/types/v3/tech-record/put/trl/testable/index.d.ts
@@ -18,7 +18,7 @@ export type FrameDescription =
   | "U section";
 export type LetterTypes = "trailer acceptance" | "trailer rejection";
 export type ParagraphIds = 3 | 4 | 5 | 6 | 7;
-export type ParagraphIds1 =
+export type Months =
   | "January"
   | "February"
   | "March"
@@ -205,7 +205,7 @@ export interface TechRecordPUTTRLTestable {
   techRecord_letterOfAuth_paragraphId?: null | ParagraphIds;
   techRecord_letterOfAuth_letterIssuer?: string | null;
   techRecord_make?: string | null;
-  techRecord_manufactureMonth?: ParagraphIds1 | null;
+  techRecord_manufactureMonth?: Months | null;
   techRecord_manufactureYear?: number | null;
   techRecord_manufacturerDetails?: string | null;
   techRecord_maxLoadOnCoupling?: number | null;

--- a/types/v3/tech-record/put/trl/testable/index.d.ts
+++ b/types/v3/tech-record/put/trl/testable/index.d.ts
@@ -18,6 +18,19 @@ export type FrameDescription =
   | "U section";
 export type LetterTypes = "trailer acceptance" | "trailer rejection";
 export type ParagraphIds = 3 | 4 | 5 | 6 | 7;
+export type ParagraphIds1 =
+  | "January"
+  | "February"
+  | "March"
+  | "April"
+  | "May"
+  | "June"
+  | "July"
+  | "August"
+  | "September"
+  | "October"
+  | "November"
+  | "December";
 export type MicrofilmDocumentType =
   | "PSV Miscellaneous"
   | "AAT - Trailer Annual Test"
@@ -192,6 +205,7 @@ export interface TechRecordPUTTRLTestable {
   techRecord_letterOfAuth_paragraphId?: null | ParagraphIds;
   techRecord_letterOfAuth_letterIssuer?: string | null;
   techRecord_make?: string | null;
+  techRecord_manufactureMonth?: ParagraphIds1 | null;
   techRecord_manufactureYear?: number | null;
   techRecord_manufacturerDetails?: string | null;
   techRecord_maxLoadOnCoupling?: number | null;


### PR DESCRIPTION
## Ticket title

Add the month of manufacture to TRLS

[CB2-13894](https://dvsa.atlassian.net/browse/CB2-13894)

<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

- TRLs now have month of manufacture

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
