### PR TITLE
patch(cb2-12692): added optional testStationCountry - implement types into cert-gen

### DIFF
--- a/json-definitions/v1/test-station/index.json
+++ b/json-definitions/v1/test-station/index.json
@@ -49,6 +49,9 @@
     },
     "testStationCountry": {
       "type": "string"
+    },
+    "testStationStatus": {
+      "type": "string"
     }
   },
   "required": [
@@ -64,7 +67,8 @@
     "testStationLongitude",
     "testStationLatitude",
     "testStationType",
-    "testStationEmails"
+    "testStationEmails",
+    "testStationStatus"
   ],
   "additionalProperties": false
 }

--- a/json-definitions/v1/test-station/index.json
+++ b/json-definitions/v1/test-station/index.json
@@ -46,6 +46,9 @@
     },
     "searchProperty": {
       "type": "string"
+    },
+    "testStationCountry": {
+      "type": "string"
     }
   },
   "required": [

--- a/json-schemas/v1/test-station/index.json
+++ b/json-schemas/v1/test-station/index.json
@@ -46,6 +46,9 @@
 		},
 		"searchProperty": {
 			"type": "string"
+		},
+		"testStationCountry": {
+			"type": "string"
 		}
 	},
 	"required": [

--- a/json-schemas/v1/test-station/index.json
+++ b/json-schemas/v1/test-station/index.json
@@ -49,6 +49,9 @@
 		},
 		"testStationCountry": {
 			"type": "string"
+		},
+		"testStationStatus": {
+			"type": "string"
 		}
 	},
 	"required": [
@@ -64,7 +67,8 @@
 		"testStationLongitude",
 		"testStationLatitude",
 		"testStationType",
-		"testStationEmails"
+		"testStationEmails",
+		"testStationStatus"
 	],
 	"additionalProperties": false
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "7.6.1",
+  "version": "7.6.2",
   "description": "type definitions for cvs vta and vtm applications",
   "main": "index.js",
   "repository": {

--- a/types/v1/test-station/index.d.ts
+++ b/types/v1/test-station/index.d.ts
@@ -20,4 +20,5 @@ export interface TestStationSchema {
   testStationType: string;
   testStationEmails: string[];
   searchProperty?: string;
+  testStationCountry?: string;
 }

--- a/types/v1/test-station/index.d.ts
+++ b/types/v1/test-station/index.d.ts
@@ -21,4 +21,5 @@ export interface TestStationSchema {
   testStationEmails: string[];
   searchProperty?: string;
   testStationCountry?: string;
+  testStationStatus: string;
 }


### PR DESCRIPTION
## Update Test Stations Schema

Added optional testStationCountry into Test Stations Schema

[CB2-12692](https://dvsa.atlassian.net/browse/CB2-12692)

<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

- added optional testStationCountry into Test Stations Schema

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
