### PR TITLE
patch(cb2-15031): add month of manufacture to small trailers

### DIFF
--- a/json-definitions/v3/tech-record/get/small trl/complete/index.json
+++ b/json-definitions/v3/tech-record/get/small trl/complete/index.json
@@ -101,6 +101,16 @@
                 "null"
             ]
         },
+        "techRecord_manufactureMonth": {
+            "anyOf": [
+                {
+                    "$ref": "../../../enums/manufactureMonth.ignore.json"
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
         "techRecord_manufactureYear": {
             "type": [
                 "integer",

--- a/json-definitions/v3/tech-record/get/small trl/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/small trl/skeleton/index.json
@@ -99,6 +99,16 @@
                 "null"
             ]
         },
+        "techRecord_manufactureMonth": {
+            "anyOf": [
+                {
+                    "$ref": "../../../enums/manufactureMonth.ignore.json"
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
         "techRecord_manufactureYear": {
             "type": [
                 "integer",

--- a/json-definitions/v3/tech-record/put/small trl/complete/index.json
+++ b/json-definitions/v3/tech-record/put/small trl/complete/index.json
@@ -68,6 +68,16 @@
                 "o2"
             ]
         },
+        "techRecord_manufactureMonth": {
+            "anyOf": [
+                {
+                    "$ref": "../../../enums/manufactureMonth.ignore.json"
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
         "techRecord_manufactureYear": {
             "type": [
                 "integer",
@@ -101,12 +111,12 @@
         "techRecord_vehicleSubclass": {
             "anyOf": [
                 {
-                  "type": "null"
+                    "type": "null"
                 },
                 {
-                  "$ref": "../../../enums/vehicleSubclass.ignore.json"
+                    "$ref": "../../../enums/vehicleSubclass.ignore.json"
                 }
-              ]
+            ]
         },
         "techRecord_vehicleType": {
             "const": "trl"

--- a/json-definitions/v3/tech-record/put/small trl/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/small trl/skeleton/index.json
@@ -66,6 +66,16 @@
                 "o2"
             ]
         },
+        "techRecord_manufactureMonth": {
+            "anyOf": [
+                {
+                    "$ref": "../../../enums/manufactureMonth.ignore.json"
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
         "techRecord_manufactureYear": {
             "type": [
                 "integer",

--- a/json-schemas/v3/tech-record/get/small trl/complete/index.json
+++ b/json-schemas/v3/tech-record/get/small trl/complete/index.json
@@ -101,6 +101,31 @@
 				"null"
 			]
 		},
+		"techRecord_manufactureMonth": {
+			"anyOf": [
+				{
+					"title": "Months",
+					"type": "string",
+					"enum": [
+						"January",
+						"February",
+						"March",
+						"April",
+						"May",
+						"June",
+						"July",
+						"August",
+						"September",
+						"October",
+						"November",
+						"December"
+					]
+				},
+				{
+					"type": "null"
+				}
+			]
+		},
 		"techRecord_manufactureYear": {
 			"type": [
 				"integer",

--- a/json-schemas/v3/tech-record/get/small trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/small trl/skeleton/index.json
@@ -99,6 +99,31 @@
 				"null"
 			]
 		},
+		"techRecord_manufactureMonth": {
+			"anyOf": [
+				{
+					"title": "Months",
+					"type": "string",
+					"enum": [
+						"January",
+						"February",
+						"March",
+						"April",
+						"May",
+						"June",
+						"July",
+						"August",
+						"September",
+						"October",
+						"November",
+						"December"
+					]
+				},
+				{
+					"type": "null"
+				}
+			]
+		},
 		"techRecord_manufactureYear": {
 			"type": [
 				"integer",

--- a/json-schemas/v3/tech-record/put/small trl/complete/index.json
+++ b/json-schemas/v3/tech-record/put/small trl/complete/index.json
@@ -68,6 +68,31 @@
 				"o2"
 			]
 		},
+		"techRecord_manufactureMonth": {
+			"anyOf": [
+				{
+					"title": "Months",
+					"type": "string",
+					"enum": [
+						"January",
+						"February",
+						"March",
+						"April",
+						"May",
+						"June",
+						"July",
+						"August",
+						"September",
+						"October",
+						"November",
+						"December"
+					]
+				},
+				{
+					"type": "null"
+				}
+			]
+		},
 		"techRecord_manufactureYear": {
 			"type": [
 				"integer",

--- a/json-schemas/v3/tech-record/put/small trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/small trl/skeleton/index.json
@@ -66,6 +66,31 @@
 				"o2"
 			]
 		},
+		"techRecord_manufactureMonth": {
+			"anyOf": [
+				{
+					"title": "Months",
+					"type": "string",
+					"enum": [
+						"January",
+						"February",
+						"March",
+						"April",
+						"May",
+						"June",
+						"July",
+						"August",
+						"September",
+						"October",
+						"November",
+						"December"
+					]
+				},
+				{
+					"type": "null"
+				}
+			]
+		},
 		"techRecord_manufactureYear": {
 			"type": [
 				"integer",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "7.6.0",
+  "version": "7.6.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "7.6.0",
+      "version": "7.6.3",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "7.6.2",
+  "version": "7.6.3",
   "description": "type definitions for cvs vta and vtm applications",
   "main": "index.js",
   "repository": {

--- a/types/v3/tech-record/get/small trl/complete/index.d.ts
+++ b/types/v3/tech-record/get/small trl/complete/index.d.ts
@@ -5,6 +5,19 @@
  * and run json-schema-to-typescript to regenerate this file.
  */
 
+export type Months =
+  | "January"
+  | "February"
+  | "March"
+  | "April"
+  | "May"
+  | "June"
+  | "July"
+  | "August"
+  | "September"
+  | "October"
+  | "November"
+  | "December";
 export type StatusCode = "provisional" | "current" | "archived";
 export type VehicleSubclass = ("n" | "p" | "a" | "s" | "c" | "l" | "t" | "e" | "m" | "r" | "w")[];
 
@@ -24,6 +37,7 @@ export interface TechRecordGETSmallTRLComplete {
   techRecord_lastUpdatedAt?: string | null;
   techRecord_lastUpdatedById?: string | null;
   techRecord_lastUpdatedByName?: string | null;
+  techRecord_manufactureMonth?: Months | null;
   techRecord_manufactureYear?: number | null;
   techRecord_noOfAxles: number;
   techRecord_notes?: string | null;

--- a/types/v3/tech-record/get/small trl/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/small trl/skeleton/index.d.ts
@@ -5,6 +5,19 @@
  * and run json-schema-to-typescript to regenerate this file.
  */
 
+export type Months =
+  | "January"
+  | "February"
+  | "March"
+  | "April"
+  | "May"
+  | "June"
+  | "July"
+  | "August"
+  | "September"
+  | "October"
+  | "November"
+  | "December";
 export type StatusCode = "provisional" | "current" | "archived";
 export type VehicleSubclass = ("n" | "p" | "a" | "s" | "c" | "l" | "t" | "e" | "m" | "r" | "w")[];
 
@@ -24,6 +37,7 @@ export interface TechRecordGETSmallTRLSkeleton {
   techRecord_lastUpdatedAt?: string | null;
   techRecord_lastUpdatedById?: string | null;
   techRecord_lastUpdatedByName?: string | null;
+  techRecord_manufactureMonth?: Months | null;
   techRecord_manufactureYear?: number | null;
   techRecord_noOfAxles?: number | null;
   techRecord_notes?: string | null;

--- a/types/v3/tech-record/put/small trl/complete/index.d.ts
+++ b/types/v3/tech-record/put/small trl/complete/index.d.ts
@@ -5,6 +5,19 @@
  * and run json-schema-to-typescript to regenerate this file.
  */
 
+export type Months =
+  | "January"
+  | "February"
+  | "March"
+  | "April"
+  | "May"
+  | "June"
+  | "July"
+  | "August"
+  | "September"
+  | "October"
+  | "November"
+  | "December";
 export type StatusCode = "provisional" | "current" | "archived";
 export type VehicleSubclass = ("n" | "p" | "a" | "s" | "c" | "l" | "t" | "e" | "m" | "r" | "w")[];
 
@@ -18,6 +31,7 @@ export interface TechRecordPUTSmallTRLComplete {
   techRecord_applicantDetails_postTown?: string | null;
   techRecord_applicantDetails_telephoneNumber?: string | null;
   techRecord_euVehicleCategory: "o1" | "o2";
+  techRecord_manufactureMonth?: Months | null;
   techRecord_manufactureYear?: number | null;
   techRecord_noOfAxles: number;
   techRecord_notes?: string | null;

--- a/types/v3/tech-record/put/small trl/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/small trl/skeleton/index.d.ts
@@ -5,6 +5,19 @@
  * and run json-schema-to-typescript to regenerate this file.
  */
 
+export type Months =
+  | "January"
+  | "February"
+  | "March"
+  | "April"
+  | "May"
+  | "June"
+  | "July"
+  | "August"
+  | "September"
+  | "October"
+  | "November"
+  | "December";
 export type StatusCode = "provisional" | "current" | "archived";
 export type VehicleSubclass = ("n" | "p" | "a" | "s" | "c" | "l" | "t" | "e" | "m" | "r" | "w")[];
 
@@ -18,6 +31,7 @@ export interface TechRecordPUTSmallTRLSkeleton {
   techRecord_applicantDetails_postTown?: string | null;
   techRecord_applicantDetails_telephoneNumber?: string | null;
   techRecord_euVehicleCategory: "o1" | "o2";
+  techRecord_manufactureMonth?: Months | null;
   techRecord_manufactureYear?: number | null;
   techRecord_noOfAxles?: number | null;
   techRecord_notes?: string | null;


### PR DESCRIPTION
## Ticket title

Small trailers also need month of manufacture

[CB2-15031](https://dvsa.atlassian.net/browse/CB2-15031)

<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

-

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
