### PR TITLE
patch(cb2-14764b): remove nullables

### DIFF
--- a/json-definitions/v1/recalls/index.json
+++ b/json-definitions/v1/recalls/index.json
@@ -3,10 +3,7 @@
   "type": "object",
   "properties": {
     "hasRecall": {
-      "type": [
-        "boolean",
-        "null"
-      ]
+      "type": "boolean"
     },
     "manufacturer": {
       "type": [

--- a/json-definitions/v1/test-result/index.json
+++ b/json-definitions/v1/test-result/index.json
@@ -283,9 +283,6 @@
       "anyOf": [
         {
           "$ref": "../recalls/index.json"
-        },
-        {
-          "type": "null"
         }
       ]
     }

--- a/json-schemas/v1/recalls/index.json
+++ b/json-schemas/v1/recalls/index.json
@@ -3,10 +3,7 @@
 	"type": "object",
 	"properties": {
 		"hasRecall": {
-			"type": [
-				"boolean",
-				"null"
-			]
+			"type": "boolean"
 		},
 		"manufacturer": {
 			"type": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "7.7.0",
+  "version": "7.7.1",
   "description": "type definitions for cvs vta and vtm applications",
   "main": "index.js",
   "repository": {

--- a/types/v1/recalls/index.d.ts
+++ b/types/v1/recalls/index.d.ts
@@ -6,6 +6,6 @@
  */
 
 export interface RecallsSchema {
-  hasRecall: boolean | null;
+  hasRecall: boolean;
   manufacturer: string | null;
 }

--- a/types/v1/test-result/index.d.ts
+++ b/types/v1/test-result/index.d.ts
@@ -61,7 +61,7 @@ export interface TestResultSchema {
   testHistory?: TestResultSchema[];
   testVersion?: string;
   deletionFlag?: boolean;
-  recalls?: RecallsSchema | null;
+  recalls?: RecallsSchema;
 }
 export interface VehicleClassSchema {
   code: string;
@@ -205,7 +205,7 @@ export interface BodyTypeSchema {
   description?: string | null;
 }
 export interface RecallsSchema {
-  hasRecall: boolean | null;
+  hasRecall: boolean;
   manufacturer: string | null;
 }
 

--- a/types/v1/test/index.d.ts
+++ b/types/v1/test/index.d.ts
@@ -282,7 +282,7 @@ export interface TestResultSchema {
   testHistory?: TestResultSchema[];
   testVersion?: string;
   deletionFlag?: boolean;
-  recalls?: RecallsSchema | null;
+  recalls?: RecallsSchema;
 }
 export interface TestTypeSchema {
   testTypeName: string | null;
@@ -422,7 +422,7 @@ export interface BodyTypeSchema {
   description?: string | null;
 }
 export interface RecallsSchema {
-  hasRecall: boolean | null;
+  hasRecall: boolean;
   manufacturer: string | null;
 }
 

--- a/types/v1/vehicle/index.d.ts
+++ b/types/v1/vehicle/index.d.ts
@@ -274,7 +274,7 @@ export interface TestResultSchema {
   testHistory?: TestResultSchema[];
   testVersion?: string;
   deletionFlag?: boolean;
-  recalls?: RecallsSchema | null;
+  recalls?: RecallsSchema;
 }
 export interface TestTypeSchema {
   testTypeName: string | null;
@@ -414,7 +414,7 @@ export interface BodyTypeSchema {
   description?: string | null;
 }
 export interface RecallsSchema {
-  hasRecall: boolean | null;
+  hasRecall: boolean;
   manufacturer: string | null;
 }
 

--- a/types/v1/visit/index.d.ts
+++ b/types/v1/visit/index.d.ts
@@ -295,7 +295,7 @@ export interface TestResultSchema {
   testHistory?: TestResultSchema[];
   testVersion?: string;
   deletionFlag?: boolean;
-  recalls?: RecallsSchema | null;
+  recalls?: RecallsSchema;
 }
 export interface TestTypeSchema {
   testTypeName: string | null;
@@ -435,7 +435,7 @@ export interface BodyTypeSchema {
   description?: string | null;
 }
 export interface RecallsSchema {
-  hasRecall: boolean | null;
+  hasRecall: boolean;
   manufacturer: string | null;
 }
 


### PR DESCRIPTION
## https://github.com/dvsa/cvs-type-definitions/pull/186

Quick patch, confirmed by PO and FE - hasRecalls is `boolean` only and no longer nullable, `recalls` on test result schema is optional, but not nullable.

[CB2-14764](https://dvsa.atlassian.net/browse/CB2-14764)

## Changelog

- hasRecalls no longer nullable
- recalls no longer nullable

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
