### PR TITLE
patch(cb2-14340): re-add small trl eu cats to trl

### DIFF
--- a/json-definitions/v3/tech-record/enums/euVehicleCategoryTrl.enum.json
+++ b/json-definitions/v3/tech-record/enums/euVehicleCategoryTrl.enum.json
@@ -2,10 +2,14 @@
   "title": "EU vehicle category",
   "type": "string",
   "tsEnumNames": [
+    "O1",
+    "O2",
     "O3",
     "O4"
   ],
   "enum": [
+    "o1",
+    "o2",
     "o3",
     "o4"
   ]

--- a/json-schemas/v3/tech-record/enums/euVehicleCategoryTrl.enum.json
+++ b/json-schemas/v3/tech-record/enums/euVehicleCategoryTrl.enum.json
@@ -2,10 +2,14 @@
 	"title": "EU vehicle category",
 	"type": "string",
 	"tsEnumNames": [
+		"O1",
+		"O2",
 		"O3",
 		"O4"
 	],
 	"enum": [
+		"o1",
+		"o2",
 		"o3",
 		"o4"
 	]

--- a/json-schemas/v3/tech-record/get/trl/complete/index.json
+++ b/json-schemas/v3/tech-record/get/trl/complete/index.json
@@ -758,10 +758,14 @@
 			"title": "EU vehicle category",
 			"type": "string",
 			"tsEnumNames": [
+				"O1",
+				"O2",
 				"O3",
 				"O4"
 			],
 			"enum": [
+				"o1",
+				"o2",
 				"o3",
 				"o4"
 			]

--- a/json-schemas/v3/tech-record/get/trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/trl/skeleton/index.json
@@ -785,10 +785,14 @@
 					"title": "EU vehicle category",
 					"type": "string",
 					"tsEnumNames": [
+						"O1",
+						"O2",
 						"O3",
 						"O4"
 					],
 					"enum": [
+						"o1",
+						"o2",
 						"o3",
 						"o4"
 					]

--- a/json-schemas/v3/tech-record/get/trl/testable/index.json
+++ b/json-schemas/v3/tech-record/get/trl/testable/index.json
@@ -781,10 +781,14 @@
 					"title": "EU vehicle category",
 					"type": "string",
 					"tsEnumNames": [
+						"O1",
+						"O2",
 						"O3",
 						"O4"
 					],
 					"enum": [
+						"o1",
+						"o2",
 						"o3",
 						"o4"
 					]

--- a/json-schemas/v3/tech-record/put/trl/complete/index.json
+++ b/json-schemas/v3/tech-record/put/trl/complete/index.json
@@ -738,10 +738,14 @@
 			"title": "EU vehicle category",
 			"type": "string",
 			"tsEnumNames": [
+				"O1",
+				"O2",
 				"O3",
 				"O4"
 			],
 			"enum": [
+				"o1",
+				"o2",
 				"o3",
 				"o4"
 			]

--- a/json-schemas/v3/tech-record/put/trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/trl/skeleton/index.json
@@ -759,10 +759,14 @@
 					"title": "EU vehicle category",
 					"type": "string",
 					"tsEnumNames": [
+						"O1",
+						"O2",
 						"O3",
 						"O4"
 					],
 					"enum": [
+						"o1",
+						"o2",
 						"o3",
 						"o4"
 					]

--- a/json-schemas/v3/tech-record/put/trl/testable/index.json
+++ b/json-schemas/v3/tech-record/put/trl/testable/index.json
@@ -761,10 +761,14 @@
 					"title": "EU vehicle category",
 					"type": "string",
 					"tsEnumNames": [
+						"O1",
+						"O2",
 						"O3",
 						"O4"
 					],
 					"enum": [
+						"o1",
+						"o2",
 						"o3",
 						"o4"
 					]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "7.9.0",
+  "version": "7.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "7.9.0",
+      "version": "7.9.1",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "7.9.0",
+  "version": "7.9.1",
   "description": "type definitions for cvs vta and vtm applications",
   "main": "index.js",
   "repository": {

--- a/types/v3/tech-record/enums/euVehicleCategoryTrl.enum.ts
+++ b/types/v3/tech-record/enums/euVehicleCategoryTrl.enum.ts
@@ -6,6 +6,8 @@
  */
 
 export enum EUVehicleCategory {
+  O1 = "o1",
+  O2 = "o2",
   O3 = "o3",
   O4 = "o4"
 }

--- a/types/v3/tech-record/get/trl/complete/index.d.ts
+++ b/types/v3/tech-record/get/trl/complete/index.d.ts
@@ -362,6 +362,8 @@ export enum ApprovalType {
   IVA_DVSA_NI = "IVA - DVSA/NI"
 }
 export enum EUVehicleCategory {
+  O1 = "o1",
+  O2 = "o2",
   O3 = "o3",
   O4 = "o4"
 }

--- a/types/v3/tech-record/get/trl/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/trl/skeleton/index.d.ts
@@ -359,6 +359,8 @@ export enum ApprovalType {
   IVA_DVSA_NI = "IVA - DVSA/NI"
 }
 export enum EUVehicleCategory {
+  O1 = "o1",
+  O2 = "o2",
   O3 = "o3",
   O4 = "o4"
 }

--- a/types/v3/tech-record/get/trl/testable/index.d.ts
+++ b/types/v3/tech-record/get/trl/testable/index.d.ts
@@ -359,6 +359,8 @@ export enum ApprovalType {
   IVA_DVSA_NI = "IVA - DVSA/NI"
 }
 export enum EUVehicleCategory {
+  O1 = "o1",
+  O2 = "o2",
   O3 = "o3",
   O4 = "o4"
 }

--- a/types/v3/tech-record/put/trl/complete/index.d.ts
+++ b/types/v3/tech-record/put/trl/complete/index.d.ts
@@ -351,6 +351,8 @@ export enum ApprovalType {
   IVA_DVSA_NI = "IVA - DVSA/NI"
 }
 export enum EUVehicleCategory {
+  O1 = "o1",
+  O2 = "o2",
   O3 = "o3",
   O4 = "o4"
 }

--- a/types/v3/tech-record/put/trl/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/trl/skeleton/index.d.ts
@@ -348,6 +348,8 @@ export enum ADRCertificateTypes {
   REPLACEMENT = "REPLACEMENT"
 }
 export enum EUVehicleCategory {
+  O1 = "o1",
+  O2 = "o2",
   O3 = "o3",
   O4 = "o4"
 }

--- a/types/v3/tech-record/put/trl/testable/index.d.ts
+++ b/types/v3/tech-record/put/trl/testable/index.d.ts
@@ -348,6 +348,8 @@ export enum ADRCertificateTypes {
   REPLACEMENT = "REPLACEMENT"
 }
 export enum EUVehicleCategory {
+  O1 = "o1",
+  O2 = "o2",
   O3 = "o3",
   O4 = "o4"
 }


### PR DESCRIPTION
## re-add small trl eu cats to trl

[CB2-14340](https://dvsa.atlassian.net/browse/CB2-14340)

<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

- add back the o1 and o2 categories to the trl enum, due to type difficulties with small trl and trl on the FE
- follow up from the previous [PR](https://github.com/dvsa/cvs-type-definitions/pull/189)

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
