### PR TITLE
minor(cb2-16579): add field validation to activity schema

### DIFF
--- a/json-definitions/v1/activity/index.json
+++ b/json-definitions/v1/activity/index.json
@@ -12,10 +12,14 @@
       "$ref": "../enums/activityType.enum.json"
     },
     "testStationName": {
-      "type": "string"
+      "type": "string",
+      "minLength": 1,
+      "pattern": ".*\\S.*"
     },
     "testStationPNumber": {
-      "type": "string"
+      "type": "string",
+      "minLength": 1,
+      "pattern": ".*\\S.*"
     },
     "testStationEmail": {
       "type": "string",
@@ -26,11 +30,14 @@
     },
     "testerName": {
       "type": "string",
+      "pattern": ".*\\S.*",
       "minLength": 1,
       "maxLength": 60
     },
     "testerStaffId": {
-      "type": "string"
+      "type": "string",
+      "minLength": 1,
+      "pattern": ".*\\S.*"
     },
     "testerEmail": {
       "type": "string",
@@ -51,10 +58,21 @@
       }
     },
     "startTime": {
-      "type": "string"
+      "type": "string",
+      "minLength": 1,
+      "pattern": ".*\\S.*"
     },
     "endTime": {
-      "type": ["null", "string"]
+      "oneOf": [
+        {
+          "type": "string",
+          "minLength": 1,
+          "pattern": ".*\\S.*"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "waitReason": {
       "type": "array",

--- a/json-schemas/v1/activity/index.json
+++ b/json-schemas/v1/activity/index.json
@@ -23,10 +23,14 @@
 			]
 		},
 		"testStationName": {
-			"type": "string"
+			"type": "string",
+			"minLength": 1,
+			"pattern": ".*\\S.*"
 		},
 		"testStationPNumber": {
-			"type": "string"
+			"type": "string",
+			"minLength": 1,
+			"pattern": ".*\\S.*"
 		},
 		"testStationEmail": {
 			"type": "string",
@@ -52,11 +56,14 @@
 		},
 		"testerName": {
 			"type": "string",
+			"pattern": ".*\\S.*",
 			"minLength": 1,
 			"maxLength": 60
 		},
 		"testerStaffId": {
-			"type": "string"
+			"type": "string",
+			"minLength": 1,
+			"pattern": ".*\\S.*"
 		},
 		"testerEmail": {
 			"type": "string",
@@ -77,12 +84,20 @@
 			}
 		},
 		"startTime": {
-			"type": "string"
+			"type": "string",
+			"minLength": 1,
+			"pattern": ".*\\S.*"
 		},
 		"endTime": {
-			"type": [
-				"null",
-				"string"
+			"oneOf": [
+				{
+					"type": "string",
+					"minLength": 1,
+					"pattern": ".*\\S.*"
+				},
+				{
+					"type": "null"
+				}
 			]
 		},
 		"waitReason": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "7.12.0",
+  "version": "7.13.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "7.12.0",
+      "version": "7.13.0",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "7.12.0",
+  "version": "7.13.0",
   "description": "type definitions for cvs vta and vtm applications",
   "main": "index.js",
   "repository": {

--- a/tests/activities/activity.test.ts
+++ b/tests/activities/activity.test.ts
@@ -1,0 +1,78 @@
+import { isValidObject } from "../../schema-validator";
+import * as CompleteActivity from '../resources/data/activity/complete.json';
+import * as MinRequiredActivity from '../resources/data/activity/minimum-required.json';
+import * as MissingRequiredActivity from '../resources/data/activity/missing-required.json';
+import * as InvalidFieldFormatActivity from '../resources/data/activity/invalid-field-formats.json';
+import * as ConditionalTestEmailActivity from '../resources/data/activity/conditional-tester-email.json';
+
+const schemaName = "v1/activity/index.json";
+
+describe("validate activity schema", () => {
+    describe("valid", () => {
+        test('should validate an object which with complete data', () => {
+            const data = CompleteActivity;
+            const res = isValidObject(schemaName, data);
+            expect(res).toEqual(true);
+        });
+
+        test('should validate an object which with partial data with all required feels', () => {
+            const data = MinRequiredActivity;
+            const res = isValidObject(schemaName, data);
+            expect(res).toEqual(true);
+        });
+    });
+
+    describe("invalid", () => {
+        test('should return error message when missing mandatory field', () => {
+            const data = MissingRequiredActivity;
+            const res = isValidObject(schemaName, data, true);
+            expect(res).toEqual([
+                {
+                    "instancePath": "",
+                    "keyword": "required",
+                    "message": "must have required property 'activityType'",
+                    "params": {
+                        "missingProperty": "activityType"
+                    },
+                    "schemaPath": "#/required"
+                }
+            ]);
+        });
+
+        test('should return error when the email is a bad format', () => {
+            const data = InvalidFieldFormatActivity;
+            const res = isValidObject(schemaName, data);
+            expect(res).toEqual(false);
+        });
+    });
+
+    describe("validation", () => {
+        test("should mandate testerEmail when activityType is visit", () => {
+            const data = {
+                ...ConditionalTestEmailActivity,
+                activityType: "visit",
+                testerEmail: "hello@gmail.com"
+            };
+            const res = isValidObject(schemaName, data);
+            expect(res).toEqual(true);
+        });
+
+        test("should fail when start time is empty", () => {
+            const data = {
+                ...ConditionalTestEmailActivity,
+                startTime: '',
+            };
+            const res = isValidObject(schemaName, data);
+            expect(res).toEqual(false);
+        });
+
+        test("should fail when start time is just whitespace", () => {
+            const data = {
+                ...ConditionalTestEmailActivity,
+                startTime: ' ',
+            };
+            const res = isValidObject(schemaName, data);
+            expect(res).toEqual(false);
+        });
+    });
+});

--- a/tests/resources/data/activity/complete.json
+++ b/tests/resources/data/activity/complete.json
@@ -1,0 +1,20 @@
+{
+  "parentId": "parent123",
+  "id": "act456",
+  "activityType": "visit",
+  "testStationName": "Central Testing Facility",
+  "testStationPNumber": "P12345",
+  "testStationEmail": "central.testing@example.com",
+  "testStationType": "atf",
+  "testerName": "John Smith",
+  "testerStaffId": "JS789",
+  "testerEmail": "john.smith@example.com",
+  "startTime": "2025-03-12T10:00:00Z",
+  "endTime": "2025-03-12T11:30:00Z",
+  "waitReason": [
+    "Other",
+    "Admin"
+  ],
+  "notes": "Regular inspection visit completed successfully.",
+  "activityDay": "2025-03-12"
+}

--- a/tests/resources/data/activity/conditional-tester-email.json
+++ b/tests/resources/data/activity/conditional-tester-email.json
@@ -1,0 +1,19 @@
+{
+  "parentId": "parent123",
+  "id": "act456",
+  "activityType": "wait",
+  "testStationName": "Central Testing Facility",
+  "testStationPNumber": "P12345",
+  "testStationEmail": "central.testing@example.com",
+  "testStationType": "atf",
+  "testerName": "John Smith",
+  "testerStaffId": "JS789",
+  "startTime": "2025-03-12T10:00:00Z",
+  "endTime": "2025-03-12T11:30:00Z",
+  "waitReason": [
+    "Other",
+    "Admin"
+  ],
+  "notes": "Regular inspection visit completed successfully.",
+  "activityDay": "2025-03-12"
+}

--- a/tests/resources/data/activity/invalid-field-formats.json
+++ b/tests/resources/data/activity/invalid-field-formats.json
@@ -1,0 +1,20 @@
+{
+  "parentId": "parent123",
+  "id": "act456",
+  "activityType": "wait",
+  "testStationName": "Central Testing Facility",
+  "testStationPNumber": "P12345",
+  "testStationEmail": "central.testing@example.com",
+  "testStationType": "atf",
+  "testerName": "John Smith",
+  "testerStaffId": "JS789",
+  "testerEmail": "bad email",
+  "startTime": "2025-03-12T10:00:00Z",
+  "endTime": "2025-03-12T11:30:00Z",
+  "waitReason": [
+    "Other",
+    "Admin"
+  ],
+  "notes": "Regular inspection visit completed successfully.",
+  "activityDay": "2025-03-12"
+}

--- a/tests/resources/data/activity/minimum-required.json
+++ b/tests/resources/data/activity/minimum-required.json
@@ -1,0 +1,10 @@
+{
+  "activityType": "visit",
+  "testStationName": "Central Testing Facility",
+  "testStationPNumber": "P12345",
+  "testStationEmail": "central.testing@example.com",
+  "testStationType": "atf",
+  "testerName": "John Smith",
+  "testerStaffId": "JS789",
+  "startTime": "2025-03-12T10:00:00Z"
+}

--- a/tests/resources/data/activity/missing-required.json
+++ b/tests/resources/data/activity/missing-required.json
@@ -1,0 +1,9 @@
+{
+  "testStationName": "Central Testing Facility",
+  "testStationPNumber": "P12345",
+  "testStationEmail": "central.testing@example.com",
+  "testStationType": "atf",
+  "testerName": "John Smith",
+  "testerStaffId": "JS789",
+  "startTime": "2025-03-12T10:00:00Z"
+}

--- a/types/v1/activity/index.d.ts
+++ b/types/v1/activity/index.d.ts
@@ -17,7 +17,7 @@ export interface ActivitySchema {
   testerStaffId: string;
   testerEmail?: string;
   startTime: string;
-  endTime?: null | string;
+  endTime?: string | null;
   waitReason?: WaitReason[];
   notes?: string;
   activityDay?: string;


### PR DESCRIPTION
## Ticket title
- See bloew

<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

- Add `minLength` and `pattern` check to activity fields which are of type string
- Add basic unit tests for validating an object against the activity schema

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->
