### PR TITLE
patch(cb2-16579): allow null and empty string for activity notes

### DIFF
--- a/json-definitions/v1/activity/index.json
+++ b/json-definitions/v1/activity/index.json
@@ -81,7 +81,15 @@
       }
     },
     "notes": {
-      "type": "string"
+      "oneOf": [
+        {
+          "type": "string",
+          "pattern": ".*\\S.*"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "activityDay": {
       "type": "string"

--- a/json-schemas/v1/activity/index.json
+++ b/json-schemas/v1/activity/index.json
@@ -122,7 +122,15 @@
 			}
 		},
 		"notes": {
-			"type": "string"
+			"oneOf": [
+				{
+					"type": "string",
+					"pattern": ".*\\S.*"
+				},
+				{
+					"type": "null"
+				}
+			]
 		},
 		"activityDay": {
 			"type": "string"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "7.13.0",
+  "version": "7.13.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "7.13.0",
+      "version": "7.13.1",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "7.13.0",
+  "version": "7.14.0",
   "description": "type definitions for cvs vta and vtm applications",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "7.14.0",
+  "version": "7.13.1",
   "description": "type definitions for cvs vta and vtm applications",
   "main": "index.js",
   "repository": {

--- a/types/v1/activity/index.d.ts
+++ b/types/v1/activity/index.d.ts
@@ -19,7 +19,7 @@ export interface ActivitySchema {
   startTime: string;
   endTime?: string | null;
   waitReason?: WaitReason[];
-  notes?: string;
+  notes?: string | null;
   activityDay?: string;
 }
 


### PR DESCRIPTION
## Migrate Activities to new Test Facility Service

Update Activity Schema so it matches notes validation in old activities service.

NB: Further change can be made to ensure min length of 1 for strings once confirmed / validated that empty strings are not currently being sent.

[CB2-16579](https://dvsa.atlassian.net/browse/CB2-16579)

<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

- updated notes validation in activity type definition

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->


[CB2-16579]: https://dvsa.atlassian.net/browse/CB2-16579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ