### PR TITLE
patch(cb2-16579): revert email check

### DIFF
--- a/json-definitions/v1/activity/index.json
+++ b/json-definitions/v1/activity/index.json
@@ -22,8 +22,7 @@
       "pattern": ".*\\S.*"
     },
     "testStationEmail": {
-      "type": "string",
-      "format": "email"
+      "type": "string"
     },
     "testStationType": {
       "$ref": "../enums/testStationType.enum.json"

--- a/json-schemas/v1/activity/index.json
+++ b/json-schemas/v1/activity/index.json
@@ -33,8 +33,7 @@
 			"pattern": ".*\\S.*"
 		},
 		"testStationEmail": {
-			"type": "string",
-			"format": "email"
+			"type": "string"
 		},
 		"testStationType": {
 			"title": "Test Station Types",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "7.13.1",
+  "version": "7.13.2",
   "description": "type definitions for cvs vta and vtm applications",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
## Migrate Activities to new Test Facility Service

Email check introduced as part of this ticket has caused issued with VTA pack, when testStationsEmails array is empty and is selected for a visit. Will need further investigation on impact, reverting to just checking string value for now.

[CB2-16579](https://dvsa.atlassian.net/browse/CB2-16579)

<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

- removed email check on string for testStationEmail

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->


[CB2-16579]: https://dvsa.atlassian.net/browse/CB2-16579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ