### PR TITLE
major(cb2-16923): no of axles mandatory for complete motorcycyle

### DIFF
--- a/json-definitions/v3/tech-record/get/motorcycle/complete/index.json
+++ b/json-definitions/v3/tech-record/get/motorcycle/complete/index.json
@@ -16,7 +16,8 @@
     "createdTimestamp",
     "partialVin",
     "vin",
-    "techRecord_vehicleConfiguration"
+    "techRecord_vehicleConfiguration",
+    "techRecord_noOfAxles"
   ],
   "properties": {
     "secondaryVrms": {
@@ -154,10 +155,7 @@
       ]
     },
     "techRecord_noOfAxles": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": "integer"
     },
     "techRecord_notes": {
       "type": [
@@ -192,7 +190,7 @@
     },
     "techRecord_vehicleConfiguration": {
       "$ref": "../../../enums/vehicleConfigurationLightVehicle.enum.json"
-    },  
+    },
     "techRecord_vehicleType": {
       "const": "motorcycle"
     },

--- a/json-definitions/v3/tech-record/put/motorcycle/complete/index.json
+++ b/json-definitions/v3/tech-record/put/motorcycle/complete/index.json
@@ -9,7 +9,8 @@
     "techRecord_vehicleType",
     "techRecord_statusCode",
     "techRecord_vehicleConfiguration",
-    "vin"
+    "vin",
+    "techRecord_noOfAxles"
   ],
   "properties": {
     "secondaryVrms": {

--- a/json-definitions/v3/tech-record/put/motorcycle/complete/index.json
+++ b/json-definitions/v3/tech-record/put/motorcycle/complete/index.json
@@ -118,10 +118,7 @@
       ]
     },
     "techRecord_noOfAxles": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": "integer"
     },
     "techRecord_notes": {
       "type": [

--- a/json-schemas/v3/tech-record/get/motorcycle/complete/index.json
+++ b/json-schemas/v3/tech-record/get/motorcycle/complete/index.json
@@ -16,7 +16,8 @@
 		"createdTimestamp",
 		"partialVin",
 		"vin",
-		"techRecord_vehicleConfiguration"
+		"techRecord_vehicleConfiguration",
+		"techRecord_noOfAxles"
 	],
 	"properties": {
 		"secondaryVrms": {
@@ -195,10 +196,7 @@
 			]
 		},
 		"techRecord_noOfAxles": {
-			"type": [
-				"null",
-				"integer"
-			]
+			"type": "integer"
 		},
 		"techRecord_notes": {
 			"type": [

--- a/json-schemas/v3/tech-record/put/motorcycle/complete/index.json
+++ b/json-schemas/v3/tech-record/put/motorcycle/complete/index.json
@@ -9,7 +9,8 @@
 		"techRecord_vehicleType",
 		"techRecord_statusCode",
 		"techRecord_vehicleConfiguration",
-		"vin"
+		"vin",
+		"techRecord_noOfAxles"
 	],
 	"properties": {
 		"secondaryVrms": {

--- a/json-schemas/v3/tech-record/put/motorcycle/complete/index.json
+++ b/json-schemas/v3/tech-record/put/motorcycle/complete/index.json
@@ -159,10 +159,7 @@
 			]
 		},
 		"techRecord_noOfAxles": {
-			"type": [
-				"null",
-				"integer"
-			]
+			"type": "integer"
 		},
 		"techRecord_notes": {
 			"type": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "7.13.2",
+  "version": "7.14.0",
   "description": "type definitions for cvs vta and vtm applications",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "7.14.0",
+  "version": "8.0.0",
   "description": "type definitions for cvs vta and vtm applications",
   "main": "index.js",
   "repository": {

--- a/types/v3/tech-record/get/motorcycle/complete/index.d.ts
+++ b/types/v3/tech-record/get/motorcycle/complete/index.d.ts
@@ -30,7 +30,7 @@ export interface TechRecordGETMotorcycleComplete {
   techRecord_lastUpdatedByName?: string | null;
   techRecord_manufactureYear?: number | null;
   techRecord_recordCompleteness?: null | string;
-  techRecord_noOfAxles?: null | number;
+  techRecord_noOfAxles: number;
   techRecord_notes?: null | string;
   techRecord_reasonForCreation: string;
   techRecord_regnDate?: string | null;

--- a/types/v3/tech-record/put/motorcycle/complete/index.d.ts
+++ b/types/v3/tech-record/put/motorcycle/complete/index.d.ts
@@ -23,7 +23,7 @@ export interface TechRecordPUTMotorcycleComplete {
   techRecord_euVehicleCategory?: null | EUVehicleCategory;
   techRecord_manufactureYear?: number | null;
   techRecord_recordCompleteness?: null | string;
-  techRecord_noOfAxles?: null | number;
+  techRecord_noOfAxles?: number;
   techRecord_notes?: null | string;
   techRecord_reasonForCreation: string;
   techRecord_regnDate?: string | null;

--- a/types/v3/tech-record/put/motorcycle/complete/index.d.ts
+++ b/types/v3/tech-record/put/motorcycle/complete/index.d.ts
@@ -23,7 +23,7 @@ export interface TechRecordPUTMotorcycleComplete {
   techRecord_euVehicleCategory?: null | EUVehicleCategory;
   techRecord_manufactureYear?: number | null;
   techRecord_recordCompleteness?: null | string;
-  techRecord_noOfAxles?: number;
+  techRecord_noOfAxles: number;
   techRecord_notes?: null | string;
   techRecord_reasonForCreation: string;
   techRecord_regnDate?: string | null;


### PR DESCRIPTION
## Number of Axles not filled in for a motorcycle should make the tech record Skeleton

Updated the type def to ensure noOfAxles is present and not nullable for GET and PUT Motorcycle in order for a status of `Complete`

[CB2-16923](https://dvsa.atlassian.net/browse/CB2-16923)

<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

- updated techRecord_noOfAxles def so it is mandatory for complete
- updated techRecord_noOfAxles so it has to be an integer value

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->


[CB2-16923]: https://dvsa.atlassian.net/browse/CB2-16923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ