### PR TITLE
major(CB2-19701): DynamicsTestStation optional properties nullable

### DIFF
--- a/json-definitions/v1/dynamics-test-station/index.json
+++ b/json-definitions/v1/dynamics-test-station/index.json
@@ -48,7 +48,10 @@
       "type": "string"
     },
     "testStationCountry": {
-      "type": "string"
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "testStationStatus": {
       "type": "string"

--- a/json-definitions/v1/dynamics-test-station/index.json
+++ b/json-definitions/v1/dynamics-test-station/index.json
@@ -15,10 +15,16 @@
       "type": "string"
     },
     "testStationAccessNotes": {
-      "type": "string"
+			"type": [
+				"string",
+				"null"
+			]
     },
     "testStationGeneralNotes": {
-      "type": "string"
+			"type": [
+				"string",
+				"null"
+			]
     },
     "testStationTown": {
       "type": "string"
@@ -30,10 +36,16 @@
       "type": "string"
     },
     "testStationLongitude": {
-      "type": "number"
+			"type": [
+				"number",
+				"null"
+			]
     },
     "testStationLatitude": {
-      "type": "number"
+			"type": [
+				"number",
+				"null"
+			]
     },
     "testStationType": {
       "type": "string"

--- a/json-schemas/v1/dynamics-test-station/index.json
+++ b/json-schemas/v1/dynamics-test-station/index.json
@@ -15,10 +15,16 @@
 			"type": "string"
 		},
 		"testStationAccessNotes": {
-			"type": "string"
+			"type": [
+				"string",
+				"null"
+			]
 		},
 		"testStationGeneralNotes": {
-			"type": "string"
+			"type": [
+				"string",
+				"null"
+			]
 		},
 		"testStationTown": {
 			"type": "string"
@@ -30,10 +36,16 @@
 			"type": "string"
 		},
 		"testStationLongitude": {
-			"type": "number"
+			"type": [
+				"number",
+				"null"
+			]
 		},
 		"testStationLatitude": {
-			"type": "number"
+			"type": [
+				"number",
+				"null"
+			]
 		},
 		"testStationType": {
 			"type": "string"

--- a/json-schemas/v1/dynamics-test-station/index.json
+++ b/json-schemas/v1/dynamics-test-station/index.json
@@ -48,7 +48,10 @@
 			"type": "string"
 		},
 		"testStationCountry": {
-			"type": "string"
+			"type": [
+				"string",
+				"null"
+			]
 		},
 		"testStationStatus": {
 			"type": "string"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "10.0.0",
+  "version": "11.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "10.0.0",
+      "version": "11.0.0",
       "license": "ISC",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^12.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "10.0.0",
+  "version": "11.0.0",
   "description": "Type definitions for CVS VTA and VTM applications",
   "main": "index.js",
   "repository": {

--- a/types/v1/dynamics-test-station/index.d.ts
+++ b/types/v1/dynamics-test-station/index.d.ts
@@ -10,13 +10,13 @@ export interface DynamicsTestStationSchema {
   testStationPNumber: string;
   testStationName: string;
   testStationContactNumber: string;
-  testStationAccessNotes?: string;
-  testStationGeneralNotes?: string;
+  testStationAccessNotes?: string | null;
+  testStationGeneralNotes?: string | null;
   testStationTown: string;
   testStationAddress: string;
   testStationPostcode: string;
-  testStationLongitude?: number;
-  testStationLatitude?: number;
+  testStationLongitude?: number | null;
+  testStationLatitude?: number | null;
   testStationType: string;
   testStationEmails: string[];
   searchProperty?: string;

--- a/types/v1/dynamics-test-station/index.d.ts
+++ b/types/v1/dynamics-test-station/index.d.ts
@@ -20,6 +20,6 @@ export interface DynamicsTestStationSchema {
   testStationType: string;
   testStationEmails: string[];
   searchProperty?: string;
-  testStationCountry?: string;
+  testStationCountry?: string | null;
   testStationStatus: string;
 }


### PR DESCRIPTION
## Ticket title

[CB2-19701](https://dvsa.atlassian.net/browse/CB2-19701)

Updates DynamicsTestStation definition and corresponding generated type to reflect optional fields also being nullable. These include:
1. testStationGeneralNotes
2. testStationAccessNotes
3. testStationLongitude
4. testStationLatitude
5. testStationCountry

This is to reflect the validation performed in the [validation](https://github.com/dvsa/cvs-test-facility-service/tree/main/src/domain/validationClasses/TestStation.ts).

Re-generates type from these schemas.

## Changelog

- nullable general notes, access notes, long, lat, country in DynamicsTestStation definition.

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->


[CB2-19701]: https://dvsa.atlassian.net/browse/CB2-19701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ