### PR TITLE
minor(cb2-20542): added media object to defects

### DIFF
--- a/json-definitions/v1/defect-details/index.json
+++ b/json-definitions/v1/defect-details/index.json
@@ -52,6 +52,12 @@
     },
     "metadata": {
       "$ref": "../defect-metadata/index.ignore.json#"
+    },
+    "media": {
+      "type":  "array",
+      "items": {
+        "$ref": "../media/index.json#"
+      }
     }
   },
   "additionalProperties": false,

--- a/json-schemas/v1/defect-details/index.json
+++ b/json-schemas/v1/defect-details/index.json
@@ -243,6 +243,71 @@
 			"required": [
 				"category"
 			]
+		},
+		"media": {
+			"type": "array",
+			"items": {
+				"title": "Media Schema",
+				"type": "object",
+				"additionalProperties": false,
+				"anyOf": [
+					{
+						"title": "Image Schema",
+						"type": "object",
+						"properties": {
+							"type": {
+								"const": "image"
+							},
+							"path": {
+								"type": "string"
+							}
+						},
+						"additionalProperties": false,
+						"required": [
+							"type",
+							"path"
+						]
+					},
+					{
+						"title": "Video Schema",
+						"type": "object",
+						"properties": {
+							"type": {
+								"const": "video"
+							},
+							"path": {
+								"type": "string"
+							}
+						},
+						"additionalProperties": false,
+						"required": [
+							"type",
+							"path"
+						]
+					},
+					{
+						"title": "Fail Reason Schema",
+						"type": "object",
+						"properties": {
+							"type": {
+								"const": "failReason"
+							},
+							"path": {
+								"type": "string"
+							},
+							"reason": {
+								"type": "string"
+							}
+						},
+						"additionalProperties": false,
+						"required": [
+							"type",
+							"path",
+							"reason"
+						]
+					}
+				]
+			}
 		}
 	},
 	"additionalProperties": false,

--- a/json-schemas/v1/test-result-test-type/index.json
+++ b/json-schemas/v1/test-result-test-type/index.json
@@ -480,6 +480,71 @@
 						"required": [
 							"category"
 						]
+					},
+					"media": {
+						"type": "array",
+						"items": {
+							"title": "Media Schema",
+							"type": "object",
+							"additionalProperties": false,
+							"anyOf": [
+								{
+									"title": "Image Schema",
+									"type": "object",
+									"properties": {
+										"type": {
+											"const": "image"
+										},
+										"path": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"type",
+										"path"
+									]
+								},
+								{
+									"title": "Video Schema",
+									"type": "object",
+									"properties": {
+										"type": {
+											"const": "video"
+										},
+										"path": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"type",
+										"path"
+									]
+								},
+								{
+									"title": "Fail Reason Schema",
+									"type": "object",
+									"properties": {
+										"type": {
+											"const": "failReason"
+										},
+										"path": {
+											"type": "string"
+										},
+										"reason": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"type",
+										"path",
+										"reason"
+									]
+								}
+							]
+						}
 					}
 				},
 				"additionalProperties": false,

--- a/json-schemas/v1/test-result/index.json
+++ b/json-schemas/v1/test-result/index.json
@@ -811,6 +811,12 @@
 									"required": [
 										"category"
 									]
+								},
+								"media": {
+									"type": "array",
+									"items": {
+										"$ref": "#/properties/media/items"
+									}
 								}
 							},
 							"additionalProperties": false,

--- a/json-schemas/v1/test/index.json
+++ b/json-schemas/v1/test/index.json
@@ -1677,6 +1677,12 @@
 												"required": [
 													"category"
 												]
+											},
+											"media": {
+												"type": "array",
+												"items": {
+													"$ref": "#/properties/vehicles/items/properties/testResultsHistory/items/properties/media/items"
+												}
 											}
 										},
 										"additionalProperties": false,

--- a/json-schemas/v1/vehicle/index.json
+++ b/json-schemas/v1/vehicle/index.json
@@ -1649,6 +1649,12 @@
 									"required": [
 										"category"
 									]
+								},
+								"media": {
+									"type": "array",
+									"items": {
+										"$ref": "#/properties/testResultsHistory/items/properties/media/items"
+									}
 								}
 							},
 							"additionalProperties": false,

--- a/json-schemas/v1/visit/index.json
+++ b/json-schemas/v1/visit/index.json
@@ -1710,6 +1710,12 @@
 															"required": [
 																"category"
 															]
+														},
+														"media": {
+															"type": "array",
+															"items": {
+																"$ref": "#/properties/tests/items/properties/vehicles/items/properties/testResultsHistory/items/properties/media/items"
+															}
 														}
 													},
 													"additionalProperties": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "12.1.1",
+  "version": "12.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "12.1.1",
+      "version": "12.2.0",
       "license": "ISC",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^12.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "12.2.1",
+  "version": "12.2.0",
   "description": "Type definitions for CVS VTA and VTM applications",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "12.1.1",
+  "version": "12.2.1",
   "description": "Type definitions for CVS VTA and VTM applications",
   "main": "index.js",
   "repository": {

--- a/types/v1/defect-details/index.d.ts
+++ b/types/v1/defect-details/index.d.ts
@@ -5,6 +5,8 @@
  * and run json-schema-to-typescript to regenerate this file.
  */
 
+export type MediaSchema = ImageSchema | VideoSchema | FailReasonSchema;
+
 export interface DefectDetailsSchema {
   imNumber: number;
   imDescription: string;
@@ -23,6 +25,7 @@ export interface DefectDetailsSchema {
   prs: boolean | null;
   prohibitionIssued: boolean | null;
   metadata: DefectMetadataSchema;
+  media?: MediaSchema[];
 }
 export interface DefectLocationSchema {
   vertical?: string | null;
@@ -50,4 +53,17 @@ export interface DefectLocationMetadataSchema {
   rowNumber?: number[] | null;
   seatNumber?: number[] | null;
   axleNumber?: number[] | null;
+}
+export interface ImageSchema {
+  type: "image";
+  path: string;
+}
+export interface VideoSchema {
+  type: "video";
+  path: string;
+}
+export interface FailReasonSchema {
+  type: "failReason";
+  path: string;
+  reason: string;
 }

--- a/types/v1/test-result-test-type/index.d.ts
+++ b/types/v1/test-result-test-type/index.d.ts
@@ -5,6 +5,7 @@
  * and run json-schema-to-typescript to regenerate this file.
  */
 
+export type MediaSchema = ImageSchema | VideoSchema | FailReasonSchema;
 export type InspectionType = "basic" | "normal";
 
 export interface TestResultTestTypeSchema {
@@ -70,6 +71,7 @@ export interface DefectDetailsSchema {
   prs: boolean | null;
   prohibitionIssued: boolean | null;
   metadata: DefectMetadataSchema;
+  media?: MediaSchema[];
 }
 export interface DefectLocationSchema {
   vertical?: string | null;
@@ -97,6 +99,19 @@ export interface DefectLocationMetadataSchema {
   rowNumber?: number[] | null;
   seatNumber?: number[] | null;
   axleNumber?: number[] | null;
+}
+export interface ImageSchema {
+  type: "image";
+  path: string;
+}
+export interface VideoSchema {
+  type: "video";
+  path: string;
+}
+export interface FailReasonSchema {
+  type: "failReason";
+  path: string;
+  reason: string;
 }
 export interface SpecialistCustomDefectsSchema {
   referenceNumber: string;

--- a/types/v1/test-result/index.d.ts
+++ b/types/v1/test-result/index.d.ts
@@ -145,6 +145,7 @@ export interface DefectDetailsSchema {
   prs: boolean | null;
   prohibitionIssued: boolean | null;
   metadata: DefectMetadataSchema;
+  media?: MediaSchema[];
 }
 export interface DefectLocationSchema {
   vertical?: string | null;

--- a/types/v1/test/index.d.ts
+++ b/types/v1/test/index.d.ts
@@ -362,6 +362,7 @@ export interface DefectDetailsSchema {
   prs: boolean | null;
   prohibitionIssued: boolean | null;
   metadata: DefectMetadataSchema;
+  media?: MediaSchema[];
 }
 export interface DefectLocationSchema {
   vertical?: string | null;

--- a/types/v1/vehicle/index.d.ts
+++ b/types/v1/vehicle/index.d.ts
@@ -354,6 +354,7 @@ export interface DefectDetailsSchema {
   prs: boolean | null;
   prohibitionIssued: boolean | null;
   metadata: DefectMetadataSchema;
+  media?: MediaSchema[];
 }
 export interface DefectLocationSchema {
   vertical?: string | null;

--- a/types/v1/visit/index.d.ts
+++ b/types/v1/visit/index.d.ts
@@ -375,6 +375,7 @@ export interface DefectDetailsSchema {
   prs: boolean | null;
   prohibitionIssued: boolean | null;
   metadata: DefectMetadataSchema;
+  media?: MediaSchema[];
 }
 export interface DefectLocationSchema {
   vertical?: string | null;


### PR DESCRIPTION
## Ticket title

Created new optional media object on defects to be used for image capture

[CB2-20542](https://dvsa.atlassian.net/browse/CB2-20542)

<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

- new optional media object on defects to be used for image capture

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->


[CB2-20542]: https://dvsa.atlassian.net/browse/CB2-20542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ