### PR TITLE
minor(cb2-21189): corrected validation for 1 axle trailer complete schema

### DIFF
--- a/json-definitions/v3/tech-record/get/trl/complete/index.json
+++ b/json-definitions/v3/tech-record/get/trl/complete/index.json
@@ -15,8 +15,6 @@
     "techRecord_couplingType",
     "techRecord_dimensions_length",
     "techRecord_dimensions_width",
-    "techRecord_frontAxleToRearAxle",
-    "techRecord_rearAxleToRearTrl",
     "techRecord_couplingCenterToRearAxleMin",
     "techRecord_couplingCenterToRearAxleMax",
     "techRecord_couplingCenterToRearTrlMax",
@@ -1434,6 +1432,23 @@
         "then": {
           "required": [
             "techRecord_adrDetails_weight"
+          ]
+        }
+      },
+      {
+        "if": {
+          "properties": {
+            "techRecord_axles": {
+              "type": "array",
+              "minItems": 2
+            }
+          },
+          "required": ["techRecord_axles"]
+        },
+        "then": {
+          "required": [
+            "techRecord_frontAxleToRearAxle",
+            "techRecord_rearAxleToRearTrl"
           ]
         }
       }

--- a/json-definitions/v3/tech-record/put/trl/complete/index.json
+++ b/json-definitions/v3/tech-record/put/trl/complete/index.json
@@ -13,8 +13,6 @@
     "techRecord_couplingType",
     "techRecord_dimensions_length",
     "techRecord_dimensions_width",
-    "techRecord_frontAxleToRearAxle",
-    "techRecord_rearAxleToRearTrl",
     "techRecord_couplingCenterToRearAxleMin",
     "techRecord_couplingCenterToRearAxleMax",
     "techRecord_couplingCenterToRearTrlMax",
@@ -1382,6 +1380,23 @@
         "then": {
           "required": [
             "techRecord_adrDetails_weight"
+          ]
+        }
+      },
+      {
+        "if": {
+          "properties": {
+            "techRecord_axles": {
+              "type": "array",
+              "minItems": 2
+            }
+          },
+          "required": ["techRecord_axles"]
+        },
+        "then": {
+          "required": [
+            "techRecord_frontAxleToRearAxle",
+            "techRecord_rearAxleToRearTrl"
           ]
         }
       }

--- a/json-schemas/v3/tech-record/get/trl/complete/index.json
+++ b/json-schemas/v3/tech-record/get/trl/complete/index.json
@@ -15,8 +15,6 @@
 		"techRecord_couplingType",
 		"techRecord_dimensions_length",
 		"techRecord_dimensions_width",
-		"techRecord_frontAxleToRearAxle",
-		"techRecord_rearAxleToRearTrl",
 		"techRecord_couplingCenterToRearAxleMin",
 		"techRecord_couplingCenterToRearAxleMax",
 		"techRecord_couplingCenterToRearTrlMax",
@@ -1720,6 +1718,25 @@
 				"then": {
 					"required": [
 						"techRecord_adrDetails_weight"
+					]
+				}
+			},
+			{
+				"if": {
+					"properties": {
+						"techRecord_axles": {
+							"type": "array",
+							"minItems": 2
+						}
+					},
+					"required": [
+						"techRecord_axles"
+					]
+				},
+				"then": {
+					"required": [
+						"techRecord_frontAxleToRearAxle",
+						"techRecord_rearAxleToRearTrl"
 					]
 				}
 			}

--- a/json-schemas/v3/tech-record/put/trl/complete/index.json
+++ b/json-schemas/v3/tech-record/put/trl/complete/index.json
@@ -13,8 +13,6 @@
 		"techRecord_couplingType",
 		"techRecord_dimensions_length",
 		"techRecord_dimensions_width",
-		"techRecord_frontAxleToRearAxle",
-		"techRecord_rearAxleToRearTrl",
 		"techRecord_couplingCenterToRearAxleMin",
 		"techRecord_couplingCenterToRearAxleMax",
 		"techRecord_couplingCenterToRearTrlMax",
@@ -1668,6 +1666,25 @@
 				"then": {
 					"required": [
 						"techRecord_adrDetails_weight"
+					]
+				}
+			},
+			{
+				"if": {
+					"properties": {
+						"techRecord_axles": {
+							"type": "array",
+							"minItems": 2
+						}
+					},
+					"required": [
+						"techRecord_axles"
+					]
+				},
+				"then": {
+					"required": [
+						"techRecord_frontAxleToRearAxle",
+						"techRecord_rearAxleToRearTrl"
 					]
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "12.6.0",
+  "version": "12.7.0",
   "description": "Type definitions for CVS VTA and VTM applications",
   "main": "index.js",
   "repository": {

--- a/types/v3/tech-record/get/trl/complete/index.d.ts
+++ b/types/v3/tech-record/get/trl/complete/index.d.ts
@@ -199,7 +199,7 @@ export interface TechRecordGETTRLComplete {
   techRecord_euVehicleCategory: EUVehicleCategory;
   techRecord_firstUseDate: string;
   techRecord_frameDescription?: FrameDescription | null;
-  techRecord_frontAxleToRearAxle: number;
+  techRecord_frontAxleToRearAxle?: number;
   techRecord_functionCode?: string | null;
   techRecord_grossDesignWeight?: number | null;
   techRecord_grossEecWeight?: number | null;
@@ -245,7 +245,7 @@ export interface TechRecordGETTRLComplete {
   techRecord_lastUpdatedAt?: string | null;
   techRecord_lastUpdatedByName?: string | null;
   techRecord_lastUpdatedById?: string | null;
-  techRecord_rearAxleToRearTrl: number;
+  techRecord_rearAxleToRearTrl?: number;
   techRecord_reasonForCreation: string;
   techRecord_recordCompleteness?: "complete";
   techRecord_regnDate?: string | null;

--- a/types/v3/tech-record/put/trl/complete/index.d.ts
+++ b/types/v3/tech-record/put/trl/complete/index.d.ts
@@ -194,7 +194,7 @@ export interface TechRecordPUTTRLComplete {
   techRecord_euVehicleCategory: EUVehicleCategory;
   techRecord_firstUseDate: string;
   techRecord_frameDescription?: FrameDescription | null;
-  techRecord_frontAxleToRearAxle: number;
+  techRecord_frontAxleToRearAxle?: number;
   techRecord_functionCode?: string | null;
   techRecord_grossDesignWeight?: number | null;
   techRecord_grossEecWeight?: number | null;
@@ -236,7 +236,7 @@ export interface TechRecordPUTTRLComplete {
   techRecord_manufacturerDetails_postTown?: string | null;
   techRecord_manufacturerDetails_manufacturerNotes?: string | null;
   techRecord_manufacturerDetails_telephoneNumber?: string | null;
-  techRecord_rearAxleToRearTrl: number;
+  techRecord_rearAxleToRearTrl?: number;
   techRecord_reasonForCreation: string;
   techRecord_regnDate?: string | null;
   techRecord_roadFriendly: boolean;


### PR DESCRIPTION
## Ticket title

Capability to create a complete technical record for a 1 axle trailer

[CB2-21189](https://dvsa.atlassian.net/browse/CB2-21189)

## Changelog

- updated get/trl/complete
- updated put/trl/complete

Existing schemas had a requirement of `techRecord_frontAxleToRearAxle` and `techRecord_rearAxleToRearTrl` being populated to match the complete schema, this would never be the case for a 1 axle trailer. Validation added so the above only applies if there are 2 or more axles in the `techRecord_axles` array.

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->


[CB2-21189]: https://dvsa.atlassian.net/browse/CB2-21189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ