### PR TITLE
minor(cb2-21110): added adr application number

### DIFF
--- a/json-definitions/v3/tech-record/get/hgv/complete/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/complete/index.json
@@ -317,6 +317,13 @@
         }
       ]
     },
+    "techRecord_adrDetails_applicationNumber": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 30
+    },
     "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
       "type": [
         "string",

--- a/json-definitions/v3/tech-record/get/hgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/skeleton/index.json
@@ -287,6 +287,13 @@
         }
       ]
     },
+    "techRecord_adrDetails_applicationNumber": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 30
+    },
     "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
       "type": [
         "string",

--- a/json-definitions/v3/tech-record/get/hgv/testable/index.json
+++ b/json-definitions/v3/tech-record/get/hgv/testable/index.json
@@ -291,6 +291,13 @@
         }
       ]
     },
+    "techRecord_adrDetails_applicationNumber": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 30
+    },
     "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
       "type": [
         "string",

--- a/json-definitions/v3/tech-record/get/lgv/complete/index.json
+++ b/json-definitions/v3/tech-record/get/lgv/complete/index.json
@@ -322,6 +322,13 @@
         }
       ]
     },
+    "techRecord_adrDetails_applicationNumber": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 30
+    },
     "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
       "type": [
         "string",

--- a/json-definitions/v3/tech-record/get/lgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/lgv/skeleton/index.json
@@ -319,6 +319,13 @@
         }
       ]
     },
+    "techRecord_adrDetails_applicationNumber": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 30
+    },
     "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
       "type": [
         "string",

--- a/json-definitions/v3/tech-record/get/trl/complete/index.json
+++ b/json-definitions/v3/tech-record/get/trl/complete/index.json
@@ -297,6 +297,13 @@
         }
       ]
     },
+    "techRecord_adrDetails_applicationNumber": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 30
+    },
     "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
       "type": [
         "string",

--- a/json-definitions/v3/tech-record/get/trl/skeleton/index.json
+++ b/json-definitions/v3/tech-record/get/trl/skeleton/index.json
@@ -279,6 +279,13 @@
         }
       ]
     },
+    "techRecord_adrDetails_applicationNumber": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 30
+    },
     "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
       "type": [
         "string",

--- a/json-definitions/v3/tech-record/get/trl/testable/index.json
+++ b/json-definitions/v3/tech-record/get/trl/testable/index.json
@@ -281,6 +281,13 @@
         }
       ]
     },
+    "techRecord_adrDetails_applicationNumber": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 30
+    },
     "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
       "type": [
         "string",

--- a/json-definitions/v3/tech-record/put/hgv/complete/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/complete/index.json
@@ -305,6 +305,13 @@
         }
       ]
     },
+    "techRecord_adrDetails_applicationNumber": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 30
+    },
     "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
       "type": [
         "string",

--- a/json-definitions/v3/tech-record/put/hgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/skeleton/index.json
@@ -273,6 +273,13 @@
         }
       ]
     },
+    "techRecord_adrDetails_applicationNumber": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 30
+    },
     "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
       "type": [
         "string",

--- a/json-definitions/v3/tech-record/put/hgv/testable/index.json
+++ b/json-definitions/v3/tech-record/put/hgv/testable/index.json
@@ -275,6 +275,13 @@
         }
       ]
     },
+    "techRecord_adrDetails_applicationNumber": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 30
+    },
     "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
       "type": [
         "string",

--- a/json-definitions/v3/tech-record/put/lgv/complete/index.json
+++ b/json-definitions/v3/tech-record/put/lgv/complete/index.json
@@ -324,6 +324,13 @@
         }
       ]
     },
+    "techRecord_adrDetails_applicationNumber": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 30
+    },
     "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
       "type": [
         "string",

--- a/json-definitions/v3/tech-record/put/lgv/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/lgv/skeleton/index.json
@@ -321,6 +321,13 @@
         }
       ]
     },
+    "techRecord_adrDetails_applicationNumber": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 30
+    },
     "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
       "type": [
         "string",

--- a/json-definitions/v3/tech-record/put/trl/complete/index.json
+++ b/json-definitions/v3/tech-record/put/trl/complete/index.json
@@ -286,6 +286,13 @@
         }
       ]
     },
+    "techRecord_adrDetails_applicationNumber": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 30
+    },
     "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
       "type": [
         "string",

--- a/json-definitions/v3/tech-record/put/trl/skeleton/index.json
+++ b/json-definitions/v3/tech-record/put/trl/skeleton/index.json
@@ -303,6 +303,13 @@
         }
       ]
     },
+    "techRecord_adrDetails_applicationNumber": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 30
+    },
     "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
       "type": [
         "string",

--- a/json-definitions/v3/tech-record/put/trl/testable/index.json
+++ b/json-definitions/v3/tech-record/put/trl/testable/index.json
@@ -305,6 +305,13 @@
         }
       ]
     },
+    "techRecord_adrDetails_applicationNumber": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 30
+    },
     "techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
       "type": [
         "string",

--- a/json-schemas/v3/tech-record/get/hgv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/complete/index.json
@@ -348,6 +348,13 @@
 				}
 			]
 		},
+		"techRecord_adrDetails_applicationNumber": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 30
+		},
 		"techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
 			"type": [
 				"string",

--- a/json-schemas/v3/tech-record/get/hgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/skeleton/index.json
@@ -318,6 +318,13 @@
 				}
 			]
 		},
+		"techRecord_adrDetails_applicationNumber": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 30
+		},
 		"techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
 			"type": [
 				"string",

--- a/json-schemas/v3/tech-record/get/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/get/hgv/testable/index.json
@@ -322,6 +322,13 @@
 				}
 			]
 		},
+		"techRecord_adrDetails_applicationNumber": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 30
+		},
 		"techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
 			"type": [
 				"string",

--- a/json-schemas/v3/tech-record/get/lgv/complete/index.json
+++ b/json-schemas/v3/tech-record/get/lgv/complete/index.json
@@ -353,6 +353,13 @@
 				}
 			]
 		},
+		"techRecord_adrDetails_applicationNumber": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 30
+		},
 		"techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
 			"type": [
 				"string",

--- a/json-schemas/v3/tech-record/get/lgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/lgv/skeleton/index.json
@@ -350,6 +350,13 @@
 				}
 			]
 		},
+		"techRecord_adrDetails_applicationNumber": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 30
+		},
 		"techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
 			"type": [
 				"string",

--- a/json-schemas/v3/tech-record/get/trl/complete/index.json
+++ b/json-schemas/v3/tech-record/get/trl/complete/index.json
@@ -328,6 +328,13 @@
 				}
 			]
 		},
+		"techRecord_adrDetails_applicationNumber": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 30
+		},
 		"techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
 			"type": [
 				"string",

--- a/json-schemas/v3/tech-record/get/trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/get/trl/skeleton/index.json
@@ -310,6 +310,13 @@
 				}
 			]
 		},
+		"techRecord_adrDetails_applicationNumber": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 30
+		},
 		"techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
 			"type": [
 				"string",

--- a/json-schemas/v3/tech-record/get/trl/testable/index.json
+++ b/json-schemas/v3/tech-record/get/trl/testable/index.json
@@ -312,6 +312,13 @@
 				}
 			]
 		},
+		"techRecord_adrDetails_applicationNumber": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 30
+		},
 		"techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
 			"type": [
 				"string",

--- a/json-schemas/v3/tech-record/put/hgv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/complete/index.json
@@ -336,6 +336,13 @@
 				}
 			]
 		},
+		"techRecord_adrDetails_applicationNumber": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 30
+		},
 		"techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
 			"type": [
 				"string",

--- a/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/skeleton/index.json
@@ -304,6 +304,13 @@
 				}
 			]
 		},
+		"techRecord_adrDetails_applicationNumber": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 30
+		},
 		"techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
 			"type": [
 				"string",

--- a/json-schemas/v3/tech-record/put/hgv/testable/index.json
+++ b/json-schemas/v3/tech-record/put/hgv/testable/index.json
@@ -306,6 +306,13 @@
 				}
 			]
 		},
+		"techRecord_adrDetails_applicationNumber": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 30
+		},
 		"techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
 			"type": [
 				"string",

--- a/json-schemas/v3/tech-record/put/lgv/complete/index.json
+++ b/json-schemas/v3/tech-record/put/lgv/complete/index.json
@@ -355,6 +355,13 @@
 				}
 			]
 		},
+		"techRecord_adrDetails_applicationNumber": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 30
+		},
 		"techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
 			"type": [
 				"string",

--- a/json-schemas/v3/tech-record/put/lgv/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/lgv/skeleton/index.json
@@ -352,6 +352,13 @@
 				}
 			]
 		},
+		"techRecord_adrDetails_applicationNumber": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 30
+		},
 		"techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
 			"type": [
 				"string",

--- a/json-schemas/v3/tech-record/put/trl/complete/index.json
+++ b/json-schemas/v3/tech-record/put/trl/complete/index.json
@@ -317,6 +317,13 @@
 				}
 			]
 		},
+		"techRecord_adrDetails_applicationNumber": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 30
+		},
 		"techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
 			"type": [
 				"string",

--- a/json-schemas/v3/tech-record/put/trl/skeleton/index.json
+++ b/json-schemas/v3/tech-record/put/trl/skeleton/index.json
@@ -369,6 +369,13 @@
 				}
 			]
 		},
+		"techRecord_adrDetails_applicationNumber": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 30
+		},
 		"techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
 			"type": [
 				"string",

--- a/json-schemas/v3/tech-record/put/trl/testable/index.json
+++ b/json-schemas/v3/tech-record/put/trl/testable/index.json
@@ -371,6 +371,13 @@
 				}
 			]
 		},
+		"techRecord_adrDetails_applicationNumber": {
+			"type": [
+				"string",
+				"null"
+			],
+			"maxLength": 30
+		},
 		"techRecord_adrDetails_tank_tankDetails_tankManufacturer": {
 			"type": [
 				"string",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "12.7.1",
+  "version": "12.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/cvs-type-definitions",
-      "version": "12.7.1",
+      "version": "12.8.0",
       "license": "ISC",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^12.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "12.7.1",
+  "version": "12.8.0",
   "description": "Type definitions for CVS VTA and VTM applications",
   "main": "index.js",
   "repository": {

--- a/types/v3/tech-record/get/hgv/complete/index.d.ts
+++ b/types/v3/tech-record/get/hgv/complete/index.d.ts
@@ -118,6 +118,7 @@ export interface TechRecordGETHGVComplete {
   techRecord_adrDetails_adrCertificateNotes?: string | null;
   techRecord_adrDetails_approved?: boolean | null;
   techRecord_adrDetails_receivedDate?: string | null;
+  techRecord_adrDetails_applicationNumber?: string | null;
   techRecord_adrDetails_tank_tankDetails_tankManufacturer?: string | null;
   techRecord_adrDetails_tank_tankDetails_yearOfManufacture?: number | null;
   techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo?: string | null;

--- a/types/v3/tech-record/get/hgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/hgv/skeleton/index.d.ts
@@ -118,6 +118,7 @@ export interface TechRecordGETHGVSkeleton {
   techRecord_adrDetails_adrCertificateNotes?: string | null;
   techRecord_adrDetails_approved?: boolean | null;
   techRecord_adrDetails_receivedDate?: string | null;
+  techRecord_adrDetails_applicationNumber?: string | null;
   techRecord_adrDetails_tank_tankDetails_tankManufacturer?: string | null;
   techRecord_adrDetails_tank_tankDetails_yearOfManufacture?: number | null;
   techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo?: string | null;

--- a/types/v3/tech-record/get/hgv/testable/index.d.ts
+++ b/types/v3/tech-record/get/hgv/testable/index.d.ts
@@ -118,6 +118,7 @@ export interface TechRecordGETHGVTestable {
   techRecord_adrDetails_adrCertificateNotes?: string | null;
   techRecord_adrDetails_approved?: boolean | null;
   techRecord_adrDetails_receivedDate?: string | null;
+  techRecord_adrDetails_applicationNumber?: string | null;
   techRecord_adrDetails_tank_tankDetails_tankManufacturer?: string | null;
   techRecord_adrDetails_tank_tankDetails_yearOfManufacture?: number | null;
   techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo?: string | null;

--- a/types/v3/tech-record/get/lgv/complete/index.d.ts
+++ b/types/v3/tech-record/get/lgv/complete/index.d.ts
@@ -48,6 +48,7 @@ export interface TechRecordGETLGVComplete {
   techRecord_adrDetails_adrCertificateNotes?: string | null;
   techRecord_adrDetails_approved?: boolean | null;
   techRecord_adrDetails_receivedDate?: string | null;
+  techRecord_adrDetails_applicationNumber?: string | null;
   techRecord_adrDetails_tank_tankDetails_tankManufacturer?: string | null;
   techRecord_adrDetails_tank_tankDetails_yearOfManufacture?: number | null;
   techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo?: string | null;

--- a/types/v3/tech-record/get/lgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/lgv/skeleton/index.d.ts
@@ -48,6 +48,7 @@ export interface TechRecordGETLGVSkeleton {
   techRecord_adrDetails_adrCertificateNotes?: string | null;
   techRecord_adrDetails_approved?: boolean | null;
   techRecord_adrDetails_receivedDate?: string | null;
+  techRecord_adrDetails_applicationNumber?: string | null;
   techRecord_adrDetails_tank_tankDetails_tankManufacturer?: string | null;
   techRecord_adrDetails_tank_tankDetails_yearOfManufacture?: number | null;
   techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo?: string | null;

--- a/types/v3/tech-record/get/trl/complete/index.d.ts
+++ b/types/v3/tech-record/get/trl/complete/index.d.ts
@@ -39,6 +39,7 @@ export interface TechRecordGETTRLComplete {
   techRecord_adrDetails_adrCertificateNotes?: string | null;
   techRecord_adrDetails_approved?: boolean | null;
   techRecord_adrDetails_receivedDate?: string | null;
+  techRecord_adrDetails_applicationNumber?: string | null;
   techRecord_adrDetails_tank_tankDetails_tankManufacturer?: string | null;
   techRecord_adrDetails_tank_tankDetails_yearOfManufacture?: number | null;
   techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo?: string | null;

--- a/types/v3/tech-record/get/trl/skeleton/index.d.ts
+++ b/types/v3/tech-record/get/trl/skeleton/index.d.ts
@@ -147,6 +147,7 @@ export interface TechRecordGETTRLSkeleton {
   techRecord_adrDetails_adrCertificateNotes?: string | null;
   techRecord_adrDetails_approved?: boolean | null;
   techRecord_adrDetails_receivedDate?: string | null;
+  techRecord_adrDetails_applicationNumber?: string | null;
   techRecord_adrDetails_tank_tankDetails_tankManufacturer?: string | null;
   techRecord_adrDetails_tank_tankDetails_yearOfManufacture?: number | null;
   techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo?: string | null;

--- a/types/v3/tech-record/get/trl/testable/index.d.ts
+++ b/types/v3/tech-record/get/trl/testable/index.d.ts
@@ -147,6 +147,7 @@ export interface TechRecordGETTRLTestable {
   techRecord_adrDetails_adrCertificateNotes?: string | null;
   techRecord_adrDetails_approved?: boolean | null;
   techRecord_adrDetails_receivedDate?: string | null;
+  techRecord_adrDetails_applicationNumber?: string | null;
   techRecord_adrDetails_tank_tankDetails_tankManufacturer?: string | null;
   techRecord_adrDetails_tank_tankDetails_yearOfManufacture?: number | null;
   techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo?: string | null;

--- a/types/v3/tech-record/put/hgv/complete/index.d.ts
+++ b/types/v3/tech-record/put/hgv/complete/index.d.ts
@@ -116,6 +116,7 @@ export interface TechRecordPUTHGVComplete {
   techRecord_adrDetails_adrCertificateNotes?: string | null;
   techRecord_adrDetails_approved?: boolean | null;
   techRecord_adrDetails_receivedDate?: string | null;
+  techRecord_adrDetails_applicationNumber?: string | null;
   techRecord_adrDetails_tank_tankDetails_tankManufacturer?: string | null;
   techRecord_adrDetails_tank_tankDetails_yearOfManufacture?: number | null;
   techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo?: string | null;

--- a/types/v3/tech-record/put/hgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/hgv/skeleton/index.d.ts
@@ -116,6 +116,7 @@ export interface TechRecordPUTHGVSkeleton {
   techRecord_adrDetails_adrCertificateNotes?: string | null;
   techRecord_adrDetails_approved?: boolean | null;
   techRecord_adrDetails_receivedDate?: string | null;
+  techRecord_adrDetails_applicationNumber?: string | null;
   techRecord_adrDetails_tank_tankDetails_tankManufacturer?: string | null;
   techRecord_adrDetails_tank_tankDetails_yearOfManufacture?: number | null;
   techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo?: string | null;

--- a/types/v3/tech-record/put/hgv/testable/index.d.ts
+++ b/types/v3/tech-record/put/hgv/testable/index.d.ts
@@ -116,6 +116,7 @@ export interface TechRecordPUTHGVTestable {
   techRecord_adrDetails_adrCertificateNotes?: string | null;
   techRecord_adrDetails_approved?: boolean | null;
   techRecord_adrDetails_receivedDate?: string | null;
+  techRecord_adrDetails_applicationNumber?: string | null;
   techRecord_adrDetails_tank_tankDetails_tankManufacturer?: string | null;
   techRecord_adrDetails_tank_tankDetails_yearOfManufacture?: number | null;
   techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo?: string | null;

--- a/types/v3/tech-record/put/lgv/complete/index.d.ts
+++ b/types/v3/tech-record/put/lgv/complete/index.d.ts
@@ -50,6 +50,7 @@ export interface TechRecordPUTLGVComplete {
   techRecord_adrDetails_adrCertificateNotes?: string | null;
   techRecord_adrDetails_approved?: boolean | null;
   techRecord_adrDetails_receivedDate?: string | null;
+  techRecord_adrDetails_applicationNumber?: string | null;
   techRecord_adrDetails_tank_tankDetails_tankManufacturer?: string | null;
   techRecord_adrDetails_tank_tankDetails_yearOfManufacture?: number | null;
   techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo?: string | null;

--- a/types/v3/tech-record/put/lgv/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/lgv/skeleton/index.d.ts
@@ -50,6 +50,7 @@ export interface TechRecordPUTLGVSkeleton {
   techRecord_adrDetails_adrCertificateNotes?: string | null;
   techRecord_adrDetails_approved?: boolean | null;
   techRecord_adrDetails_receivedDate?: string | null;
+  techRecord_adrDetails_applicationNumber?: string | null;
   techRecord_adrDetails_tank_tankDetails_tankManufacturer?: string | null;
   techRecord_adrDetails_tank_tankDetails_yearOfManufacture?: number | null;
   techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo?: string | null;

--- a/types/v3/tech-record/put/trl/complete/index.d.ts
+++ b/types/v3/tech-record/put/trl/complete/index.d.ts
@@ -37,6 +37,7 @@ export interface TechRecordPUTTRLComplete {
   techRecord_adrDetails_adrCertificateNotes?: string | null;
   techRecord_adrDetails_approved?: boolean | null;
   techRecord_adrDetails_receivedDate?: string | null;
+  techRecord_adrDetails_applicationNumber?: string | null;
   techRecord_adrDetails_tank_tankDetails_tankManufacturer?: string | null;
   techRecord_adrDetails_tank_tankDetails_yearOfManufacture?: number | null;
   techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo?: string | null;

--- a/types/v3/tech-record/put/trl/skeleton/index.d.ts
+++ b/types/v3/tech-record/put/trl/skeleton/index.d.ts
@@ -150,6 +150,7 @@ export interface TechRecordPUTTRLSkeleton {
   techRecord_adrDetails_adrCertificateNotes?: string | null;
   techRecord_adrDetails_approved?: boolean | null;
   techRecord_adrDetails_receivedDate?: string | null;
+  techRecord_adrDetails_applicationNumber?: string | null;
   techRecord_adrDetails_tank_tankDetails_tankManufacturer?: string | null;
   techRecord_adrDetails_tank_tankDetails_yearOfManufacture?: number | null;
   techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo?: string | null;

--- a/types/v3/tech-record/put/trl/testable/index.d.ts
+++ b/types/v3/tech-record/put/trl/testable/index.d.ts
@@ -150,6 +150,7 @@ export interface TechRecordPUTTRLTestable {
   techRecord_adrDetails_adrCertificateNotes?: string | null;
   techRecord_adrDetails_approved?: boolean | null;
   techRecord_adrDetails_receivedDate?: string | null;
+  techRecord_adrDetails_applicationNumber?: string | null;
   techRecord_adrDetails_tank_tankDetails_tankManufacturer?: string | null;
   techRecord_adrDetails_tank_tankDetails_yearOfManufacture?: number | null;
   techRecord_adrDetails_tank_tankDetails_tankManufacturerSerialNo?: string | null;


### PR DESCRIPTION
## Ticket title

Addition to https://github.com/dvsa/cvs-type-definitions/pull/222 to also add ADR application number 

[CB2-21117](https://dvsa.atlassian.net/browse/CB2-21117)

<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

- optional adr application number added to all HGV, TRL and LGV schemas

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->


[CB2-21117]: https://dvsa.atlassian.net/browse/CB2-21117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ