### PR TITLE
minor(cb2-21756): added dgtw enum for not applicable logic

### DIFF
--- a/json-definitions/v1/enums/designTrainWeight.enum.json
+++ b/json-definitions/v1/enums/designTrainWeight.enum.json
@@ -5,6 +5,6 @@
     "NOT_APPLICABLE"
   ],
   "enum": [
-    "n/a"
+    "N/A"
   ]
 }

--- a/json-definitions/v1/enums/designTrainWeight.enum.json
+++ b/json-definitions/v1/enums/designTrainWeight.enum.json
@@ -1,0 +1,10 @@
+{
+  "title": "Design Train Weight Required",
+  "type": "string",
+  "tsEnumNames": [
+    "NOT_APPLICABLE"
+  ],
+  "enum": [
+    "n/a"
+  ]
+}

--- a/json-definitions/v1/test-result-weights/index.json
+++ b/json-definitions/v1/test-result-weights/index.json
@@ -16,6 +16,9 @@
       "type": ["integer", "null"],
       "maximum": 99999,
       "minimum": 1
+    },
+    "designTrainWeightRequired": {
+      "$ref": "../enums/designTrainWeight.enum.json"
     }
   },
   "additionalProperties": false,

--- a/json-schemas/v1/enums/designTrainWeight.enum.json
+++ b/json-schemas/v1/enums/designTrainWeight.enum.json
@@ -5,6 +5,6 @@
 		"NOT_APPLICABLE"
 	],
 	"enum": [
-		"n/a"
+		"N/A"
 	]
 }

--- a/json-schemas/v1/enums/designTrainWeight.enum.json
+++ b/json-schemas/v1/enums/designTrainWeight.enum.json
@@ -1,0 +1,10 @@
+{
+	"title": "Design Train Weight Required",
+	"type": "string",
+	"tsEnumNames": [
+		"NOT_APPLICABLE"
+	],
+	"enum": [
+		"n/a"
+	]
+}

--- a/json-schemas/v1/test-result-weights/index.json
+++ b/json-schemas/v1/test-result-weights/index.json
@@ -30,7 +30,7 @@
 				"NOT_APPLICABLE"
 			],
 			"enum": [
-				"n/a"
+				"N/A"
 			]
 		}
 	},

--- a/json-schemas/v1/test-result-weights/index.json
+++ b/json-schemas/v1/test-result-weights/index.json
@@ -22,6 +22,16 @@
 			],
 			"maximum": 99999,
 			"minimum": 1
+		},
+		"designTrainWeightRequired": {
+			"title": "Design Train Weight Required",
+			"type": "string",
+			"tsEnumNames": [
+				"NOT_APPLICABLE"
+			],
+			"enum": [
+				"n/a"
+			]
 		}
 	},
 	"additionalProperties": false,

--- a/json-schemas/v1/test-result/index.json
+++ b/json-schemas/v1/test-result/index.json
@@ -351,6 +351,16 @@
 					],
 					"maximum": 99999,
 					"minimum": 1
+				},
+				"designTrainWeightRequired": {
+					"title": "Design Train Weight Required",
+					"type": "string",
+					"tsEnumNames": [
+						"NOT_APPLICABLE"
+					],
+					"enum": [
+						"n/a"
+					]
 				}
 			},
 			"additionalProperties": false,

--- a/json-schemas/v1/test-result/index.json
+++ b/json-schemas/v1/test-result/index.json
@@ -359,7 +359,7 @@
 						"NOT_APPLICABLE"
 					],
 					"enum": [
-						"n/a"
+						"N/A"
 					]
 				}
 			},

--- a/json-schemas/v1/test/index.json
+++ b/json-schemas/v1/test/index.json
@@ -1002,6 +1002,16 @@
 											],
 											"maximum": 99999,
 											"minimum": 1
+										},
+										"designTrainWeightRequired": {
+											"title": "Design Train Weight Required",
+											"type": "string",
+											"tsEnumNames": [
+												"NOT_APPLICABLE"
+											],
+											"enum": [
+												"n/a"
+											]
 										}
 									},
 									"additionalProperties": false,

--- a/json-schemas/v1/test/index.json
+++ b/json-schemas/v1/test/index.json
@@ -1010,7 +1010,7 @@
 												"NOT_APPLICABLE"
 											],
 											"enum": [
-												"n/a"
+												"N/A"
 											]
 										}
 									},

--- a/json-schemas/v1/vehicle/index.json
+++ b/json-schemas/v1/vehicle/index.json
@@ -974,6 +974,16 @@
 								],
 								"maximum": 99999,
 								"minimum": 1
+							},
+							"designTrainWeightRequired": {
+								"title": "Design Train Weight Required",
+								"type": "string",
+								"tsEnumNames": [
+									"NOT_APPLICABLE"
+								],
+								"enum": [
+									"n/a"
+								]
 							}
 						},
 						"additionalProperties": false,

--- a/json-schemas/v1/vehicle/index.json
+++ b/json-schemas/v1/vehicle/index.json
@@ -982,7 +982,7 @@
 									"NOT_APPLICABLE"
 								],
 								"enum": [
-									"n/a"
+									"N/A"
 								]
 							}
 						},

--- a/json-schemas/v1/visit/index.json
+++ b/json-schemas/v1/visit/index.json
@@ -1043,7 +1043,7 @@
 															"NOT_APPLICABLE"
 														],
 														"enum": [
-															"n/a"
+															"N/A"
 														]
 													}
 												},

--- a/json-schemas/v1/visit/index.json
+++ b/json-schemas/v1/visit/index.json
@@ -1035,6 +1035,16 @@
 														],
 														"maximum": 99999,
 														"minimum": 1
+													},
+													"designTrainWeightRequired": {
+														"title": "Design Train Weight Required",
+														"type": "string",
+														"tsEnumNames": [
+															"NOT_APPLICABLE"
+														],
+														"enum": [
+															"n/a"
+														]
 													}
 												},
 												"additionalProperties": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-type-definitions",
-  "version": "13.0.0",
+  "version": "13.1.0",
   "description": "Type definitions for CVS VTA and VTM applications",
   "main": "index.js",
   "repository": {

--- a/schemas.ts
+++ b/schemas.ts
@@ -19,6 +19,7 @@ export const schemas = [
   "v1/dynamics-test-station/index.json",
   "v1/enums/activityType.enum.json",
   "v1/enums/closureReason.enum.json",
+  "v1/enums/designTrainWeight.enum.json",
   "v1/enums/emissionStandard.enum.json",
   "v1/enums/fuelType.enum.json",
   "v1/enums/odometerReadingUnits.enum.json",

--- a/types/v1/enums/designTrainWeight.enum.ts
+++ b/types/v1/enums/designTrainWeight.enum.ts
@@ -6,5 +6,5 @@
  */
 
 export enum DesignTrainWeightRequired {
-  NOT_APPLICABLE = "n/a"
+  NOT_APPLICABLE = "N/A"
 }

--- a/types/v1/enums/designTrainWeight.enum.ts
+++ b/types/v1/enums/designTrainWeight.enum.ts
@@ -5,13 +5,6 @@
  * and run json-schema-to-typescript to regenerate this file.
  */
 
-export interface TestResultWeightsSchema {
-  designGrossVehicleWeight: number;
-  designGrossTrainWeight?: number | null;
-  designGrossAxleWeight?: number | null;
-  designTrainWeightRequired?: DesignTrainWeightRequired;
-}
-
 export enum DesignTrainWeightRequired {
   NOT_APPLICABLE = "n/a"
 }

--- a/types/v1/test-result-weights/index.d.ts
+++ b/types/v1/test-result-weights/index.d.ts
@@ -13,5 +13,5 @@ export interface TestResultWeightsSchema {
 }
 
 export enum DesignTrainWeightRequired {
-  NOT_APPLICABLE = "n/a"
+  NOT_APPLICABLE = "N/A"
 }

--- a/types/v1/test-result/index.d.ts
+++ b/types/v1/test-result/index.d.ts
@@ -87,6 +87,7 @@ export interface TestResultWeightsSchema {
   designGrossVehicleWeight: number;
   designGrossTrainWeight?: number | null;
   designGrossAxleWeight?: number | null;
+  designTrainWeightRequired?: DesignTrainWeightRequired;
 }
 export interface TestResultTestTypeSchema {
   testTypeName: string | null;
@@ -243,6 +244,9 @@ export enum EUVehicleCategory {
   L5E = "l5e",
   L6E = "l6e",
   L7E = "l7e"
+}
+export enum DesignTrainWeightRequired {
+  NOT_APPLICABLE = "n/a"
 }
 export enum TestResults {
   PASS = "pass",

--- a/types/v1/test-result/index.d.ts
+++ b/types/v1/test-result/index.d.ts
@@ -246,7 +246,7 @@ export enum EUVehicleCategory {
   L7E = "l7e"
 }
 export enum DesignTrainWeightRequired {
-  NOT_APPLICABLE = "n/a"
+  NOT_APPLICABLE = "N/A"
 }
 export enum TestResults {
   PASS = "pass",

--- a/types/v1/test/index.d.ts
+++ b/types/v1/test/index.d.ts
@@ -304,6 +304,7 @@ export interface TestResultWeightsSchema {
   designGrossVehicleWeight: number;
   designGrossTrainWeight?: number | null;
   designGrossAxleWeight?: number | null;
+  designTrainWeightRequired?: DesignTrainWeightRequired;
 }
 export interface TestResultTestTypeSchema {
   testTypeName: string | null;
@@ -460,6 +461,9 @@ export enum EUVehicleCategory {
   L5E = "l5e",
   L6E = "l6e",
   L7E = "l7e"
+}
+export enum DesignTrainWeightRequired {
+  NOT_APPLICABLE = "n/a"
 }
 export enum TestResults {
   PASS = "pass",

--- a/types/v1/test/index.d.ts
+++ b/types/v1/test/index.d.ts
@@ -463,7 +463,7 @@ export enum EUVehicleCategory {
   L7E = "l7e"
 }
 export enum DesignTrainWeightRequired {
-  NOT_APPLICABLE = "n/a"
+  NOT_APPLICABLE = "N/A"
 }
 export enum TestResults {
   PASS = "pass",

--- a/types/v1/vehicle/index.d.ts
+++ b/types/v1/vehicle/index.d.ts
@@ -455,7 +455,7 @@ export enum EUVehicleCategory {
   L7E = "l7e"
 }
 export enum DesignTrainWeightRequired {
-  NOT_APPLICABLE = "n/a"
+  NOT_APPLICABLE = "N/A"
 }
 export enum TestResults {
   PASS = "pass",

--- a/types/v1/vehicle/index.d.ts
+++ b/types/v1/vehicle/index.d.ts
@@ -296,6 +296,7 @@ export interface TestResultWeightsSchema {
   designGrossVehicleWeight: number;
   designGrossTrainWeight?: number | null;
   designGrossAxleWeight?: number | null;
+  designTrainWeightRequired?: DesignTrainWeightRequired;
 }
 export interface TestResultTestTypeSchema {
   testTypeName: string | null;
@@ -452,6 +453,9 @@ export enum EUVehicleCategory {
   L5E = "l5e",
   L6E = "l6e",
   L7E = "l7e"
+}
+export enum DesignTrainWeightRequired {
+  NOT_APPLICABLE = "n/a"
 }
 export enum TestResults {
   PASS = "pass",

--- a/types/v1/visit/index.d.ts
+++ b/types/v1/visit/index.d.ts
@@ -317,6 +317,7 @@ export interface TestResultWeightsSchema {
   designGrossVehicleWeight: number;
   designGrossTrainWeight?: number | null;
   designGrossAxleWeight?: number | null;
+  designTrainWeightRequired?: DesignTrainWeightRequired;
 }
 export interface TestResultTestTypeSchema {
   testTypeName: string | null;
@@ -473,6 +474,9 @@ export enum EUVehicleCategory {
   L5E = "l5e",
   L6E = "l6e",
   L7E = "l7e"
+}
+export enum DesignTrainWeightRequired {
+  NOT_APPLICABLE = "n/a"
 }
 export enum TestResults {
   PASS = "pass",

--- a/types/v1/visit/index.d.ts
+++ b/types/v1/visit/index.d.ts
@@ -476,7 +476,7 @@ export enum EUVehicleCategory {
   L7E = "l7e"
 }
 export enum DesignTrainWeightRequired {
-  NOT_APPLICABLE = "n/a"
+  NOT_APPLICABLE = "N/A"
 }
 export enum TestResults {
   PASS = "pass",


### PR DESCRIPTION
## Capture value N/A if vehicle does not have design gross train weight

As discussed on refinement and on ticket, new optional enum key added to existing weights object, to be used to determine when n/a should be displayed on RWT certificates, on certain edge cases where it does not exist on tech record or plate.

[CB2-21756](https://dvsa.atlassian.net/browse/CB2-21756)

<!-- Include a summary of the changes in the `Changelog` section below, in bullet point form. These will be used to describe the changes in the new version of the release. Only useful if merging to `develop`. -->

## Changelog

- added new enum
- update relevant weights object

<!--DO NOT REMOVE COMMENT. MARKS END OF CHANGES SECTION.-->


[CB2-21756]: https://dvsa.atlassian.net/browse/CB2-21756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ